### PR TITLE
UUID base all

### DIFF
--- a/src/cript/nodes/core.py
+++ b/src/cript/nodes/core.py
@@ -12,7 +12,7 @@ from cript.nodes.exceptions import (
     CRIPTJsonSerializationError,
 )
 
-tolerated_extra_json = ["component_count", "computational_forcefield_count", "property_count"]
+tolerated_extra_json = []
 
 
 def add_tolerated_extra_json(additional_tolerated_json: str):
@@ -69,10 +69,18 @@ class BaseNode(ABC):
     def __init__(self, **kwargs):
         for kwarg in kwargs:
             if kwarg not in tolerated_extra_json:
-                try:
-                    getattr(self._json_attrs, kwarg)
-                except KeyError:
-                    raise CRIPTExtraJsonAttributes(self.node_type, kwarg)
+                if kwarg.endswith("_count"):
+                    try:
+                        possible_array = getattr(self._json_attrs.kwarg[: -len("_count")])
+                        if not isinstance(possible_array, list):
+                            raise CRIPTExtraJsonAttributes(self.node_type, kwarg)
+                    except KeyError:
+                        raise CRIPTExtraJsonAttributes(self.node_type, kwarg)
+                else:
+                    try:
+                        getattr(self._json_attrs, kwarg)
+                    except KeyError:
+                        raise CRIPTExtraJsonAttributes(self.node_type, kwarg)
 
         uid = get_new_uid()
         self._json_attrs = replace(self._json_attrs, node=[self.node_type], uid=uid)

--- a/src/cript/nodes/primary_nodes/primary_base_node.py
+++ b/src/cript/nodes/primary_nodes/primary_base_node.py
@@ -1,6 +1,5 @@
 from abc import ABC
 from dataclasses import dataclass, replace
-from typing import Any
 
 from cript.nodes.uuid_base import UUIDBaseNode
 

--- a/src/cript/nodes/primary_nodes/primary_base_node.py
+++ b/src/cript/nodes/primary_nodes/primary_base_node.py
@@ -19,8 +19,6 @@ class PrimaryBaseNode(UUIDBaseNode, ABC):
 
         locked: bool = False
         model_version: str = ""
-        updated_by: Any = None
-        created_by: Any = None
         public: bool = False
         name: str = ""
         notes: str = ""
@@ -44,8 +42,6 @@ class PrimaryBaseNode(UUIDBaseNode, ABC):
         {
         'locked': False,
         'model_version': '',
-        'updated_by': None,
-        'created_by': None,
         'public': False,
         'notes': ''
         }
@@ -65,14 +61,6 @@ class PrimaryBaseNode(UUIDBaseNode, ABC):
     @property
     def model_version(self):
         return self._json_attrs.model_version
-
-    @property
-    def updated_by(self):
-        return self._json_attrs.updated_by
-
-    @property
-    def created_by(self):
-        return self._json_attrs.created_by
 
     @property
     def public(self):

--- a/src/cript/nodes/subobjects/algorithm.py
+++ b/src/cript/nodes/subobjects/algorithm.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass, field, replace
 from typing import List
 
-from cript.nodes.core import BaseNode
 from cript.nodes.subobjects.citation import Citation
 from cript.nodes.subobjects.parameter import Parameter
+from cript.nodes.uuid_base import UUIDBaseNode
 
 
-class Algorithm(BaseNode):
+class Algorithm(UUIDBaseNode):
     """
     ## Definition
 
@@ -63,7 +63,7 @@ class Algorithm(BaseNode):
     """
 
     @dataclass(frozen=True)
-    class JsonAttributes(BaseNode.JsonAttributes):
+    class JsonAttributes(UUIDBaseNode.JsonAttributes):
         key: str = ""
         type: str = ""
 

--- a/src/cript/nodes/subobjects/citation.py
+++ b/src/cript/nodes/subobjects/citation.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass, replace
 from typing import Union
 
-from cript.nodes.core import BaseNode
 from cript.nodes.primary_nodes.reference import Reference
+from cript.nodes.uuid_base import UUIDBaseNode
 
 
-class Citation(BaseNode):
+class Citation(UUIDBaseNode):
     """
     ## Definition
     The [Citation sub-object](https://pubs.acs.org/doi/suppl/10.1021/acscentsci.3c00011/suppl_file/oc3c00011_si_001.pdf#page=26)
@@ -58,7 +58,7 @@ class Citation(BaseNode):
     """
 
     @dataclass(frozen=True)
-    class JsonAttributes(BaseNode.JsonAttributes):
+    class JsonAttributes(UUIDBaseNode.JsonAttributes):
         type: str = ""
         reference: Union[Reference, None] = None
 

--- a/src/cript/nodes/subobjects/computational_forcefield.py
+++ b/src/cript/nodes/subobjects/computational_forcefield.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass, field, replace
 from typing import List, Union
 
