### PR TITLE
Create mypy_check.yaml CI

### DIFF
--- a/.github/workflows/mypy_check.yaml
+++ b/.github/workflows/mypy_check.yaml
@@ -1,0 +1,31 @@
+# check code types with mypy to be sure the static types are correct and make sense
+
+name: MyPy Check
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        python-version: [3.7, 3.11]
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_dev.txt
+
+      - name: Run MyPy
+        run: mypy src/cript/


### PR DESCRIPTION
# Description
Added [mypy](https://mypy.readthedocs.io/en/stable/) static type checker for our code. This is just one more layer of protection that we could have to possibly catch errors as we go.

## Changes
* created `mypy_check.yaml`
      * I am running this only on ubuntu with both python version `3.7` and `3.11` only
            * I thinking this is pretty minimal, but I would be open to adding more OS and Python versions or only using a single OS and 1 Python version
    * running it on every push and pull_request

## Tests
* tested it on a [forked repository](https://github.com/nh916/Python-SDK-tests/actions/workflows/mypy_check.yaml)

## Known Issues
* a lot of our current code is not passing it, and not sure if we need to start optimizing for this yet and checking it
    * but it might be nice to just have just in case and we can check the report and catch any bugs as we go

## Notes
* this might be too much CI and we could be overloading ourselves, but I think it could be helpful

