### PR TITLE
add member and admin to collection

### DIFF
--- a/src/cript/nodes/core.py
+++ b/src/cript/nodes/core.py
@@ -168,13 +168,13 @@ class BaseNode(ABC):
         attrs = cls.JsonAttributes(**arguments)
 
         # Handle default attributes manually.
-        for field in attrs.__dataclass_fields__:
+        for field in attrs.__dict__:
             # Conserve newly assigned uid if uid is default (empty)
-            if getattr(attrs, field) == getattr(cls.JsonAttributes(), field):
+            if getattr(attrs, field) == getattr(default_dataclass, field):
                 attrs = replace(attrs, **{str(field): getattr(node, field)})
-
         # But here we force even usually unwritable fields to be set.
         node._update_json_attrs_if_valid(attrs)
+
         return node
 
     def __deepcopy__(self, memo):

--- a/src/cript/nodes/primary_nodes/collection.py
+++ b/src/cript/nodes/primary_nodes/collection.py
@@ -1,7 +1,8 @@
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import Any, List
 
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
+from cript.nodes.supporting_nodes import User
 
 
 class Collection(PrimaryBaseNode):
@@ -33,6 +34,8 @@ class Collection(PrimaryBaseNode):
         """
 
         # TODO add proper typing in future, using Any for now to avoid circular import error
+        member: List[User] = field(default_factory=list)
+        admin: List[User] = field(default_factory=list)
         experiment: List[Any] = None
         inventory: List[Any] = None
         doi: str = ""
@@ -86,6 +89,13 @@ class Collection(PrimaryBaseNode):
         self.validate()
 
     # ------------------ Properties ------------------
+    @property
+    def member(self) -> List[User]:
+        return self._json_attrs.member.copy()
+
+    @property
+    def admin(self) -> List[User]:
+        return self._json_attrs.admin
 
     @property
     def experiment(self) -> List[Any]:

--- a/src/cript/nodes/primary_nodes/project.py
+++ b/src/cript/nodes/primary_nodes/project.py
@@ -31,7 +31,7 @@ class Project(PrimaryBaseNode):
         """
 
         member: List[User] = field(default_factory=list)
-        admin: User = None
+        admin: List[User] = field(default_factory=list)
         collection: List[Collection] = field(default_factory=list)
         material: List[Material] = field(default_factory=list)
 
@@ -119,7 +119,7 @@ class Project(PrimaryBaseNode):
         return self._json_attrs.member.copy()
 
     @property
-    def admin(self) -> User:
+    def admin(self) -> List[User]:
         return self._json_attrs.admin
 
     # Collection

--- a/tests/nodes/primary_nodes/test_collection.py
+++ b/tests/nodes/primary_nodes/test_collection.py
@@ -81,7 +81,7 @@ def test_collection_getters_and_setters(simple_experiment_node, simple_inventory
     assert my_collection.citation == [complex_citation_node]
 
 
-def test_serialize_collection_to_json(simple_collection_node) -> None:
+def test_serialize_collection_to_json(complex_user_node) -> None:
     """
     test that Collection node can be correctly serialized to JSON
 
@@ -100,12 +100,17 @@ def test_serialize_collection_to_json(simple_collection_node) -> None:
         "experiment": [{"node": ["Experiment"], "name": "my experiment name"}],
         "inventory": [],
         "citation": [],
+        "member": [json.loads(copy.deepcopy(complex_user_node).json)],
+        "admin": [json.loads(complex_user_node.json)],
     }
 
+    collection_node = cript.load_nodes_from_json(json.dumps(expected_collection_dict))
+    print(collection_node.get_json(indent=2).json)
     # assert
-    ref_dict = json.loads(simple_collection_node.json)
+    ref_dict = json.loads(collection_node.get_json(condense_to_uuid={}).json)
     ref_dict = strip_uid_from_dict(ref_dict)
-    assert ref_dict == expected_collection_dict
+
+    assert ref_dict == strip_uid_from_dict(expected_collection_dict)
 
 
 def test_uuid(complex_collection_node):


### PR DESCRIPTION
# Description

With the removal of the group node, we also need to add the `member` and `admin` to collections.

## Changes

A few changes to the expected data types of project, that I overlooked.

## Tests

added a check in the serialization test

## Known Issues

Docs not updated.

## Notes

## Checklist

- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
