### PR TITLE
Removing the faulty test from merge q

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,6 @@ on:
     branches:
       - main
       - develop
-      - trunk-merge/**
   pull_request:
     branches:
       - develop

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -52,4 +52,3 @@ merge:
     - install (macos-latest, 3.11)
     - test-coverage (ubuntu-latest, 3.7)
     - test-coverage (ubuntu-latest, 3.11)
-    - dependency-review


### PR DESCRIPTION
# Description
It seems like that the dependency test doesn't like to run on wild card branch pushes.
But these are required for the trunk merge q

## Changes

Removed the test to run on trunk merge q and remove it from requirements.

## Tests
Tested on fork. The merge q works.

## Known Issues
The tests still run on PRs and pushes, it just doesn't prevent merging with the Q.
## Notes
Trunk Merge Q doesn't work on forked repos. But we can still merge manually and sholdn't be a big deal.
## Checklist

- [ x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
