### PR TITLE
updatied db schema test to after db schema was updated

### DIFF
--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -56,7 +56,7 @@ def test_get_db_schema_from_api(cript_api: cript.API) -> None:
     assert bool(db_schema)
     assert isinstance(db_schema, dict)
 
-    total_fields_in_db_schema = 69
+    total_fields_in_db_schema = 70
     assert len(db_schema["$defs"]) == total_fields_in_db_schema
 
 


### PR DESCRIPTION
# Description
API test `test_get_db_schema_from_api` was failing previously on other PR because the fields on the db schema has been updated from `69` to `70` fields. This PR reflects the latest updates in the API tests