-from cript.nodes.core import BaseNode
 from cript.nodes.primary_nodes.data import Data
 from cript.nodes.subobjects.citation import Citation
+from cript.nodes.uuid_base import UUIDBaseNode
 
 
-class ComputationalForcefield(BaseNode):
+class ComputationalForcefield(UUIDBaseNode):
     """
     ## Definition
     A [Computational Forcefield Subobject](https://pubs.acs.org/doi/suppl/10.1021/acscentsci.3c00011/suppl_file/oc3c00011_si_001.pdf#page=23)
@@ -79,7 +79,7 @@ class ComputationalForcefield(BaseNode):
     """
 
     @dataclass(frozen=True)
-    class JsonAttributes(BaseNode.JsonAttributes):
+    class JsonAttributes(UUIDBaseNode.JsonAttributes):
         key: str = ""
         building_block: str = ""
         coarse_grained_mapping: str = ""

--- a/src/cript/nodes/subobjects/condition.py
+++ b/src/cript/nodes/subobjects/condition.py
@@ -2,11 +2,11 @@ from dataclasses import dataclass, replace
 from numbers import Number
 from typing import Union
 
-from cript.nodes.core import BaseNode
 from cript.nodes.primary_nodes.data import Data
+from cript.nodes.uuid_base import UUIDBaseNode
 
 
-class Condition(BaseNode):
+class Condition(UUIDBaseNode):
     """
     ## Definition
 
@@ -74,7 +74,7 @@ class Condition(BaseNode):
     """
 
     @dataclass(frozen=True)
-    class JsonAttributes(BaseNode.JsonAttributes):
+    class JsonAttributes(UUIDBaseNode.JsonAttributes):
         key: str = ""
         type: str = ""
         descriptor: str = ""

--- a/src/cript/nodes/subobjects/equipment.py
+++ b/src/cript/nodes/subobjects/equipment.py
@@ -1,13 +1,13 @@
 from dataclasses import dataclass, field, replace
 from typing import List, Union
 
-from cript.nodes.core import BaseNode
 from cript.nodes.subobjects.citation import Citation
 from cript.nodes.subobjects.condition import Condition
 from cript.nodes.supporting_nodes.file import File
+from cript.nodes.uuid_base import UUIDBaseNode
 
 
-class Equipment(BaseNode):
+class Equipment(UUIDBaseNode):
     """
     ## Definition
     An [Equipment](https://pubs.acs.org/doi/suppl/10.1021/acscentsci.3c00011/suppl_file/oc3c00011_si_001.pdf#page=23)
@@ -42,7 +42,7 @@ class Equipment(BaseNode):
     """
 
     @dataclass(frozen=True)
-    class JsonAttributes(BaseNode.JsonAttributes):
+    class JsonAttributes(UUIDBaseNode.JsonAttributes):
         key: str = ""
         description: str = ""
         condition: List[Condition] = field(default_factory=list)

--- a/src/cript/nodes/subobjects/ingredient.py
+++ b/src/cript/nodes/subobjects/ingredient.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass, field, replace
 from typing import List, Union
 
-from cript.nodes.core import BaseNode
 from cript.nodes.primary_nodes.material import Material
 from cript.nodes.subobjects.quantity import Quantity
+from cript.nodes.uuid_base import UUIDBaseNode
 
 
-class Ingredient(BaseNode):
+class Ingredient(UUIDBaseNode):
     """
     ## Definition
     An [Ingredient](https://pubs.acs.org/doi/suppl/10.1021/acscentsci.3c00011/suppl_file/oc3c00011_si_001.pdf#page=22)
@@ -38,7 +38,7 @@ class Ingredient(BaseNode):
     """
 
     @dataclass(frozen=True)
-    class JsonAttributes(BaseNode.JsonAttributes):
+    class JsonAttributes(UUIDBaseNode.JsonAttributes):
         material: Union[Material, None] = None
         quantity: List[Quantity] = field(default_factory=list)
         keyword: str = ""

--- a/src/cript/nodes/subobjects/parameter.py
+++ b/src/cript/nodes/subobjects/parameter.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass, replace
 from typing import Union
 
-from cript.nodes.core import BaseNode
+from cript.nodes.uuid_base import UUIDBaseNode
 
 
-class Parameter(BaseNode):
+class Parameter(UUIDBaseNode):
     """
     ## Definition
 
@@ -45,7 +45,7 @@ class Parameter(BaseNode):
     """
 
     @dataclass(frozen=True)
-    class JsonAttributes(BaseNode.JsonAttributes):
+    class JsonAttributes(UUIDBaseNode.JsonAttributes):
         key: str = ""
         value: Union[int, float, str] = ""
         # We explicitly allow None for unit here (instead of empty str),

