### PR TITLE
Feature: `File.upload()` & `File.download()`

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -626,7 +626,6 @@ class API:
         with open(destination_file_path, "wb") as file:
             file.write(file_contents)
 
-    # TODO reset to work with real nodes node_type.node and node_type to be PrimaryNode
     def search(
         self,
         node_type: BaseNode,

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -518,7 +518,6 @@ class API:
         1. rename the file to avoid clash or overwriting of previously uploaded files
             * change file name to `original_name_uuid4.extension`
                 *  `document_42926a201a624fdba0fd6271defc9e88.txt`
-        # it would be without the hyphens like: `document_42926a201a624fdba0fd6271defc9e88.txt`
         1. upload file to AWS S3
         1. get the link of the uploaded file and return it
 
@@ -544,7 +543,9 @@ class API:
         Raises
         ------
         FileNotFoundError
-            In case the file could not be found because the file does not exist
+            In case the CRIPT Python SDK cannot find the file on your computer because the file does not exist
+            or the path to it is incorrect it raises
+            [FileNotFoundError](https://docs.python.org/3/library/exceptions.html#FileNotFoundError)
 
         Returns
         -------

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -389,19 +389,18 @@ class File(UUIDBaseNode):
         new_attrs = replace(self._json_attrs, data_dictionary=new_data_dictionary)
         self._update_json_attrs_if_valid(new_attrs)
 
-    # TODO rename to `destination_directory_path`
     # TODO get file name from node itself as default and allow for customization as well optional
-    # TODO make the destination path optional
-    def download(self, destination_source: Union[str, Path], file_name: str) -> None:
+    def download(self, file_name: str, destination_directory_path: Union[str, Path] = ".",) -> None:
         """
         download this file to current working directory or a specific destination
 
         Parameters
         ----------
-        destination_source: Union[str, Path]
-            where you want the file to be stored and what you want the name to be
         file_name: str
             what you want to name the file node on your computer
+        destination_directory_path: Union[str, Path]
+            where you want the file to be stored and what you want the name to be
+            by default it is the current working directory
 
         Returns
         -------
@@ -411,9 +410,11 @@ class File(UUIDBaseNode):
 
         api = _get_global_cached_api()
 
-        existing_folder_path = Path(destination_source)
-        # TODO add file extension to it
-        file_name = f"{file_name}"
+        existing_folder_path = Path(destination_directory_path)
+
+        # TODO add file extension to it and be sure that it is always `.csv` and never just `csv`
+        file_name = f"{file_name}{self.extension}"
+
         absolute_file_path = str((existing_folder_path / file_name).resolve())
 
         api.download_file(file_url=self.source, destination_path=absolute_file_path)

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -393,6 +393,7 @@ class File(UUIDBaseNode):
 
     # TODO rename to `destination_directory_path`
     # TODO get file name from node itself as default and allow for customization as well optional
+    # TODO make the destination path optional
     def download(self, destination_source: Union[str, Path], file_name: str) -> None:
         """
         download this file to current working directory or a specific destination

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -9,12 +9,10 @@ def _is_local_file(file_source: Union[str, Path]) -> bool:
     """
     Determines if the file the user is uploading is a local file or a link.
 
-    the file is a local file path if it does Not start with "http" or isinstance of Path object
-
     Parameters
     ----------
-    file_source: Union[str, Path]
-        The source of the file
+    file_source : str
+        The source of the file.
 
     Returns
     -------
@@ -410,6 +408,7 @@ class File(UUIDBaseNode):
         None
         """
         from cript.api.api import _get_global_cached_api
+
         api = _get_global_cached_api()
 
         existing_folder_path = Path(destination_source)

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -21,7 +21,7 @@ def _is_local_file(file_source: Union[str, Path]) -> bool:
     """
 
     # checking "http" so it works with both "https://" and "http://"
-    if file_source.startswith("http"):
+    if file_source.startswith("http") or isinstance(file_source, Path):
         return False
     else:
         return True

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -391,7 +391,11 @@ class File(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     # TODO get file name from node itself as default and allow for customization as well optional
-    def download(self, file_name: str, destination_directory_path: Union[str, Path] = ".",) -> None:
+    def download(
+        self,
+        file_name: str,
+        destination_directory_path: Union[str, Path] = ".",
+    ) -> None:
         """
         download this file to current working directory or a specific destination
 

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -53,7 +53,7 @@ def _upload_file_and_get_url(source: Union[str, Path]) -> str:
         url_source = api.upload_file(file_path=source)
         source = url_source
 
-        return source
+    return source
 
 
 class File(UUIDBaseNode):
@@ -187,8 +187,9 @@ class File(UUIDBaseNode):
 
         super().__init__(**kwargs)
 
-        # upload file source if local file
-        source = _upload_file_and_get_url(source=source)
+        if _is_local_file(file_source=source):
+            # upload file source if local file
+            source = _upload_file_and_get_url(source=source)
 
         # TODO add validation that extension must start with `.` or be uniform to work with it easier
         self._json_attrs = replace(
@@ -412,8 +413,9 @@ class File(UUIDBaseNode):
 
         existing_folder_path = Path(destination_directory_path)
 
-        # TODO add file extension to it and be sure that it is always `.csv` and never just `csv`
-        file_name = f"{file_name}{self.extension}"
+        # TODO automatically add the correct file extension to it from the node
+        #  and be sure that it is always `.csv` and never just `csv`
+        file_name = f"{file_name}"
 
         absolute_file_path = str((existing_folder_path / file_name).resolve())
 

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -388,3 +388,26 @@ class File(UUIDBaseNode):
         """
         new_attrs = replace(self._json_attrs, data_dictionary=new_data_dictionary)
         self._update_json_attrs_if_valid(new_attrs)
+
+    def download(self, destination_source: Union[str, Path], file_name: str) -> None:
+        """
+        download this file to current working directory or a specific destination
+
+        Parameters
+        ----------
+        destination_source: Union[str, Path]
+            where you want the file to be stored and what you want the name to be
+        file_name: str
+            what you want to name the file node on your computer
+
+        Returns
+        -------
+        None
+        """
+        api = _get_global_cached_api()
+
+        existing_folder_path = Path(destination_source)
+        file_name = f"{file_name}.{self.extension}"
+        absolute_file_path = (existing_folder_path / file_name).resolve()
+
+        api.download_file(file_url=self.source, destination_source=absolute_file_path)

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -1,8 +1,6 @@
 import copy
 import datetime
 import json
-import os
-import tempfile
 import uuid
 
 import pytest

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -20,7 +20,7 @@ def test_create_file() -> None:
     assert isinstance(file_node, cript.File)
 
 
-def test_local_file_source_upload_and_download(tmpdir, tmp_path_factory) -> None:
+def test_local_file_source_upload_and_download(tmp_path_factory) -> None:
     """
     upload a file and download it and be sure the contents are the same
 

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -20,7 +20,7 @@ def test_create_file() -> None:
     assert isinstance(file_node, cript.File)
 
 
-def test_local_file_source_upload_and_download(tmpdir) -> None:
+def test_local_file_source_upload_and_download(tmpdir, tmp_path_factory) -> None:
     """
     upload a file and download it and be sure the contents are the same
 
@@ -39,21 +39,18 @@ def test_local_file_source_upload_and_download(tmpdir) -> None:
         f"The test is conducted on UTC time of '{datetime.datetime.utcnow()}' " 
         f"with the unique UUID of '{str(uuid.uuid4())}'"
     )
-    
-    with tempfile.NamedTemporaryFile(mode="w+t", suffix=".txt", delete=False) as temp_file:
-        local_file_path = temp_file.name
 
-        # write text to temporary file
-        temp_file.write(file_text)
+    # create a temp file and write to it
+    upload_file_dir = tmp_path_factory.mktemp("file_test_upload_file_dir")
+    local_file_path = upload_file_dir / "my_upload_file.txt"
 
-        # force text to be written to file
-        temp_file.flush()
+    local_file_path.write_text(file_text)
 
-        # create a file node with a local file path
-        my_file = cript.File(source=local_file_path, type="data")
+    # create a file node with a local file path
+    my_file = cript.File(source=str(local_file_path), type="data")
 
-        # check that the file source has been uploaded to cloud storage and source has changed to reflect that
-        assert my_file.source.startswith("https://cript-development-user-data.s3.amazonaws.com")
+    # check that the file source has been uploaded to cloud storage and source has changed to reflect that
+    assert my_file.source.startswith("https://cript-development-user-data.s3.amazonaws.com")
 
     # Get the temporary directory path and clean up handled by pytest
     temp_dir = tmpdir.strpath
@@ -70,7 +67,7 @@ def test_local_file_source_upload_and_download(tmpdir) -> None:
 
     # clean up created files to not leave them on disk
     # TODO use pytest for automatic clean up
-    os.remove(local_file_path)
+    # os.remove(local_file_path)
 
 
 @pytest.fixture(scope="session")

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -56,7 +56,7 @@ def test_local_file_source_upload_and_download(tmpdir, tmp_path_factory) -> None
     download_file_name = "my_downloaded_file.txt"
 
     # download file
-    my_file.download(destination_source=download_file_dir, file_name=download_file_name)
+    my_file.download(destination_directory_path=download_file_dir, file_name=download_file_name)
 
     # the path the file was downloaded to and can be read from
     downloaded_local_file_path = download_file_dir / download_file_name

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -34,9 +34,9 @@ def test_local_file_source_upload_and_download(tmpdir, tmp_path_factory) -> None
         1. read that file text and assert that the string written and read are the same
     """
     file_text: str = (
-        f"This is an automated test from the Python SDK within `tests/nodes/supporting_nodes/test_file.py` " 
+        f"This is an automated test from the Python SDK within `tests/nodes/supporting_nodes/test_file.py` "
         f"checking that the file source is automatically and correctly uploaded to AWS S3. "
-        f"The test is conducted on UTC time of '{datetime.datetime.utcnow()}' " 
+        f"The test is conducted on UTC time of '{datetime.datetime.utcnow()}' "
         f"with the unique UUID of '{str(uuid.uuid4())}'"
     )
 

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -43,7 +43,6 @@ def test_local_file_source_upload_and_download(tmpdir, tmp_path_factory) -> None
     # create a temp file and write to it
     upload_file_dir = tmp_path_factory.mktemp("file_test_upload_file_dir")
     local_file_path = upload_file_dir / "my_upload_file.txt"
-
     local_file_path.write_text(file_text)
 
     # create a file node with a local file path
@@ -53,21 +52,20 @@ def test_local_file_source_upload_and_download(tmpdir, tmp_path_factory) -> None
     assert my_file.source.startswith("https://cript-development-user-data.s3.amazonaws.com")
 
     # Get the temporary directory path and clean up handled by pytest
-    temp_dir = tmpdir.strpath
+    download_file_dir = tmp_path_factory.mktemp("file_test_download_file_dir")
+    download_file_name = "my_downloaded_file.txt"
 
-    # give the file you are downloading a name and extension
-    file_name = "my_downloaded_file.txt"
+    # download file
+    my_file.download(destination_source=download_file_dir, file_name=download_file_name)
 
-    my_file.download(destination_source=temp_dir, file_name=file_name)
+    # the path the file was downloaded to and can be read from
+    downloaded_local_file_path = download_file_dir / download_file_name
 
-    with open(f"{temp_dir}/{file_name}", mode="r") as file_handle:
-        downloaded_file_contents = file_handle.read()
+    # read file contents from where the file was downloaded
+    downloaded_file_contents = downloaded_local_file_path.read_text()
 
-        assert downloaded_file_contents == file_text
-
-    # clean up created files to not leave them on disk
-    # TODO use pytest for automatic clean up
-    # os.remove(local_file_path)
+    # assert file contents for upload and download are the same
+    assert downloaded_file_contents == file_text
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
# Description

## Changes
* wrote `_file_source_setter` with typehints and docstrings
    * this is not my favorite design because it is essentially a setter for the setter, but since both constructor and setter check node schema and the file node might not be valid yet because everything has not been set yet, it might create an issue
        * this avoids duplicate code for both setter and constructor, but it is not the best
    * Since Python says whatever that can be a function should be a function, I wrote `_file_source_setter`  as a function
         * since it does not refer to self it can easily be made into a function for easy refactoring if needed.
* updated docs for file source in constructor
    > Note: File constructor is longer than expected. Some of it can later be cut down to be more concise with user testing or just review
* quickly updated `API.upload_file()` while I was on it to finish it off
* importing cached API into both upload and download function/method separately to avoid `circular import error`

## Tests
* write test for file source constructor setter and it passed successfully
* wrote test for file source setter and it passed successfully

## Known Issues

## Notes
* we could give users the ability to name their file whatever name they want or take it from the file node name, but I wasn't sure how much that was needed so for now I am just taking the name from the file node and we can add that as an upgrade if needed later
* Not sure if the design is good or not, but users can let us know in user testing