### PR TITLE
add process back into material

### DIFF
--- a/src/cript/nodes/primary_nodes/material.py
+++ b/src/cript/nodes/primary_nodes/material.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass, field, replace
-from typing import Any, List
+from typing import Any, List, Union
 
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
+from cript.nodes.primary_nodes.process import Process
 
 
 class Material(PrimaryBaseNode):
@@ -71,6 +72,7 @@ class Material(PrimaryBaseNode):
         identifiers: List[dict[str, str]] = field(default_factory=dict)
         # TODO add proper typing in future, using Any for now to avoid circular import error
         component: List["Material"] = field(default_factory=list)
+        process: Union[Process, None] = None
         property: List[Any] = field(default_factory=list)
         parent_material: List["Material"] = field(default_factory=list)
         computational_forcefield: List[Any] = field(default_factory=list)
@@ -83,6 +85,7 @@ class Material(PrimaryBaseNode):
         name: str,
         identifiers: List[dict[str, str]],
         component: List["Material"] = None,
+        process: Union[Process, None] = None,
         property: List[Any] = None,
         parent_material: List["Material"] = None,
         computational_forcefield: List[Any] = None,
@@ -98,7 +101,7 @@ class Material(PrimaryBaseNode):
         name: str
         identifiers: List[dict[str, str]]
         component: List["Material"], default=None
-        property: List[Property], default=None
+        property: Union[Process, None], default=None
         process: List[Process], default=None
         parent_material: List["Material"], default=None
         computational_forcefield: List[ComputationalProcess], default=None
@@ -136,6 +139,7 @@ class Material(PrimaryBaseNode):
             name=name,
             identifiers=identifiers,
             component=component,
+            process=process,
             property=property,
             parent_material=parent_material,
             computational_forcefield=computational_forcefield,
@@ -406,6 +410,15 @@ class Material(PrimaryBaseNode):
                 # TODO validate keys here
                 # is_vocab_valid("material_identifiers", value)
                 pass
+
+    @property
+    def process(self) -> Process:
+        return self._json_attrs.process
+
+    @process.setter
+    def process(self, new_process: Process) -> None:
+        new_attrs = replace(self._json_attrs, process=new_process)
+        self._update_json_attrs_if_valid(new_attrs)
 
     @property
     def property(self) -> List[Any]:

--- a/src/cript/nodes/primary_nodes/material.py
+++ b/src/cript/nodes/primary_nodes/material.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field, replace
-from typing import Any, List, Union
+from typing import Any, List, Optional
 
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
 from cript.nodes.primary_nodes.process import Process
@@ -72,7 +72,7 @@ class Material(PrimaryBaseNode):
         identifiers: List[dict[str, str]] = field(default_factory=dict)
         # TODO add proper typing in future, using Any for now to avoid circular import error
         component: List["Material"] = field(default_factory=list)
-        process: Union[Process, None] = None
+        process: Optional[Process] = None
         property: List[Any] = field(default_factory=list)
         parent_material: List["Material"] = field(default_factory=list)
         computational_forcefield: List[Any] = field(default_factory=list)
@@ -85,7 +85,7 @@ class Material(PrimaryBaseNode):
         name: str,
         identifiers: List[dict[str, str]],
         component: List["Material"] = None,
-        process: Union[Process, None] = None,
+        process: Optional[Process] = None,
         property: List[Any] = None,
         parent_material: List["Material"] = None,
         computational_forcefield: List[Any] = None,
@@ -101,7 +101,7 @@ class Material(PrimaryBaseNode):
         name: str
         identifiers: List[dict[str, str]]
         component: List["Material"], default=None