--- a/src/cript/nodes/subobjects/property.py
+++ b/src/cript/nodes/subobjects/property.py
@@ -2,16 +2,16 @@ from dataclasses import dataclass, field, replace
 from numbers import Number
 from typing import List, Union
 
-from cript.nodes.core import BaseNode
 from cript.nodes.primary_nodes.computation import Computation
 from cript.nodes.primary_nodes.data import Data
 from cript.nodes.primary_nodes.material import Material
 from cript.nodes.primary_nodes.process import Process
 from cript.nodes.subobjects.citation import Citation
 from cript.nodes.subobjects.condition import Condition
+from cript.nodes.uuid_base import UUIDBaseNode
 
 
-class Property(BaseNode):
+class Property(UUIDBaseNode):
     """
     ## Definition
     [Property](https://pubs.acs.org/doi/suppl/10.1021/acscentsci.3c00011/suppl_file/oc3c00011_si_001.pdf#page=18) sub-objects
@@ -58,7 +58,7 @@ class Property(BaseNode):
     """
 
     @dataclass(frozen=True)
-    class JsonAttributes(BaseNode.JsonAttributes):
+    class JsonAttributes(UUIDBaseNode.JsonAttributes):
         key: str = ""
         type: str = ""
         value: Union[Number, None] = None

--- a/src/cript/nodes/subobjects/quantity.py
+++ b/src/cript/nodes/subobjects/quantity.py
@@ -2,10 +2,10 @@ from dataclasses import dataclass, replace
 from numbers import Number
 from typing import Union
 
-from cript.nodes.core import BaseNode
+from cript.nodes.uuid_base import UUIDBaseNode
 
 
-class Quantity(BaseNode):
+class Quantity(UUIDBaseNode):
     """
     ## Definition
     The [Quantity](https://pubs.acs.org/doi/suppl/10.1021/acscentsci.3c00011/suppl_file/oc3c00011_si_001.pdf#page=22)
@@ -40,7 +40,7 @@ class Quantity(BaseNode):
     """
 
     @dataclass(frozen=True)
-    class JsonAttributes(BaseNode.JsonAttributes):
+    class JsonAttributes(UUIDBaseNode.JsonAttributes):
         key: str = ""
         value: Union[Number, None] = None
         unit: str = ""

--- a/src/cript/nodes/supporting_nodes/user.py
+++ b/src/cript/nodes/supporting_nodes/user.py
@@ -47,12 +47,10 @@ class User(UUIDBaseNode):
         all User attributes
         """
 
-        created_at: str = ""
         email: str = ""
         model_version: str = ""
         orcid: str = ""
         picture: str = ""
-        updated_at: str = ""
         username: str = ""
 
     _json_attrs: JsonAttributes = JsonAttributes()
@@ -77,10 +75,6 @@ class User(UUIDBaseNode):
         self.validate()
 
     # ------------------ properties ------------------
-
-    @property
-    def created_at(self) -> str:
-        return self._json_attrs.created_at
 
     @property
     def email(self) -> str:
@@ -121,10 +115,6 @@ class User(UUIDBaseNode):
     @property
     def picture(self) -> str:
         return self._json_attrs.picture
-
-    @property
-    def updated_at(self) -> str:
-        return self._json_attrs.updated_at
 
     @property
     def username(self) -> str:

--- a/src/cript/nodes/uuid_base.py
+++ b/src/cript/nodes/uuid_base.py
@@ -1,6 +1,7 @@
 import uuid
 from abc import ABC
 from dataclasses import dataclass, replace
+from typing import Any
 
 from cript.nodes.core import BaseNode
 
@@ -21,6 +22,10 @@ class UUIDBaseNode(BaseNode, ABC):
         """
 
         uuid: str = ""
+        updated_by: Any = None
+        created_by: Any = None
+        created_at: str = ""
+        updated_at: str = ""
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
@@ -47,3 +52,19 @@ class UUIDBaseNode(BaseNode, ABC):
         node = super().__deepcopy__(memo)
         node._json_attrs = replace(node._json_attrs, uuid=get_uuid_from_uid(node.uid))
         return node
+
+    @property
+    def updated_by(self):
+        return self._json_attrs.updated_by
+
+    @property
+    def created_by(self):
+        return self._json_attrs.created_by
+
+    @property
+    def updated_at(self):
+        return self._json_attrs.updated_at
+
+    @property
+    def created_at(self):
+        return self._json_attrs.created_at


### PR DESCRIPTION
# Description

According to @brili all nodes (including subobjects) have a UUID, and a few other attributes.
So, I added those attributes to the UUIDBaseNode and have all nodes inherit from it.

## Changes

## Tests

## Known Issues
This might be better done with refactoring, and considering how BaseNode and UUIDBaseNode now serve a similar function.

## Notes

## Checklist

- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
Documentation isn't up to date with this.