### PR TITLE
successfully flatten the identifiers

### DIFF
--- a/src/cript/nodes/util.py
+++ b/src/cript/nodes/util.py
@@ -39,15 +39,39 @@ class NodeEncoder(json.JSONEncoder):
                         serialize_dict[key] = getattr(obj._json_attrs, key)
             serialize_dict["node"] = obj._json_attrs.node
 
-            # if node is material, then convert the identifiers list to JSON fields
-            if serialize_dict["node"] == ["Material"]:
-                serialize_dict = material_identifiers_list_to_json_fields(serialize_dict)
+            # check if further modifications to the dict is needed before considering it done
+            serialize_dict = _apply_modifications(serialize_dict)
 
             return serialize_dict
         return json.JSONEncoder.default(self, obj)
 
 
-def material_identifiers_list_to_json_fields(serialize_dict: dict) -> dict:
+def _apply_modifications(serialize_dict):
+    """
+    checks the serialized_dict to see if any other operations are required before it
+    can be considered done. If other operations are required, then it passes it to the other operations
+    and at the end returns the fully finished dict.
+
+    This function is essentially a big switch case that checks the node type
+    and sees what other operations are required for it
+
+    Parameters
+    ----------
+    serialize_dict: dict
+
+
+    Returns
+    -------
+    serialize_dict: dict
+    """
+    # if node is material, then convert the identifiers list to JSON fields
+    if serialize_dict["node"] == ["Material"]:
+        serialize_dict = _material_identifiers_list_to_json_fields(serialize_dict)
+
+    return serialize_dict
+
+
+def _material_identifiers_list_to_json_fields(serialize_dict: dict) -> dict:
     """
     input:
     ```json


### PR DESCRIPTION
# Description
flattens out the identifiers list from a list of dicts to be on the dict itself

## Changes
made a change to the node encoder. 

Before the serialization is fully done I check if the node is a "Material" node and if it is then I send it to 
`material_identifiers_list_to_json_fields` function to flatten the identifiers into the serialized_dict
and set the serialized_dict to the output of `material_identifiers_list_to_json_fields` 

## Tests
* This serialization can be posted to the API
* 

## Known Issues
* function name to flatten identifiers is very long and should be shortened to something easily understandable
* comments and docstrings could be cleaner

## Notes
Have not updated tests to work with the new code, but I can do that if we like it