-        property: Union[Process, None], default=None
+        property: Optional[Process], default=None
         process: List[Process], default=None
         parent_material: List["Material"], default=None
         computational_forcefield: List[ComputationalProcess], default=None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ import pytest
 from fixtures.primary_nodes import (
     complex_collection_node,
     complex_data_node,
+    complex_material_dict,
     complex_material_node,
     complex_project_dict,
     complex_project_node,

--- a/tests/fixtures/primary_nodes.py
+++ b/tests/fixtures/primary_nodes.py
@@ -2,6 +2,7 @@ import copy
 import json
 
 import pytest
+from util import strip_uid_from_dict
 
 import cript
 
@@ -193,25 +194,37 @@ def simple_material_dict() -> dict:
 
 
 @pytest.fixture(scope="function")
+def complex_material_dict(simple_property_node, simple_process_node, complex_computational_forcefield_node, simple_material_node) -> cript.Material:
+    """
+    complex Material node with all possible attributes filled
+    """
+    my_material_keyword = ["acetylene"]
+
+    material_dict = {"node": ["Material"]}
+    material_dict["name"] = "my complex material"
+    material_dict["property"] = [json.loads(simple_property_node.json)]
+    material_dict["process"] = json.loads(simple_process_node.json)
+    material_dict["parent_material"] = json.loads(simple_material_node.json)
+    material_dict["computational_forcefield"] = json.loads(complex_computational_forcefield_node.json)
+    material_dict["bigsmiles"] = "my complex_material_node"
+    material_dict["keyword"] = my_material_keyword
+
+    return strip_uid_from_dict(material_dict)
+
+
+@pytest.fixture(scope="function")
 def complex_material_node(simple_property_node, simple_process_node, complex_computational_forcefield_node, simple_material_node) -> cript.Material:
     """
     complex Material node with all possible attributes filled
     """
     my_identifier = [{"bigsmiles": "my complex_material_node"}]
-
-    [
-        cript.Material(name="my component material 1", identifiers=[{"bigsmiles": "component 1 bigsmiles"}]),
-        cript.Material(name="my component material 2", identifiers=[{"bigsmiles": "component 2 bigsmiles"}]),
-    ]
-
     my_material_keyword = ["acetylene"]
 
     my_complex_material = cript.Material(
         name="my complex material",
         identifiers=my_identifier,
-        # component=my_component,
         property=[simple_property_node],
-        # process=copy.deepcopy(simple_process_node),
+        process=copy.deepcopy(simple_process_node),
         parent_material=simple_material_node,
         computational_forcefield=complex_computational_forcefield_node,
         keyword=my_material_keyword,

--- a/tests/nodes/primary_nodes/test_material.py
+++ b/tests/nodes/primary_nodes/test_material.py
@@ -5,7 +5,7 @@ from util import strip_uid_from_dict
 import cript
 
 
-def test_create_complex_material(simple_material_node, simple_computational_forcefield_node) -> None:
+def test_create_complex_material(simple_material_node, simple_computational_forcefield_node, simple_process_node) -> None:
     """
     tests that a simple material can be created with only the required arguments
     """
@@ -19,13 +19,14 @@ def test_create_complex_material(simple_material_node, simple_computational_forc
 
     my_property = [cript.Property(key="modulus_shear", type="min", value=1.23, unit="gram")]
 
-    my_material = cript.Material(name=material_name, identifiers=identifiers, keyword=keyword, component=component, property=my_property, computational_forcefield=forcefield)
+    my_material = cript.Material(name=material_name, identifiers=identifiers, keyword=keyword, component=component, process=simple_process_node, property=my_property, computational_forcefield=forcefield)
 
     assert isinstance(my_material, cript.Material)
     assert my_material.name == material_name
     assert my_material.identifiers == identifiers
     assert my_material.keyword == keyword
     assert my_material.component == component
+    assert my_material.process == simple_process_node
     assert my_material.property == my_property
     assert my_material.computational_forcefield == forcefield
 
@@ -88,21 +89,17 @@ def test_all_getters_and_setters(simple_material_node, simple_property_node, sim
     assert simple_material_node.component == new_components
 
 
-def test_serialize_material_to_json(simple_material_node) -> None:
+def test_serialize_material_to_json(complex_material_dict, complex_material_node) -> None:
     """
     tests that it can correctly turn the material node into its equivalent JSON
     """
     # the JSON that the material should serialize to
-    expected_dict = {
-        "node": ["Material"],
-        "name": "my material",
-        "bigsmiles": "123456",
-    }
 
     # compare dicts because that is more accurate
-    ref_dict = json.loads(simple_material_node.json)
+    ref_dict = json.loads(complex_material_node.get_json(condense_to_uuid={}).json)
     ref_dict = strip_uid_from_dict(ref_dict)
-    assert ref_dict == expected_dict
+
+    assert ref_dict == complex_material_dict
 
 
 # ---------- Integration Tests ----------

--- a/tests/test_node_util.py
+++ b/tests/test_node_util.py
@@ -208,6 +208,8 @@ def test_invalid_project_graphs(simple_project_node, simple_material_node, simpl
                 project.validate()
             except CRIPTOrphanedMaterialError as exc:
                 project._json_attrs.material.append(exc.orphaned_node)
+            except CRIPTOrphanedProcessError as exc:
+                project.collection[0].experiment[0]._json_attrs.process.append(exc.orphaned_node)
             else:
                 break
 


### PR DESCRIPTION
# Description
Process is again part of the material node.

## Changes
I think it used to be an array, now it is a single value.
## Tests
Testing this like ususal.
## Known Issues
None
## Notes

## Checklist

- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.

Not sure about documentation, the old one with the process was still in.