### PR TITLE
updated packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.28.2
+requests==2.30.0
 jsonschema==4.17.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.30.0
+requests==2.31.0
 jsonschema==4.17.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 black==23.3.0
-mypy==1.2.0
-coverage==7.2.3
+mypy==1.3.0
+coverage==7.2.5

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,4 +1,4 @@
-mkdocs==1.4.2
-mkdocs-material==9.1.6
+mkdocs==1.4.3
+mkdocs-material==9.1.13
 mkdocstrings[python]==0.21.2
-pymdown-extensions==9.11
+pymdown-extensions==10.0.1

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,4 +1,4 @@
 mkdocs==1.4.3
-mkdocs-material==9.1.13
+mkdocs-material==9.1.14
 mkdocstrings[python]==0.21.2
 pymdown-extensions==10.0.1


### PR DESCRIPTION
# Description
updated outdated packages. 

`pymdown-extensions` version 9 has vulnerabilities that can be fixed by updating to v10

## Changes

## Tests
* tests are all still passing except for the db schema test that expects 70 fields but is getting 74 fields

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
