### PR TITLE
created docs_ci_check

### DIFF
--- a/.github/workflows/docs_check.yaml
+++ b/.github/workflows/docs_check.yaml
@@ -1,0 +1,39 @@
+# this CI workflow checks the documentation for any broken links or errors within documentation files/configuration
+# and reports errors to catch errors and never deploy broken documentation
+name: MkDocs CI Check
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - "*"
+  pull_request:
+    branches:
+      - main
+      - develop
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Set Up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
+
+      - name: Install Python SDK
+        run: pip install -e .
+
+      - name: Install Doc Dependencies
+        run: pip install -r requirements_docs.txt
+
+      - name: Build and Test Documentation
+        run: |
+          mkdocs build
+          mkdocs build


### PR DESCRIPTION
# Description

This would be a great workflow check to have for mass refactoring and changes such as [Computation Process PR](https://github.com/C-Accel-CRIPT/Python-SDK/pull/123), that could catch any errors with documentation quickly and easily.

**Issue Link:** https://github.com/C-Accel-CRIPT/Python-SDK/issues/129

## Changes
* created docs_check.yaml

## Tests
* tested this CI on a [forked repository](https://github.com/nh916/Python-SDK-tests)

## Known Issues
* None

## Notes
I was not sure if I should set it as strict or not. I set it as strict once and ran it and it reported harmless warnings as errors that need attention, so I removed it because I think it is fine not being strict for now

```yaml
      - name: Build and Test Documentation
        run: |
          mkdocs build
          mkdocs build --strict
```

I think the next step that could be even better is that if documentation only deploys if this check has been passed, so our documentation online is always working and never broken