### PR TITLE
introduce project context manager for active project

### DIFF
--- a/src/cript/nodes/exceptions.py
+++ b/src/cript/nodes/exceptions.py
@@ -57,3 +57,22 @@ class CRIPTJsonSerializationError(CRIPTException):
 
     def __str__(self):
         return f"JSON Serialization failed for node type {self.node_type} with JSON dict: {self.json_str}"
+
+
+class CRIPTProjectAccessError(CRIPTException):
+    """
+    Exception to be raised when the cached API object is requested, but no cached API exists yet.
+    """
+
+    def __init__(self):
+        pass
+
+    def __str__(self) -> str:
+        ret_str = "An operation you requested (see stack trace) requires that you "
+        ret_str += " a project first.\n"
+        ret_str += "This is common for node creation (especially materials).\n"
+        ret_str += "It is necessary that you activate the project via a context manager like this:\n"
+        ret_str += "`with cript.Project(....) as project:\n"
+        ret_str += "\t# code that uses the project explicily or implicitly."
+        ret_str += "See documentation of cript.Project for more details."
+        return ret_str

--- a/src/cript/nodes/primary_nodes/collection.py
+++ b/src/cript/nodes/primary_nodes/collection.py
@@ -86,6 +86,12 @@ class Collection(PrimaryBaseNode):
 
         self.validate()
 
+        # Add collection to the currently active project
+        from cript.nodes.primary_nodes.project import _get_global_cached_project
+
+        current_project = _get_global_cached_project()
+        current_project.collections += [self]
+
     # ------------------ Properties ------------------
 
     @property
@@ -142,7 +148,7 @@ class Collection(PrimaryBaseNode):
         )
 
         my_inventory = cript.Inventory(
-            name="my inventory name", materials_list=[material_1, material_2]
+            name="my inventory name", materials=[material_1, material_2]
         )
 
         my_collection.inventories = [my_inventory]

--- a/src/cript/nodes/primary_nodes/inventory.py
+++ b/src/cript/nodes/primary_nodes/inventory.py
@@ -35,7 +35,7 @@ class Inventory(PrimaryBaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
-    def __init__(self, name: str, materials_list: List[Material], notes: str = "", **kwargs) -> None:
+    def __init__(self, name: str, materials: List[Material], notes: str = "", **kwargs) -> None:
         """
         Instantiate an inventory node
 
@@ -60,7 +60,7 @@ class Inventory(PrimaryBaseNode):
 
         Parameters
         ----------
-        materials_list: List[Material]
+        materials: List[Material]
             list of materials in this inventory
 
         Returns
@@ -69,12 +69,12 @@ class Inventory(PrimaryBaseNode):
             instantiate an inventory node
         """
 
-        if materials_list is None:
-            materials_list = []
+        if materials is None:
+            materials = []
 
         super().__init__(name=name, notes=notes)
 
-        self._json_attrs = replace(self._json_attrs, materials=materials_list)
+        self._json_attrs = replace(self._json_attrs, materials=materials)
 
     # ------------------ Properties ------------------
     @property

--- a/src/cript/nodes/primary_nodes/material.py
+++ b/src/cript/nodes/primary_nodes/material.py
@@ -149,6 +149,12 @@ class Material(PrimaryBaseNode):
             keywords=keywords,
         )
 
