### PR TITLE
Created Test coverage CI

### DIFF
--- a/.github/workflows/test_coverage.yaml
+++ b/.github/workflows/test_coverage.yaml
@@ -1,12 +1,9 @@
 # use pytest-cov to see what percentage of the code is being covered by tests
-# WARNING: this workflow will automatically fail if any of the tests withing it fail
+# WARNING: this workflow will fail if any of the tests within it fail
 
 name: Test Coverage
 
-on:
-  push:
-  pull_request:
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test-coverage:

--- a/.github/workflows/test_coverage.yaml
+++ b/.github/workflows/test_coverage.yaml
@@ -1,0 +1,35 @@
+# use pytest-cov to see what percentage of the code is being covered by tests
+# WARNING: this workflow will automatically fail if any of the tests withing it fail
+
+name: Test Coverage
+
+on: [ push, pull_request ]
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+
+    # set environment variables for the whole workflow
+    env:
+      CRIPT_HOST: http://development.api.mycriptapp.org/
+      CRIPT_TOKEN: 125433546
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
+
+      - name: upgrade pip
+        run: pip install --upgrade pip
+
+      - name: Install CRIPT Python SDK
+        run: pip install -e .
+
+      - name: Install requirements_dev.txt
+        run: pip install -r requirements_dev.txt
+
+      - name: Test Coverage
+        run: pytest --cov --cov-fail-under=90

--- a/.github/workflows/test_coverage.yaml
+++ b/.github/workflows/test_coverage.yaml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        os: [ubuntu-latest]
+        python-version: [3.7, 3.11]
 
     env:
       CRIPT_HOST: http://development.api.mycriptapp.org/

--- a/.github/workflows/test_coverage.yaml
+++ b/.github/workflows/test_coverage.yaml
@@ -8,6 +8,10 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   test-coverage:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
 
     env:
       CRIPT_HOST: http://development.api.mycriptapp.org/

--- a/.github/workflows/test_coverage.yaml
+++ b/.github/workflows/test_coverage.yaml
@@ -3,13 +3,15 @@
 
 name: Test Coverage
 
-on: [ push, pull_request ]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   test-coverage:
     runs-on: ubuntu-latest
 
-    # set environment variables for the whole workflow
     env:
       CRIPT_HOST: http://development.api.mycriptapp.org/
       CRIPT_TOKEN: 125433546

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 black==23.3.0
-mypy==1.2.0
+mypy==1.3.0
 pytest-cov==4.1.0
 coverage==7.2.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 black==23.3.0
-mypy==1.3.0
-pytest==7.3.1
-coverage==7.2.5
+mypy==1.2.0
+pytest-cov==4.1.0
+coverage==7.2.3


### PR DESCRIPTION
# Description
Added CI to keep track of how much of the code our tests are covering. Test coverage is important because it helps to ensure that all of the code is tested, and that any bugs are caught early. We can have a million tests, but if we are not covering a large portion of the code then the tests are useless.

## Changes
* Added [pytest coverage](https://pytest-cov.readthedocs.io/en/latest/) to `requirements_dev.txt` for CI 
    * we already have [coverage.py](https://coverage.readthedocs.io/en/7.2.7/) and it works well and shows the coverage well in terminal locally, it is nice for local checking
        * I am okay with keeping or removing it, I can see a case for both ways
* Wrote GitHub workflow CI to check code coverage on every push, pull_request, and can be triggered manually if needed
     * set it to 90% coverage as default
* it runs on Ubuntu with Python 3.7 and 3.11
    * I think testing coverage on Ubuntu with min and max version we support is probably enough, but I am happy to change it for more or less

## Tests
tested this on my [forked repository](https://github.com/nh916/Python-SDK-tests/actions/workflows/test_coverage.yaml) and can confirm that it works well 

## Known Issues
* it seems to fail if any test within it fails