+        # Add material to the currently active project
+        from cript.nodes.primary_nodes.project import _get_global_cached_project
+
+        current_project = _get_global_cached_project()
+        current_project.materials += [self]
+
     # ------------ Properties ------------
     @property
     def name(self) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,6 @@ from fixtures.primary_nodes import (
     complex_collection_node,
     complex_data_node,
     complex_material_node,
-    complex_project_node,
     simple_collection_node,
     simple_computation_node,
     simple_computational_process_node,

--- a/tests/fixtures/primary_nodes.py
+++ b/tests/fixtures/primary_nodes.py
@@ -5,8 +5,8 @@ import pytest
 import cript
 
 
-@pytest.fixture(scope="function")
-def simple_project_node(simple_collection_node) -> cript.Project:
+@pytest.fixture(scope="session", autouse=True)
+def simple_project_node() -> cript.Project:
     """
     create a minimal Project node with only required arguments for other tests to use
 
@@ -14,20 +14,10 @@ def simple_project_node(simple_collection_node) -> cript.Project:
     -------
     cript.Project
     """
-
-    return cript.Project(name="my Project name", collections=[simple_collection_node])
-
-
-@pytest.fixture(scope="function")
-def complex_project_node(complex_collection_node, complex_material_node) -> cript.Project:
-    """
-    a complex Project node that includes all possible optional arguments that are themselves complex as well
-    """
-    project_name = "my project name"
-
-    complex_project = cript.Project(name=project_name, collections=[complex_collection_node], materials=[complex_material_node])
-
-    return complex_project
+    assert cript.nodes.primary_nodes.project._global_cached_project is None
+    with cript.Project(name="my Project name") as project:
+        yield project
+    assert cript.nodes.primary_nodes.project._global_cached_project is None
 
 
 @pytest.fixture(scope="function")
@@ -233,7 +223,7 @@ def simple_inventory_node() -> None:
 
     material_2 = cript.Material(name="material 2", identifiers=[{"alternative_names": "material 2 alternative name"}])
 
-    my_inventory = cript.Inventory(name="my inventory name", materials_list=[material_1, material_2])
+    my_inventory = cript.Inventory(name="my inventory name", materials=[material_1, material_2])
 
     # use my_inventory in another test
     return my_inventory

--- a/tests/nodes/primary_nodes/test_project.py
+++ b/tests/nodes/primary_nodes/test_project.py
@@ -1,3 +1,4 @@
+import copy
 import json
 
 from util import strip_uid_from_dict
@@ -28,20 +29,21 @@ def test_project_getters_and_setters(simple_project_node, simple_collection_node
     3. get all of its attributes
     4. what was set and what was gotten should be equivalent
     """
+    project_node = copy.deepcopy(simple_project_node)
     new_project_name = "my new project name"
 
     # set attributes
-    simple_project_node.name = new_project_name
-    simple_project_node.collections = [complex_collection_node]
-    simple_project_node.materials = [simple_material_node]
+    project_node.name = new_project_name
+    project_node.collections = [complex_collection_node]
+    project_node.materials = [simple_material_node]
 
     # get attributes and assert that they are the same
-    assert simple_project_node.name == new_project_name
-    assert simple_project_node.collections == [complex_collection_node]
-    assert simple_project_node.materials == [simple_material_node]
+    assert project_node.name == new_project_name
+    assert project_node.collections == [complex_collection_node]
+    assert project_node.materials == [simple_material_node]
 
 
-def test_serialize_project_to_json(simple_project_node) -> None:
+def test_serialize_project_to_json(simple_project_node, simple_collection_node) -> None:
     """
     tests that a Project node can be correctly converted to a JSON
     """
@@ -60,8 +62,12 @@ def test_serialize_project_to_json(simple_project_node) -> None:
     }
 
     # comparing dicts instead of JSON strings because dict comparison is more accurate
-    ref_dict = json.loads(simple_project_node.json)
-    ref_dict = strip_uid_from_dict(ref_dict)
+    project_node = copy.deepcopy(simple_project_node)
+    project_node.collections = [simple_collection_node]
+    project_node.materials = []
+    ref_node = json.loads(project_node.json)
+    ref_dict = strip_uid_from_dict(ref_node)
+
     assert ref_dict == expected_dict
 
 

--- a/tests/test_node_util.py
+++ b/tests/test_node_util.py
@@ -117,9 +117,6 @@ def test_invalid_json_load():
 
 
 def test_project_auto_assignement(simple_project_node, simple_material_node, simple_collection_node):
-    material_length = len(simple_project_node.materials)
-    collection_length = len(simple_project_node.collections)
-
     # Let's create a new project (from the old project)
     # Let's activate this project
     with copy.deepcopy(simple_project_node) as new_project:

--- a/tests/test_node_util.py
+++ b/tests/test_node_util.py
@@ -114,3 +114,27 @@ def test_invalid_json_load():
     raise_node_dict(node_dict)
     node_dict = {"node": [None]}
     raise_node_dict(node_dict)
+
+
+def test_project_auto_assignement(simple_project_node, simple_material_node, simple_collection_node):
+    material_length = len(simple_project_node.materials)
+    collection_length = len(simple_project_node.collections)
+
+    # Let's create a new project (from the old project)
+    # Let's activate this project
+    with copy.deepcopy(simple_project_node) as new_project:
+        # Let's create a new materials
+        new_material = copy.deepcopy(simple_material_node)
+        # It should be in the new project, but not the old project
+        assert new_material in new_project.materials
+        assert new_material not in simple_project_node.materials
+
+        # Same for collection
+        new_collection = copy.deepcopy(simple_collection_node)
+        assert new_collection in new_project.collections
+        assert new_collection not in simple_project_node.collections
+
+    simple_project_node.deactivate()
+    assert cript.nodes.primary_nodes.project._global_cached_project is not simple_project_node
+    simple_project_node.activate()
+    assert cript.nodes.primary_nodes.project._global_cached_project is simple_project_node


### PR DESCRIPTION
# Description

## Changes

## Tests

## Known Issues

Deepcopying nodes automatically adds the new nodes to the activate project.
So, when deep copying a project.
The new project behaves like expected, but the old project (if active) has all materials and collections duplicated.
(As they get automatically added, when the new project is generated.)
This is probably not the intent of a user, but I don't know how to prevent is at this point.
I am just hoping, that deepcopying projects is not very likely.

## Notes

## Checklist

- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
