### PR TITLE
Add beartype check

### DIFF
--- a/.trunk/configs/.cspell.json
+++ b/.trunk/configs/.cspell.json
@@ -71,6 +71,7 @@
     "Autobuild",
     "buildscript",
     "markdownlint",
-    "Numpy"
+    "Numpy",
+    "beartype"
   ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.31.0
 jsonschema==4.17.3
+beartype>=0.12

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 black==23.3.0
+beartype==0.14.1
 mypy==1.3.0
 pytest-cov==4.1.0
 coverage==7.2.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ include_package_data = True
 install_requires =
 		 requests>=2.28.2
 		 jsonschema>=4.17.3
+		 beartype>=0.12
     
 
 [options.packages.find]

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Union
 
 import jsonschema
 import requests
+from beartype import beartype
 
 from cript.api.exceptions import (
     APIError,
@@ -51,6 +52,7 @@ class API:
     _api_handle: str = "api"
     _api_version: str = "v1"
 
+    @beartype
     def __init__(self, host: Union[str, None] = None, token: Union[str, None] = None, config_file_path: str = ""):
         """
         Initialize CRIPT API client with host and token.
@@ -147,6 +149,7 @@ class API:
 
         self._get_db_schema()
 
+    @beartype
     def _prepare_host(self, host: str) -> str:
         # strip ending slash to make host always uniform
         host = host.rstrip("/")
@@ -165,6 +168,7 @@ class API:
         self.connect()
         return self
 
+    @beartype
     def __exit__(self, type, value, traceback):
         self.disconnect()
 
@@ -275,6 +279,7 @@ class API:
 
         return self._vocabulary
 
+    @beartype
     def get_vocab_by_category(self, category: ControlledVocabularyCategories) -> List[dict]:
         """
         get the CRIPT controlled vocabulary by category
@@ -306,6 +311,7 @@ class API:
 
         return self._vocabulary[category.value]
 
+    @beartype
     def _is_vocab_valid(self, vocab_category: ControlledVocabularyCategories, vocab_word: str) -> bool:
         """
         checks if the vocabulary is valid within the CRIPT controlled vocabulary.
@@ -382,7 +388,7 @@ class API:
             self._db_schema = response["data"]
             return self._db_schema
 
-    # TODO this should later work with both POST and PATCH. Currently, just works for POST
+    @beartype
     def _is_node_schema_valid(self, node_json: str) -> bool:
         """
         checks a node JSON schema against the db schema to return if it is valid or not.
@@ -441,6 +447,7 @@ class API:
         # if validation goes through without any problems return True
         return True
 
+    @beartype
     def save(self, project: Project) -> None:
         """
         This method takes a project node, serializes the class into JSON
@@ -472,7 +479,7 @@ class API:
         if response["code"] != 200:
             raise CRIPTAPISaveError(api_host_domain=self._host, http_code=response["code"], api_response=response["error"])
 
-    # TODO reset to work with real nodes node_type.node and node_type to be PrimaryNode
+    @beartype
     def search(
         self,
         node_type: BaseNode,

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -137,8 +137,8 @@ class API:
             host = authentication_dict["host"]
             token = authentication_dict["token"]
 
-        self._host = self._prepare_host(host=host)      # type: ignore
-        self._token = token     # type: ignore
+        self._host = self._prepare_host(host=host)  # type: ignore
+        self._token = token  # type: ignore
 
         # assign headers
         # TODO might need to add Bearer to it or check for it

--- a/src/cript/api/paginator.py
+++ b/src/cript/api/paginator.py
@@ -2,6 +2,7 @@ from typing import List, Union, Optional
 from urllib.parse import quote
 
 import requests
+from beartype import beartype
 
 
 class Paginator:
@@ -31,6 +32,7 @@ class Paginator:
 
     current_page_results: List[dict]
 
+    @beartype
     def __init__(
         self,
         http_headers: dict,
@@ -103,6 +105,7 @@ class Paginator:
         self.current_page_number -= 1
 
     @property
+    @beartype
     def current_page_number(self) -> int:
         """
         get the current page number that you are on.
@@ -123,6 +126,7 @@ class Paginator:
         return self._current_page_number
 
     @current_page_number.setter
+    @beartype
     def current_page_number(self, new_page_number: int) -> None:
         """
         flips to a specific page of data that has been requested
@@ -153,6 +157,7 @@ class Paginator:
             # when new page number is set, it is then fetched from the API
             self.fetch_page_from_api()
 
+    @beartype
     def fetch_page_from_api(self) -> List[dict]:
         """
         1. builds the URL from the query and page number

--- a/src/cript/api/paginator.py
+++ b/src/cript/api/paginator.py
@@ -1,4 +1,4 @@
-from typing import List, Union, Optional
+from typing import List, Optional, Union
 from urllib.parse import quote
 
 import requests

--- a/src/cript/nodes/primary_nodes/collection.py
+++ b/src/cript/nodes/primary_nodes/collection.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field, replace
 from typing import Any, List, Optional
 
+from beartype import beartype
+
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
 from cript.nodes.supporting_nodes import User
 
@@ -43,6 +45,7 @@ class Collection(PrimaryBaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(self, name: str, experiment: Optional[List[Any]] = None, inventory: Optional[List[Any]] = None, doi: str = "", citation: Optional[List[Any]] = None, notes: str = "", **kwargs) -> None:
         """
         create a Collection with a name
@@ -89,14 +92,17 @@ class Collection(PrimaryBaseNode):
         self.validate()
 
     @property
+    @beartype
     def member(self) -> List[User]:
         return self._json_attrs.member.copy()
 
     @property
+    @beartype
     def admin(self) -> List[User]:
         return self._json_attrs.admin
 
     @property
+    @beartype
     def experiment(self) -> List[Any]:
         """
         List of all [experiment](../experiment) within this Collection
@@ -115,6 +121,7 @@ class Collection(PrimaryBaseNode):
         return self._json_attrs.experiment.copy()  # type: ignore
 
     @experiment.setter
+    @beartype
     def experiment(self, new_experiment: List[Any]) -> None:
         """
         sets the Experiment list within this collection
@@ -132,6 +139,7 @@ class Collection(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def inventory(self) -> List[Any]:
         """
         List of [inventory](../inventory) that belongs to this collection
@@ -164,6 +172,7 @@ class Collection(PrimaryBaseNode):
         return self._json_attrs.inventory.copy()  # type: ignore
 
     @inventory.setter
+    @beartype
     def inventory(self, new_inventory: List[Any]) -> None:
         """
         Sets the List of inventories within this collection to a new list
@@ -181,6 +190,7 @@ class Collection(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def doi(self) -> str:
         """
         The CRIPT DOI for this collection
@@ -197,6 +207,7 @@ class Collection(PrimaryBaseNode):
         return self._json_attrs.doi
 
     @doi.setter
+    @beartype
     def doi(self, new_doi: str) -> None:
         """
         set the CRIPT DOI for this collection to new CRIPT DOI
@@ -213,6 +224,7 @@ class Collection(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def citation(self) -> List[Any]:
         """
         List of Citations within this Collection
@@ -233,6 +245,7 @@ class Collection(PrimaryBaseNode):
         return self._json_attrs.citation.copy()  # type: ignore
 
     @citation.setter
+    @beartype
     def citation(self, new_citation: List[Any]) -> None:
         """
         set the list of citations for this Collection

--- a/src/cript/nodes/primary_nodes/computation_process.py
+++ b/src/cript/nodes/primary_nodes/computation_process.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field, replace
 from typing import Any, List, Optional
 
+from beartype import beartype
+
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
 
 
@@ -61,6 +63,7 @@ class ComputationProcess(PrimaryBaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(
         self,
         name: str,
@@ -185,9 +188,8 @@ class ComputationProcess(PrimaryBaseNode):
 
         # self.validate()
 
-    # -------------- Properties --------------
-
     @property
+    @beartype
     def type(self) -> str:
         """
         The computational process type must come from CRIPT Controlled vocabulary
@@ -206,6 +208,7 @@ class ComputationProcess(PrimaryBaseNode):
         return self._json_attrs.type
 
     @type.setter
+    @beartype
     def type(self, new_type: str) -> None:
         """
         set the computational_process type
@@ -227,6 +230,7 @@ class ComputationProcess(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def input_data(self) -> List[Any]:
         """
         List of input data for the computational process node
@@ -257,6 +261,7 @@ class ComputationProcess(PrimaryBaseNode):
         return self._json_attrs.input_data.copy()
 
     @input_data.setter
+    @beartype
     def input_data(self, new_input_data_list: List[Any]) -> None:
         """
         set the input data for this computational process
@@ -273,6 +278,7 @@ class ComputationProcess(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def output_data(self) -> List[Any]:
         """
         List of the output data for the computational_process
@@ -303,6 +309,7 @@ class ComputationProcess(PrimaryBaseNode):
         return self._json_attrs.output_data.copy()
 
     @output_data.setter
+    @beartype
     def output_data(self, new_output_data_list: List[Any]) -> None:
         """
         set the output_data list for the computational_process
@@ -319,6 +326,7 @@ class ComputationProcess(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def ingredient(self) -> List[Any]:
         """
         List of ingredients for the computational_process
@@ -343,6 +351,7 @@ class ComputationProcess(PrimaryBaseNode):
         return self._json_attrs.ingredient.copy()
 
     @ingredient.setter
+    @beartype
     def ingredient(self, new_ingredient_list: List[Any]) -> None:
         """
         set the ingredients list for this computational process
@@ -359,6 +368,7 @@ class ComputationProcess(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def software_configuration(self) -> List[Any]:
         """
         List of software_configuration for the computational process
@@ -380,6 +390,7 @@ class ComputationProcess(PrimaryBaseNode):
         return self._json_attrs.software_configuration.copy()
 
     @software_configuration.setter
+    @beartype
     def software_configuration(self, new_software_configuration_list: List[Any]) -> None:
         """
         set the list of software_configuration for the computational process
@@ -396,6 +407,7 @@ class ComputationProcess(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def condition(self) -> List[Any]:
         """
         List of condition for the computational process
@@ -418,6 +430,7 @@ class ComputationProcess(PrimaryBaseNode):
         return self._json_attrs.condition.copy()
 
     @condition.setter
+    @beartype
     def condition(self, new_condition: List[Any]) -> None:
         """
         set the condition for the computational process
@@ -434,6 +447,7 @@ class ComputationProcess(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def citation(self) -> List[Any]:
         """
         List of citation for the computational process
@@ -458,6 +472,7 @@ class ComputationProcess(PrimaryBaseNode):
         return self._json_attrs.citation.copy()
 
     @citation.setter
+    @beartype
     def citation(self, new_citation_list: List[Any]) -> None:
         """
         set the citation list for the computational process node
@@ -474,6 +489,7 @@ class ComputationProcess(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def property(self) -> List[Any]:
         """
         List of properties
@@ -495,6 +511,7 @@ class ComputationProcess(PrimaryBaseNode):
         return self._json_attrs.property.copy()
 
     @property.setter
+    @beartype
     def property(self, new_property_list: List[Any]) -> None:
         """
         set the properties list for the computational process

--- a/src/cript/nodes/primary_nodes/data.py
+++ b/src/cript/nodes/primary_nodes/data.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field, replace
 from typing import Any, List, Optional, Union
 
+from beartype import beartype
+
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
 
 
@@ -76,6 +78,7 @@ class Data(PrimaryBaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(
         self,
         name: str,
@@ -127,8 +130,8 @@ class Data(PrimaryBaseNode):
 
         self.validate()
 
-    # ------------------ Properties ------------------
     @property
+    @beartype
     def type(self) -> str:
         """
         Type of data node. The data type must come from [CRIPT data type vocabulary]()
@@ -147,6 +150,7 @@ class Data(PrimaryBaseNode):
         return self._json_attrs.type
 
     @type.setter
+    @beartype
     def type(self, new_data_type: str) -> None:
         """
         set the data type.
@@ -166,6 +170,7 @@ class Data(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def file(self) -> List[Any]:
         """
         get the list of files for this data node
@@ -195,6 +200,7 @@ class Data(PrimaryBaseNode):
         return self._json_attrs.file.copy()
 
     @file.setter
+    @beartype
     def file(self, new_file_list: List[Any]) -> None:
         """
         set the list of file for this data node
@@ -212,6 +218,7 @@ class Data(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def sample_preparation(self) -> Union[Any, None]:
         """
         The sample preparation for this data node
@@ -224,6 +231,7 @@ class Data(PrimaryBaseNode):
         return self._json_attrs.sample_preparation
 
     @sample_preparation.setter
+    @beartype
     def sample_preparation(self, new_sample_preparation: Union[Any, None]) -> None:
         """
         set sample_preparation
@@ -241,6 +249,7 @@ class Data(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def computation(self) -> List[Any]:
         """
         list of computation nodes for this material node
@@ -253,6 +262,7 @@ class Data(PrimaryBaseNode):
         return self._json_attrs.computation.copy()
 
     @computation.setter
+    @beartype
     def computation(self, new_computation_list: List[Any]) -> None:
         """
         set list of computation  for this data node
@@ -270,6 +280,7 @@ class Data(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def computation_process(self) -> Union[Any, None]:
         """
         The computation_process for this data node
@@ -282,6 +293,7 @@ class Data(PrimaryBaseNode):
         return self._json_attrs.computation_process
 
     @computation_process.setter
+    @beartype
     def computation_process(self, new_computation_process: Union[Any, None]) -> None:
         """
         set the computational process
@@ -298,6 +310,7 @@ class Data(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def material(self) -> List[Any]:
         """
         List of materials for this node
@@ -310,6 +323,7 @@ class Data(PrimaryBaseNode):
         return self._json_attrs.material.copy()
 
     @material.setter
+    @beartype
     def material(self, new_material_list: List[Any]) -> None:
         """
         set the list of materials for this data node
@@ -326,6 +340,7 @@ class Data(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def process(self) -> List[Any]:
         """
         list of [Process nodes](./process.md) for this data node
@@ -344,6 +359,7 @@ class Data(PrimaryBaseNode):
         return self._json_attrs.process.copy()
 
     @process.setter
+    @beartype
     def process(self, new_process_list: List[Any]) -> None:
         """
         set the list of process for this data node
@@ -361,6 +377,7 @@ class Data(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def citation(self) -> List[Any]:
         """
         List of [citation](../supporting_nodes/citations.md) within the data node
@@ -386,6 +403,7 @@ class Data(PrimaryBaseNode):
         return self._json_attrs.citation.copy()
 
     @citation.setter
+    @beartype
     def citation(self, new_citation_list: List[Any]) -> None:
         """
         set the list of citation

--- a/src/cript/nodes/primary_nodes/experiment.py
+++ b/src/cript/nodes/primary_nodes/experiment.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field, replace
 from typing import Any, List, Optional
 
+from beartype import beartype
+
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
 
 
@@ -62,6 +64,7 @@ class Experiment(PrimaryBaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(
         self,
         name: str,
@@ -140,6 +143,7 @@ class Experiment(PrimaryBaseNode):
         self.validate()
 
     @property
+    @beartype
     def process(self) -> List[Any]:
         """
         List of process for experiment
@@ -159,6 +163,7 @@ class Experiment(PrimaryBaseNode):
         return self._json_attrs.process.copy()
 
     @process.setter
+    @beartype
     def process(self, new_process_list: List[Any]) -> None:
         """
         set the list of process for this experiment
@@ -176,6 +181,7 @@ class Experiment(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def computation(self) -> List[Any]:
         """
         List of the [computations](../computation) in this experiment
@@ -198,6 +204,7 @@ class Experiment(PrimaryBaseNode):
         return self._json_attrs.computation.copy()
 
     @computation.setter
+    @beartype
     def computation(self, new_computation_list: List[Any]) -> None:
         """
         set the list of computations for this experiment
@@ -215,6 +222,7 @@ class Experiment(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def computation_process(self) -> List[Any]:
         """
         List of [computation_process](../computational_process) for this experiment
@@ -241,6 +249,7 @@ class Experiment(PrimaryBaseNode):
         return self._json_attrs.computation_process.copy()
 
     @computation_process.setter
+    @beartype
     def computation_process(self, new_computation_process_list: List[Any]) -> None:
         """
         set the list of computation_process for this experiment
@@ -258,6 +267,7 @@ class Experiment(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def data(self) -> List[Any]:
         """
         List of [data nodes](../data) for this experiment
@@ -287,6 +297,7 @@ class Experiment(PrimaryBaseNode):
         return self._json_attrs.data.copy()
 
     @data.setter
+    @beartype
     def data(self, new_data_list: List[Any]) -> None:
         """
         set the list of data for this experiment
@@ -304,6 +315,7 @@ class Experiment(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def funding(self) -> List[str]:
         """
         List of strings of all the funders for this experiment
@@ -322,6 +334,7 @@ class Experiment(PrimaryBaseNode):
         return self._json_attrs.funding.copy()
 
     @funding.setter
+    @beartype
     def funding(self, new_funding_list: List[str]) -> None:
         """
         set the list of funders for this experiment
@@ -339,6 +352,7 @@ class Experiment(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def citation(self) -> List[Any]:
         """
         List of [citation](../citation) for this experiment
@@ -361,6 +375,7 @@ class Experiment(PrimaryBaseNode):
         return self._json_attrs.citation.copy()
 
     @citation.setter
+    @beartype
     def citation(self, new_citation_list: List[Any]) -> None:
         """
         set the list of citations for this experiment

--- a/src/cript/nodes/primary_nodes/inventory.py
+++ b/src/cript/nodes/primary_nodes/inventory.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field, replace
 from typing import List
 
+from beartype import beartype
+
 from cript.nodes.primary_nodes.material import Material
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
 
@@ -35,6 +37,7 @@ class Inventory(PrimaryBaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(self, name: str, material: List[Material], notes: str = "", **kwargs) -> None:
         """
         Instantiate an inventory node
@@ -76,8 +79,8 @@ class Inventory(PrimaryBaseNode):
 
         self._json_attrs = replace(self._json_attrs, material=material)
 
-    # ------------------ Properties ------------------
     @property
+    @beartype
     def material(self) -> List[Material]:
         """
         List of [material](../material) in this inventory
@@ -101,6 +104,7 @@ class Inventory(PrimaryBaseNode):
         return self._json_attrs.material.copy()
 
     @material.setter
+    @beartype
     def material(self, new_material_list: List[Material]):
         """
         set the list of material for this inventory node

--- a/src/cript/nodes/primary_nodes/material.py
+++ b/src/cript/nodes/primary_nodes/material.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field, replace
 from typing import Any, List, Optional
 
+from beartype import beartype
+
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
 
 
@@ -78,6 +80,7 @@ class Material(PrimaryBaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(
         self,
         name: str,
@@ -143,6 +146,7 @@ class Material(PrimaryBaseNode):
         )
 
     @property
+    @beartype
     def name(self) -> str:
         """
         material name
@@ -160,6 +164,7 @@ class Material(PrimaryBaseNode):
         return self._json_attrs.name
 
     @name.setter
+    @beartype
     def name(self, new_name: str) -> None:
         """
         set the name of the material
@@ -176,6 +181,7 @@ class Material(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def identifiers(self) -> List[dict[str, str]]:
         """
         get the identifiers for this material
@@ -192,6 +198,7 @@ class Material(PrimaryBaseNode):
         return self._json_attrs.identifiers.copy()
 
     @identifiers.setter
+    @beartype
     def identifiers(self, new_identifiers_list: List[dict[str, str]]) -> None:
         """
         set the list of identifiers for this material
@@ -211,6 +218,7 @@ class Material(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def component(self) -> List["Material"]:
         """
         list of component ([material nodes](./)) that make up this material
@@ -243,6 +251,7 @@ class Material(PrimaryBaseNode):
         return self._json_attrs.component
 
     @component.setter
+    @beartype
     def component(self, new_component_list: List["Material"]) -> None:
         """
         set the list of component (material nodes) that make up this material
@@ -259,6 +268,7 @@ class Material(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def parent_material(self) -> List["Material"]:
         """
         List of parent materials
@@ -271,6 +281,7 @@ class Material(PrimaryBaseNode):
         return self._json_attrs.parent_material
 
     @parent_material.setter
+    @beartype
     def parent_material(self, new_parent_material_list: List["Material"]) -> None:
         """
         set the [parent materials](./) for this material
@@ -288,6 +299,7 @@ class Material(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def computational_forcefield(self) -> List[Any]:
         """
         list of [computational_forcefield](../../subobjects/computational_forcefield) for this material node
@@ -300,6 +312,7 @@ class Material(PrimaryBaseNode):
         return self._json_attrs.computational_forcefield
 
     @computational_forcefield.setter
+    @beartype
     def computational_forcefield(self, new_computational_forcefield_list: List[Any]) -> None:
         """
         sets the list of computational forcefields for this material
@@ -316,6 +329,7 @@ class Material(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def keyword(self) -> List[str]:
         """
         List of keyword for this material
@@ -342,6 +356,7 @@ class Material(PrimaryBaseNode):
         return self._json_attrs.keyword
 
     @keyword.setter
+    @beartype
     def keyword(self, new_keyword_list: List[str]) -> None:
         """
         set the keyword for this material
@@ -407,6 +422,7 @@ class Material(PrimaryBaseNode):
                 pass
 
     @property
+    @beartype
     def property(self) -> List[Any]:
         """
         list of material [property](../../subobjects/property)
@@ -426,6 +442,7 @@ class Material(PrimaryBaseNode):
         return self._json_attrs.property.copy()
 
     @property.setter
+    @beartype
     def property(self, new_property_list: List[Any]) -> None:
         """
         set the list of properties for this material
@@ -442,6 +459,7 @@ class Material(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @classmethod
+    @beartype
     def _from_json(cls, json_dict: dict):
         """
         Create a new instance of a node from a JSON representation.

--- a/src/cript/nodes/primary_nodes/primary_base_node.py
+++ b/src/cript/nodes/primary_nodes/primary_base_node.py
@@ -2,6 +2,8 @@ from abc import ABC
 from dataclasses import dataclass, replace
 from typing import Any
 
+from beartype import beartype
+
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -27,12 +29,14 @@ class PrimaryBaseNode(UUIDBaseNode, ABC):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(self, name: str, notes: str, **kwargs):
         # initialize Base class with node
         super().__init__(**kwargs)
         # replace name and notes within PrimaryBase
         self._json_attrs = replace(self._json_attrs, name=name, notes=notes)
 
+    @beartype
     def __str__(self) -> str:
         """
         Return a string representation of a primary node dataclass attributes.
@@ -59,30 +63,37 @@ class PrimaryBaseNode(UUIDBaseNode, ABC):
         return super().__str__()
 
     @property
+    @beartype
     def locked(self):
         return self._json_attrs.locked
 
     @property
+    @beartype
     def model_version(self):
         return self._json_attrs.model_version
 
     @property
+    @beartype
     def updated_by(self):
         return self._json_attrs.updated_by
 
     @property
+    @beartype
     def created_by(self):
         return self._json_attrs.created_by
 
     @property
+    @beartype
     def public(self):
         return self._json_attrs.public
 
     @property
+    @beartype
     def name(self):
         return self._json_attrs.name
 
     @name.setter
+    @beartype
     def name(self, new_name: str) -> None:
         """
         set the PrimaryBaseNode name
@@ -99,10 +110,12 @@ class PrimaryBaseNode(UUIDBaseNode, ABC):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def notes(self):
         return self._json_attrs.notes
 
     @notes.setter
+    @beartype
     def notes(self, new_notes: str) -> None:
         """
         allow every node that inherits base attributes to set its notes

--- a/src/cript/nodes/primary_nodes/process.py
+++ b/src/cript/nodes/primary_nodes/process.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field, replace
 from typing import Any, List, Optional
 
+from beartype import beartype
+
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
 
 
@@ -56,6 +58,7 @@ class Process(PrimaryBaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(
         self,
         name: str,
@@ -156,9 +159,8 @@ class Process(PrimaryBaseNode):
         )
         self._update_json_attrs_if_valid(new_attrs)
 
-    # --------------- Properties -------------
-
     @property
+    @beartype
     def type(self) -> str:
         """
         Process type must come from the [CRIPT controlled vocabulary](https://criptapp.org/keys/process-type/)
@@ -177,6 +179,7 @@ class Process(PrimaryBaseNode):
         return self._json_attrs.type
 
     @type.setter
+    @beartype
     def type(self, new_process_type: str) -> None:
         """
         set process type from CRIPT controlled vocabulary
@@ -194,6 +197,7 @@ class Process(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def ingredient(self) -> List[Any]:
         """
         List of [ingredient](../../subobjects/ingredients) for this process
@@ -217,6 +221,7 @@ class Process(PrimaryBaseNode):
         return self._json_attrs.ingredient.copy()
 
     @ingredient.setter
+    @beartype
     def ingredient(self, new_ingredient_list: List[Any]) -> None:
         """
         set the list of the ingredients for this process
@@ -236,6 +241,7 @@ class Process(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def description(self) -> str:
         """
         description of this process
@@ -254,6 +260,7 @@ class Process(PrimaryBaseNode):
         return self._json_attrs.description
 
     @description.setter
+    @beartype
     def description(self, new_description: str) -> None:
         """
         set the description of this process
@@ -271,6 +278,7 @@ class Process(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def equipment(self) -> List[Any]:
         """
         List of [equipment](../../subobjects/equipment) used for this process
@@ -283,6 +291,7 @@ class Process(PrimaryBaseNode):
         return self._json_attrs.equipment.copy()
 
     @equipment.setter
+    @beartype
     def equipment(self, new_equipment_list: List[Any]) -> None:
         """
         set the list of equipment used for this process
@@ -300,6 +309,7 @@ class Process(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def product(self) -> List[Any]:
         """
         List of product (material nodes) for this process
@@ -312,6 +322,7 @@ class Process(PrimaryBaseNode):
         return self._json_attrs.product.copy()
 
     @product.setter
+    @beartype
     def product(self, new_product_list: List[Any]) -> None:
         """
         set the product list for this process
@@ -329,6 +340,7 @@ class Process(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def waste(self) -> List[Any]:
         """
         List of waste that resulted from this process
@@ -347,6 +359,7 @@ class Process(PrimaryBaseNode):
         return self._json_attrs.waste.copy()
 
     @waste.setter
+    @beartype
     def waste(self, new_waste_list: List[Any]) -> None:
         """
         set the list of waste (Material node) for that resulted from this process
@@ -364,6 +377,7 @@ class Process(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def prerequisite_process(self) -> List["Process"]:
         """
         list of prerequisite process nodes
@@ -388,6 +402,7 @@ class Process(PrimaryBaseNode):
         return self._json_attrs.prerequisite_process.copy()
 
     @prerequisite_process.setter
+    @beartype
     def prerequisite_process(self, new_prerequisite_process_list: List["Process"]) -> None:
         """
         set the prerequisite_process for the process node
@@ -404,6 +419,7 @@ class Process(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def condition(self) -> List[Any]:
         """
         List of condition present for this process
@@ -425,6 +441,7 @@ class Process(PrimaryBaseNode):
         return self._json_attrs.condition.copy()
 
     @condition.setter
+    @beartype
     def condition(self, new_condition_list: List[Any]) -> None:
         """
         set the list of condition for this process
@@ -441,6 +458,7 @@ class Process(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def keyword(self) -> List[str]:
         """
         List of keyword for this process
@@ -455,6 +473,7 @@ class Process(PrimaryBaseNode):
         return self._json_attrs.keyword.copy()  # type: ignore
 
     @keyword.setter
+    @beartype
     def keyword(self, new_keyword_list: List[str]) -> None:
         """
         set the list of keyword for this process from CRIPT controlled vocabulary
@@ -473,6 +492,7 @@ class Process(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def citation(self) -> List[Any]:
         """
         List of citation for this process
@@ -497,6 +517,7 @@ class Process(PrimaryBaseNode):
         return self._json_attrs.citation.copy()
 
     @citation.setter
+    @beartype
     def citation(self, new_citation_list: List[Any]) -> None:
         """
         set the list of citation for this process
@@ -514,6 +535,7 @@ class Process(PrimaryBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def property(self) -> List[Any]:
         """
         List of [Property nodes](../../subobjects/property) for this process
@@ -535,6 +557,7 @@ class Process(PrimaryBaseNode):
         return self._json_attrs.property.copy()
 
     @property.setter
+    @beartype
     def property(self, new_property_list: List[Any]) -> None:
         """
         set the list of Property nodes for this process

--- a/src/cript/nodes/primary_nodes/project.py
+++ b/src/cript/nodes/primary_nodes/project.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field, replace
 from typing import List, Optional
 
+from beartype import beartype
+
 from cript.nodes.primary_nodes.collection import Collection
 from cript.nodes.primary_nodes.material import Material
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
@@ -37,6 +39,7 @@ class Project(PrimaryBaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(self, name: str, collection: Optional[List[Collection]] = None, material: Optional[List[Material]] = None, notes: str = "", **kwargs):
         """
         Create a Project node with Project name and Group
@@ -112,18 +115,18 @@ class Project(PrimaryBaseNode):
                 if node not in experiment_nodes:
                     raise get_orphaned_experiment_exception(node)
 
-    # ------------------ Properties ------------------
-
     @property
+    @beartype
     def member(self) -> List[User]:
         return self._json_attrs.member.copy()
 
     @property
+    @beartype
     def admin(self) -> List[User]:
         return self._json_attrs.admin
 
-    # Collection
     @property
+    @beartype
     def collection(self) -> List[Collection]:
         """
         Collection is a Project node's property that can be set during creation in the constructor
@@ -146,8 +149,8 @@ class Project(PrimaryBaseNode):
         """
         return self._json_attrs.collection
 
-    # Collection
     @collection.setter
+    @beartype
     def collection(self, new_collection: List[Collection]) -> None:
         """
         set list of collections for the project node
@@ -163,8 +166,8 @@ class Project(PrimaryBaseNode):
         new_attrs = replace(self._json_attrs, collection=new_collection)
         self._update_json_attrs_if_valid(new_attrs)
 
-    # Material
     @property
+    @beartype
     def material(self) -> List[Material]:
         """
         List of Materials that belong to this Project.
@@ -186,6 +189,7 @@ class Project(PrimaryBaseNode):
         return self._json_attrs.material
 
     @material.setter
+    @beartype
     def material(self, new_materials: List[Material]) -> None:
         """
         set the list of materials for this project

--- a/src/cript/nodes/primary_nodes/reference.py
+++ b/src/cript/nodes/primary_nodes/reference.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field, replace
-from typing import List, Union, Optional
+from typing import List, Optional, Union
 
 from beartype import beartype
 

--- a/src/cript/nodes/primary_nodes/reference.py
+++ b/src/cript/nodes/primary_nodes/reference.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, field, replace
-from typing import List, Optional, Union
+from typing import List, Union, Optional
+
+from beartype import beartype
 
 from cript.nodes.uuid_base import UUIDBaseNode
 
@@ -69,6 +71,7 @@ class Reference(UUIDBaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(
         self,
         type: str,
@@ -149,8 +152,8 @@ class Reference(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
         self.validate()
 
-    # ------------------ Properties ------------------
     @property
+    @beartype
     def type(self) -> str:
         """
         type of reference. The reference type must come from the CRIPT controlled vocabulary
@@ -169,6 +172,7 @@ class Reference(UUIDBaseNode):
         return self._json_attrs.type
 
     @type.setter
+    @beartype
     def type(self, new_reference_type: str) -> None:
         """
         set the reference type attribute
@@ -188,6 +192,7 @@ class Reference(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def title(self) -> str:
         """
         title of publication
@@ -206,6 +211,7 @@ class Reference(UUIDBaseNode):
         return self._json_attrs.title
 
     @title.setter
+    @beartype
     def title(self, new_title: str) -> None:
         """
         set the title for the reference node
@@ -222,6 +228,7 @@ class Reference(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def author(self) -> List[str]:
         """
         List of authors for this reference node
@@ -240,6 +247,7 @@ class Reference(UUIDBaseNode):
         return self._json_attrs.author.copy()
 
     @author.setter
+    @beartype
     def author(self, new_author: List[str]) -> None:
         """
         set the list of authors for the reference node
@@ -256,6 +264,7 @@ class Reference(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def journal(self) -> str:
         """
         journal of publication
@@ -274,6 +283,7 @@ class Reference(UUIDBaseNode):
         return self._json_attrs.journal
 
     @journal.setter
+    @beartype
     def journal(self, new_journal: str) -> None:
         """
         set the journal attribute for this reference node
@@ -290,6 +300,7 @@ class Reference(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def publisher(self) -> str:
         """
         publisher for this reference node
@@ -308,6 +319,7 @@ class Reference(UUIDBaseNode):
         return self._json_attrs.publisher
 
     @publisher.setter
+    @beartype
     def publisher(self, new_publisher: str) -> None:
         """
         set the publisher for this reference node
@@ -324,6 +336,7 @@ class Reference(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def year(self) -> Union[int, None]:
         """
         year for the scholarly work
@@ -341,6 +354,7 @@ class Reference(UUIDBaseNode):
         return self._json_attrs.year
 
     @year.setter
+    @beartype
     def year(self, new_year: Union[int, None]) -> None:
         """
         set the year for the scholarly work within the reference node
@@ -358,6 +372,7 @@ class Reference(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def volume(self) -> Union[int, None]:
         """
         Volume of the scholarly work from the reference node
@@ -376,6 +391,7 @@ class Reference(UUIDBaseNode):
         return self._json_attrs.volume
 
     @volume.setter
+    @beartype
     def volume(self, new_volume: Union[int, None]) -> None:
         """
         set the volume of the scholarly work for this reference node
@@ -392,6 +408,7 @@ class Reference(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def issue(self) -> Union[int, None]:
         """
         issue of the scholarly work for the reference node
@@ -409,6 +426,7 @@ class Reference(UUIDBaseNode):
         return self._json_attrs.issue
 
     @issue.setter
+    @beartype
     def issue(self, new_issue: Union[int, None]) -> None:
         """
         set the issue of the scholarly work
@@ -425,6 +443,7 @@ class Reference(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def pages(self) -> List[int]:
         """
         pages of the scholarly work used in the reference node
@@ -442,6 +461,7 @@ class Reference(UUIDBaseNode):
         return self._json_attrs.pages.copy()
 
     @pages.setter
+    @beartype
     def pages(self, new_pages_list: List[int]) -> None:
         """
         set the list of pages of the scholarly work for this reference node
@@ -458,6 +478,7 @@ class Reference(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def doi(self) -> str:
         """
         get the digital object identifier (DOI) for this reference node
@@ -476,6 +497,7 @@ class Reference(UUIDBaseNode):
         return self._json_attrs.doi
 
     @doi.setter
+    @beartype
     def doi(self, new_doi: str) -> None:
         """
         set the digital object identifier (DOI) for the scholarly work for this reference node
@@ -498,6 +520,7 @@ class Reference(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def issn(self) -> str:
         """
         The international standard serial number (ISSN) for this reference node
@@ -515,6 +538,7 @@ class Reference(UUIDBaseNode):
         return self._json_attrs.issn
 
     @issn.setter
+    @beartype
     def issn(self, new_issn: str) -> None:
         """
         set the international standard serial number (ISSN) for the scholarly work for this reference node
@@ -531,6 +555,7 @@ class Reference(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def arxiv_id(self) -> str:
         """
         The arXiv identifier for the scholarly work for this reference node
@@ -549,6 +574,7 @@ class Reference(UUIDBaseNode):
         return self._json_attrs.arxiv_id
 
     @arxiv_id.setter
+    @beartype
     def arxiv_id(self, new_arxiv_id: str) -> None:
         """
         set the arXiv identifier for the scholarly work for this reference node
@@ -565,6 +591,7 @@ class Reference(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def pmid(self) -> Union[int, None]:
         """
         The PubMed ID (PMID) for this reference node
@@ -583,6 +610,7 @@ class Reference(UUIDBaseNode):
         return self._json_attrs.pmid
 
     @pmid.setter
+    @beartype
     def pmid(self, new_pmid: Union[int, None]) -> None:
         """
 
@@ -600,6 +628,7 @@ class Reference(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def website(self) -> str:
         """
         The website URL for the scholarly work
@@ -618,6 +647,7 @@ class Reference(UUIDBaseNode):
         return self._json_attrs.website
 
     @website.setter
+    @beartype
     def website(self, new_website: str) -> None:
         """
         set the website URL for the scholarly work

--- a/src/cript/nodes/subobjects/citation.py
+++ b/src/cript/nodes/subobjects/citation.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, replace
 from typing import Optional, Union
 
+from beartype import beartype
+
 from cript.nodes.core import BaseNode
 from cript.nodes.primary_nodes.reference import Reference
 
@@ -64,6 +66,7 @@ class Citation(BaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(self, type: str, reference: Reference, **kwargs):
         """
         create a Citation subobject
@@ -109,6 +112,7 @@ class Citation(BaseNode):
         self.validate()
 
     @property
+    @beartype
     def type(self) -> str:
         """
         Citation type subobject
@@ -129,6 +133,7 @@ class Citation(BaseNode):
         return self._json_attrs.type
 
     @type.setter
+    @beartype
     def type(self, new_type: str) -> None:
         """
         set the citation subobject type
@@ -148,6 +153,7 @@ class Citation(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def reference(self) -> Union[Reference, None]:
         """
         citation reference node
@@ -180,6 +186,7 @@ class Citation(BaseNode):
         return self._json_attrs.reference
 
     @reference.setter
+    @beartype
     def reference(self, new_reference: Reference) -> None:
         """
         replace the current Reference node for the citation subobject

--- a/src/cript/nodes/subobjects/computational_forcefield.py
+++ b/src/cript/nodes/subobjects/computational_forcefield.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field, replace
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from beartype import beartype
 

--- a/src/cript/nodes/subobjects/computational_forcefield.py
+++ b/src/cript/nodes/subobjects/computational_forcefield.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field, replace
 from typing import List, Optional, Union
 
+from beartype import beartype
+
 from cript.nodes.core import BaseNode
 from cript.nodes.primary_nodes.data import Data
 from cript.nodes.subobjects.citation import Citation
@@ -91,6 +93,7 @@ class ComputationalForcefield(BaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(self, key: str, building_block: str, coarse_grained_mapping: str = "", implicit_solvent: str = "", source: str = "", description: str = "", data: Optional[List[Data]] = None, citation: Optional[List[Citation]] = None, **kwargs):
         """
         instantiate a computational_forcefield subobject
@@ -150,6 +153,7 @@ class ComputationalForcefield(BaseNode):
         self.validate()
 
     @property
+    @beartype
     def key(self) -> str:
         """
         type of forcefield
@@ -170,6 +174,7 @@ class ComputationalForcefield(BaseNode):
         return self._json_attrs.key
 
     @key.setter
+    @beartype
     def key(self, new_key: str) -> None:
         """
         set key for this computational_forcefield
@@ -187,6 +192,7 @@ class ComputationalForcefield(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def building_block(self) -> str:
         """
         type of building block
@@ -207,6 +213,7 @@ class ComputationalForcefield(BaseNode):
         return self._json_attrs.building_block
 
     @building_block.setter
+    @beartype
     def building_block(self, new_building_block: str) -> None:
         """
         type of building block
@@ -224,6 +231,7 @@ class ComputationalForcefield(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def coarse_grained_mapping(self) -> str:
         """
         atom to beads mapping
@@ -242,6 +250,7 @@ class ComputationalForcefield(BaseNode):
         return self._json_attrs.coarse_grained_mapping
 
     @coarse_grained_mapping.setter
+    @beartype
     def coarse_grained_mapping(self, new_coarse_grained_mapping: str) -> None:
         """
         atom to beads mapping
@@ -259,6 +268,7 @@ class ComputationalForcefield(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def implicit_solvent(self) -> str:
         """
         Name of implicit solvent
@@ -277,6 +287,7 @@ class ComputationalForcefield(BaseNode):
         return self._json_attrs.implicit_solvent
 
     @implicit_solvent.setter
+    @beartype
     def implicit_solvent(self, new_implicit_solvent: str) -> None:
         """
         set the implicit_solvent
@@ -290,6 +301,7 @@ class ComputationalForcefield(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def source(self) -> str:
         """
         source of forcefield
@@ -308,6 +320,7 @@ class ComputationalForcefield(BaseNode):
         return self._json_attrs.source
 
     @source.setter
+    @beartype
     def source(self, new_source: str) -> None:
         """
         set the computational_forcefield
@@ -321,6 +334,7 @@ class ComputationalForcefield(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def description(self) -> str:
         """
         description of the forcefield and any modifications that have been added
@@ -339,6 +353,7 @@ class ComputationalForcefield(BaseNode):
         return self._json_attrs.description
 
     @description.setter
+    @beartype
     def description(self, new_description: str) -> None:
         """
         set this computational_forcefields description
@@ -356,6 +371,7 @@ class ComputationalForcefield(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def data(self) -> List[Data]:
         """
         details of mapping schema and forcefield parameters
@@ -389,6 +405,7 @@ class ComputationalForcefield(BaseNode):
         return self._json_attrs.data.copy()
 
     @data.setter
+    @beartype
     def data(self, new_data: List[Data]) -> None:
         """
         set the data attribute of this computational_forcefield node
@@ -406,6 +423,7 @@ class ComputationalForcefield(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def citation(self) -> List[Citation]:
         """
         reference to a book, paper, or scholarly work
@@ -444,6 +462,7 @@ class ComputationalForcefield(BaseNode):
         return self._json_attrs.citation.copy()
 
     @citation.setter
+    @beartype
     def citation(self, new_citation: List[Citation]) -> None:
         """
         set the citation subobject of the computational_forcefield subobject

--- a/src/cript/nodes/subobjects/condition.py
+++ b/src/cript/nodes/subobjects/condition.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, replace
 from numbers import Number
 from typing import Union
 
+from beartype import beartype
+
 from cript.nodes.core import BaseNode
 from cript.nodes.primary_nodes.data import Data
 
@@ -88,6 +90,7 @@ class Condition(BaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(
         self,
         key: str,
@@ -163,6 +166,7 @@ class Condition(BaseNode):
         self.validate()
 
     @property
+    @beartype
     def key(self) -> str:
         """
         type of condition
@@ -183,6 +187,7 @@ class Condition(BaseNode):
         return self._json_attrs.key
 
     @key.setter
+    @beartype
     def key(self, new_key: str) -> None:
         """
         set this Condition sub-object key
@@ -202,6 +207,7 @@ class Condition(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def type(self) -> str:
         """
         description for the value stored for this Condition node
@@ -220,6 +226,7 @@ class Condition(BaseNode):
         return self._json_attrs.type
 
     @type.setter
+    @beartype
     def type(self, new_type: str) -> None:
         """
         set the type attribute for this Condition node
@@ -237,6 +244,7 @@ class Condition(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def descriptor(self) -> str:
         """
         freeform description for Condition
@@ -255,6 +263,7 @@ class Condition(BaseNode):
         return self._json_attrs.descriptor
 
     @descriptor.setter
+    @beartype
     def descriptor(self, new_descriptor: str) -> None:
         """
         set the description of this Condition sub-object
@@ -272,6 +281,7 @@ class Condition(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def value(self) -> Union[Number, None]:
         """
         value or quantity
@@ -314,6 +324,7 @@ class Condition(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def unit(self) -> str:
         """
         set units for this Condition subobject
@@ -332,6 +343,7 @@ class Condition(BaseNode):
         return self._json_attrs.unit
 
     @property
+    @beartype
     def uncertainty(self) -> Union[Number, None]:
         """
         set uncertainty value for this Condition subobject
@@ -349,6 +361,7 @@ class Condition(BaseNode):
         """
         return self._json_attrs.uncertainty
 
+    @beartype
     def set_uncertainty(self, new_uncertainty: Number, new_uncertainty_type: str) -> None:
         """
         set uncertainty and uncertainty type
@@ -374,6 +387,7 @@ class Condition(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def uncertainty_type(self) -> str:
         """
         Uncertainty type for the uncertainty value
@@ -392,6 +406,7 @@ class Condition(BaseNode):
         return self._json_attrs.uncertainty_type
 
     @property
+    @beartype
     def set_id(self) -> Union[int, None]:
         """
         ID of set (used to link measurements in as series)
@@ -410,6 +425,7 @@ class Condition(BaseNode):
         return self._json_attrs.set_id
 
     @set_id.setter
+    @beartype
     def set_id(self, new_set_id: Union[int, None]) -> None:
         """
          set this Condition subobjects set_id
@@ -427,6 +443,7 @@ class Condition(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def measurement_id(self) -> Union[int, None]:
         """
         ID for a single measurement (used to link multiple condition at a single instance)
@@ -445,6 +462,7 @@ class Condition(BaseNode):
         return self._json_attrs.measurement_id
 
     @measurement_id.setter
+    @beartype
     def measurement_id(self, new_measurement_id: Union[int, None]) -> None:
         """
         set the set_id for this Condition subobject
@@ -462,6 +480,7 @@ class Condition(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def data(self) -> Union[Data, None]:
         """
         detailed data associated with the condition
@@ -495,6 +514,7 @@ class Condition(BaseNode):
         return self._json_attrs.data
 
     @data.setter
+    @beartype
     def data(self, new_data: Data) -> None:
         """
         set the data node for this Condition Subobject

--- a/src/cript/nodes/subobjects/equipment.py
+++ b/src/cript/nodes/subobjects/equipment.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field, replace
 from typing import List, Union
 
+from beartype import beartype
+
 from cript.nodes.core import BaseNode
 from cript.nodes.subobjects.citation import Citation
 from cript.nodes.subobjects.condition import Condition
@@ -51,6 +53,7 @@ class Equipment(BaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(self, key: str, description: str = "", condition: Union[List[Condition], None] = None, file: Union[List[File], None] = None, citation: Union[List[Citation], None] = None, **kwargs) -> None:
         """
         create equipment sub-object
@@ -90,6 +93,7 @@ class Equipment(BaseNode):
         self.validate()
 
     @property
+    @beartype
     def key(self) -> str:
         """
         scientific instrument
@@ -110,6 +114,7 @@ class Equipment(BaseNode):
         return self._json_attrs.key
 
     @key.setter
+    @beartype
     def key(self, new_key: str) -> None:
         """
         set the equipment key
@@ -129,6 +134,7 @@ class Equipment(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def description(self) -> str:
         """
         description of the equipment
@@ -147,6 +153,7 @@ class Equipment(BaseNode):
         return self._json_attrs.description
 
     @description.setter
+    @beartype
     def description(self, new_description: str) -> None:
         """
         set this equipments description
@@ -164,6 +171,7 @@ class Equipment(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def condition(self) -> List[Condition]:
         """
         conditions under which the property was measured
@@ -191,6 +199,7 @@ class Equipment(BaseNode):
         return self._json_attrs.condition.copy()
 
     @condition.setter
+    @beartype
     def condition(self, new_condition: List[Condition]) -> None:
         """
         set a list of Conditions for the equipment sub-object
@@ -208,6 +217,7 @@ class Equipment(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def file(self) -> List[File]:
         """
         list of file nodes to link to calibration or equipment specification documents
@@ -235,6 +245,7 @@ class Equipment(BaseNode):
         return self._json_attrs.file.copy()
 
     @file.setter
+    @beartype
     def file(self, new_file: List[File]) -> None:
         """
         set the file node for the equipment subobject
@@ -252,6 +263,7 @@ class Equipment(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def citation(self) -> List[Citation]:
         """
         reference to a book, paper, or scholarly work
@@ -291,6 +303,7 @@ class Equipment(BaseNode):
         return self._json_attrs.citation.copy()
 
     @citation.setter
+    @beartype
     def citation(self, new_citation: List[Citation]) -> None:
         """
         set the citation subobject for this equipment subobject

--- a/src/cript/nodes/subobjects/ingredient.py
+++ b/src/cript/nodes/subobjects/ingredient.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field, replace
 from typing import List, Union
 
+from beartype import beartype
+
 from cript.nodes.core import BaseNode
 from cript.nodes.primary_nodes.material import Material
 from cript.nodes.subobjects.quantity import Quantity
@@ -45,6 +47,7 @@ class Ingredient(BaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(self, material: Material, quantity: List[Quantity], keyword: str = "", **kwargs):
         """
         create an ingredient sub-object
@@ -84,6 +87,7 @@ class Ingredient(BaseNode):
         self.validate()
 
     @property
+    @beartype
     def material(self) -> Union[Material, None]:
         """
         current material in this ingredient sub-object
@@ -96,6 +100,7 @@ class Ingredient(BaseNode):
         return self._json_attrs.material
 
     @property
+    @beartype
     def quantity(self) -> List[Quantity]:
         """
         quantity for the ingredient sub-object
@@ -107,6 +112,7 @@ class Ingredient(BaseNode):
         """
         return self._json_attrs.quantity.copy()
 
+    @beartype
     def set_material(self, new_material: Material, new_quantity: List[Quantity]) -> None:
         """
         update ingredient sub-object with new material and new list of quantities
@@ -141,6 +147,7 @@ class Ingredient(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def keyword(self) -> str:
         """
         ingredient keyword must come from the [CRIPT controlled vocabulary]()
@@ -160,6 +167,7 @@ class Ingredient(BaseNode):
         return self._json_attrs.keyword
 
     @keyword.setter
+    @beartype
     def keyword(self, new_keyword: str) -> None:
         """
         set new ingredient keyword to replace the current

--- a/src/cript/nodes/subobjects/parameter.py
+++ b/src/cript/nodes/subobjects/parameter.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, replace
 from typing import Union
 
+from beartype import beartype
+
 from cript.nodes.core import BaseNode
 
 
@@ -57,6 +59,7 @@ class Parameter(BaseNode):
 
     # Note that the key word args are ignored.
     # They are just here, such that we can feed more kwargs in that we get from the back end.
+    @beartype
     def __init__(self, key: str, value: Union[int, float], unit: Union[str, None] = None, **kwargs):
         """
         create new Parameter sub-object
@@ -88,6 +91,7 @@ class Parameter(BaseNode):
         self.validate()
 
     @property
+    @beartype
     def key(self) -> str:
         """
         Parameter key must come from the [CRIPT Controlled Vocabulary]()
@@ -106,6 +110,7 @@ class Parameter(BaseNode):
         return self._json_attrs.key
 
     @key.setter
+    @beartype
     def key(self, new_key: str) -> None:
         """
         set new key for the Parameter sub-object
@@ -125,6 +130,7 @@ class Parameter(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def value(self) -> Union[int, float, str]:
         """
         Parameter value
@@ -143,6 +149,7 @@ class Parameter(BaseNode):
         return self._json_attrs.value
 
     @value.setter
+    @beartype
     def value(self, new_value: Union[int, float, str]) -> None:
         """
         set the Parameter value
@@ -160,6 +167,7 @@ class Parameter(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def unit(self) -> Union[str, None]:
         """
         Parameter unit
@@ -178,6 +186,7 @@ class Parameter(BaseNode):
         return self._json_attrs.unit
 
     @unit.setter
+    @beartype
     def unit(self, new_unit: str) -> None:
         """
         set the unit attribute for the Parameter sub-object

--- a/src/cript/nodes/subobjects/property.py
+++ b/src/cript/nodes/subobjects/property.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, field, replace
 from numbers import Number
 from typing import List, Union
 
+from beartype import beartype
+
 from cript.nodes.core import BaseNode
 from cript.nodes.primary_nodes.computation import Computation
 from cript.nodes.primary_nodes.data import Data
@@ -77,6 +79,7 @@ class Property(BaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(
         self,
         key: str,
@@ -179,6 +182,7 @@ class Property(BaseNode):
         self.validate()
 
     @property
+    @beartype
     def key(self) -> str:
         """
         Property key must come from [CRIPT Controlled Vocabulary]()
@@ -197,6 +201,7 @@ class Property(BaseNode):
         return self._json_attrs.key
 
     @key.setter
+    @beartype
     def key(self, new_key: str) -> None:
         """
         set the key for this Property sub-object
@@ -214,6 +219,7 @@ class Property(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def type(self) -> str:
         """
         type of value for this Property sub-object
@@ -231,6 +237,7 @@ class Property(BaseNode):
         return self._json_attrs.type
 
     @type.setter
+    @beartype
     def type(self, new_type: str) -> None:
         """
         set the Property type for this subobject
@@ -248,6 +255,7 @@ class Property(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def value(self) -> Union[Number, None]:
         """
         get the Property value
@@ -259,6 +267,7 @@ class Property(BaseNode):
         """
         return self._json_attrs.value
 
+    @beartype
     def set_value(self, new_value: Number, new_unit: str) -> None:
         """
         set the value attribute of the Property subobject
@@ -284,6 +293,7 @@ class Property(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def unit(self) -> str:
         """
         get the Property unit for the value
@@ -296,6 +306,7 @@ class Property(BaseNode):
         return self._json_attrs.unit
 
     @property
+    @beartype
     def uncertainty(self) -> Union[Number, None]:
         """
         get the uncertainty value of the Property node
@@ -307,6 +318,7 @@ class Property(BaseNode):
         """
         return self._json_attrs.uncertainty
 
+    @beartype
     def set_uncertainty(self, new_uncertainty: Number, new_uncertainty_type: str) -> None:
         """
         set the uncertainty value and type
@@ -334,6 +346,7 @@ class Property(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def uncertainty_type(self) -> str:
         """
         get the uncertainty_type for this Property subobject
@@ -348,6 +361,7 @@ class Property(BaseNode):
         return self._json_attrs.uncertainty_type
 
     @property
+    @beartype
     def component(self) -> List[Material]:
         """
         list of Materials that the Property relates to
@@ -371,6 +385,7 @@ class Property(BaseNode):
         return self._json_attrs.component.copy()
 
     @component.setter
+    @beartype
     def component(self, new_component: List[Material]) -> None:
         """
         set the list of Materials as components for the Property subobject
@@ -388,6 +403,7 @@ class Property(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def structure(self) -> str:
         """
         specific chemical structure associate with the property with atom mappings
@@ -406,6 +422,7 @@ class Property(BaseNode):
         return self._json_attrs.structure
 
     @structure.setter
+    @beartype
     def structure(self, new_structure: str) -> None:
         """
         set the this Property's structure
@@ -423,6 +440,7 @@ class Property(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def method(self) -> str:
         """
         approach or source of property data True sample_preparation Process sample preparation
@@ -443,6 +461,7 @@ class Property(BaseNode):
         return self._json_attrs.method
 
     @method.setter
+    @beartype
     def method(self, new_method: str) -> None:
         """
         set the Property method
@@ -462,6 +481,7 @@ class Property(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def sample_preparation(self) -> Union[Process, None]:
         """
         sample_preparation
@@ -482,6 +502,7 @@ class Property(BaseNode):
         return self._json_attrs.sample_preparation
 
     @sample_preparation.setter
+    @beartype
     def sample_preparation(self, new_sample_preparation: Union[Process, None]) -> None:
         """
         set the sample_preparation for the Property subobject
@@ -499,6 +520,7 @@ class Property(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def condition(self) -> List[Condition]:
         """
         list of Conditions under which the property was measured
@@ -519,6 +541,7 @@ class Property(BaseNode):
         return self._json_attrs.condition.copy()
 
     @condition.setter
+    @beartype
     def condition(self, new_condition: List[Condition]) -> None:
         """
         set the list of Conditions for this property subobject
@@ -536,6 +559,7 @@ class Property(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def data(self) -> List[Data]:
         """
         List of Data nodes for this Property subobjects
@@ -566,6 +590,7 @@ class Property(BaseNode):
         return self._json_attrs.data.copy()
 
     @data.setter
+    @beartype
     def data(self, new_data: List[Data]) -> None:
         """
         set the Data node for the Property subobject
@@ -583,6 +608,7 @@ class Property(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def computation(self) -> List[Computation]:
         """
         list of Computation nodes that produced this property
@@ -603,6 +629,7 @@ class Property(BaseNode):
         return self._json_attrs.computation.copy()
 
     @computation.setter
+    @beartype
     def computation(self, new_computation: List[Computation]) -> None:
         """
         set the list of Computation nodes that produced this property
@@ -620,6 +647,7 @@ class Property(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def citation(self) -> List[Citation]:
         """
         list of Citation subobjects for this Property subobject
@@ -659,6 +687,7 @@ class Property(BaseNode):
         return self._json_attrs.citation.copy()
 
     @citation.setter
+    @beartype
     def citation(self, new_citation: List[Citation]) -> None:
         """
         set the list of Citation subobjects for the Property subobject
@@ -676,6 +705,7 @@ class Property(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def notes(self) -> str:
         """
         notes for this Property subobject
@@ -694,6 +724,7 @@ class Property(BaseNode):
         return self._json_attrs.notes
 
     @notes.setter
+    @beartype
     def notes(self, new_notes: str) -> None:
         """
         set the notes for this Property subobject

--- a/src/cript/nodes/subobjects/quantity.py
+++ b/src/cript/nodes/subobjects/quantity.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, replace
 from numbers import Number
-from typing import Union, Optional
+from typing import Optional, Union
 
 from beartype import beartype
 

--- a/src/cript/nodes/subobjects/quantity.py
+++ b/src/cript/nodes/subobjects/quantity.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, replace
 from numbers import Number
 from typing import Union, Optional
 
+from beartype import beartype
+
 from cript.nodes.core import BaseNode
 
 
@@ -49,6 +51,7 @@ class Quantity(BaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(self, key: str, value: Number, unit: str, uncertainty: Optional[Number] = None, uncertainty_type: str = "", **kwargs):
         """
         create Quantity sub-object
@@ -85,6 +88,7 @@ class Quantity(BaseNode):
         self._json_attrs = replace(self._json_attrs, key=key, value=value, unit=unit, uncertainty=uncertainty, uncertainty_type=uncertainty_type)
         self.validate()
 
+    @beartype
     def set_key_unit(self, new_key: str, new_unit: str) -> None:
         """
         set the Quantity key and unit attributes
@@ -112,6 +116,7 @@ class Quantity(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def key(self) -> str:
         """
         get the Quantity sub-object key attribute
@@ -124,6 +129,7 @@ class Quantity(BaseNode):
         return self._json_attrs.key
 
     @property
+    @beartype
     def value(self) -> Union[int, float, str]:
         """
         amount of Material
@@ -142,6 +148,7 @@ class Quantity(BaseNode):
         return self._json_attrs.value
 
     @value.setter
+    @beartype
     def value(self, new_value: Union[int, float, str]) -> None:
         """
         set the amount of Material
@@ -159,6 +166,7 @@ class Quantity(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def unit(self) -> str:
         """
         get the Quantity unit attribute
@@ -171,6 +179,7 @@ class Quantity(BaseNode):
         return self._json_attrs.unit
 
     @property
+    @beartype
     def uncertainty(self) -> Number:
         """
         get the uncertainty value
@@ -183,6 +192,7 @@ class Quantity(BaseNode):
         return self._json_attrs.uncertainty
 
     @property
+    @beartype
     def uncertainty_type(self) -> str:
         """
         get the uncertainty type attribute for the Quantity sub-object
@@ -196,6 +206,7 @@ class Quantity(BaseNode):
         """
         return self._json_attrs.uncertainty_type
 
+    @beartype
     def set_uncertainty(self, uncertainty: Number, type: str) -> None:
         """
         set the `uncertainty value` and `uncertainty_type`

--- a/src/cript/nodes/subobjects/software.py
+++ b/src/cript/nodes/subobjects/software.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, replace
 
+from beartype import beartype
+
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -45,6 +47,7 @@ class Software(UUIDBaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(self, name: str, version: str, source: str = "", **kwargs):
         """
         create Software node
@@ -77,6 +80,7 @@ class Software(UUIDBaseNode):
         self.validate()
 
     @property
+    @beartype
     def name(self) -> str:
         """
         Software name
@@ -95,6 +99,7 @@ class Software(UUIDBaseNode):
         return self._json_attrs.name
 
     @name.setter
+    @beartype
     def name(self, new_name: str) -> None:
         """
         set the name of the Software node
@@ -112,6 +117,7 @@ class Software(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attr)
 
     @property
+    @beartype
     def version(self) -> str:
         """
         Software version
@@ -126,6 +132,7 @@ class Software(UUIDBaseNode):
         return self._json_attrs.version
 
     @version.setter
+    @beartype
     def version(self, new_version: str) -> None:
         """
         set the Software version
@@ -143,6 +150,7 @@ class Software(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attr)
 
     @property
+    @beartype
     def source(self) -> str:
         """
         Software source
@@ -161,6 +169,7 @@ class Software(UUIDBaseNode):
         return self._json_attrs.source
 
     @source.setter
+    @beartype
     def source(self, new_source: str) -> None:
         """
         set the Software source

--- a/src/cript/nodes/subobjects/software_configuration.py
+++ b/src/cript/nodes/subobjects/software_configuration.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field, replace
 from typing import List, Union
 
+from beartype import beartype
+
 from cript.nodes.core import BaseNode
 from cript.nodes.subobjects.algorithm import Algorithm
 from cript.nodes.subobjects.citation import Citation
@@ -51,6 +53,7 @@ class SoftwareConfiguration(BaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(self, software: Software, algorithm: Union[List[Algorithm], None] = None, notes: str = "", citation: Union[List[Citation], None] = None, **kwargs):
         """
         Create Software_Configuration sub-object
@@ -91,6 +94,7 @@ class SoftwareConfiguration(BaseNode):
         self.validate()
 
     @property
+    @beartype
     def software(self) -> Union[Software, None]:
         """
         Software used
@@ -113,6 +117,7 @@ class SoftwareConfiguration(BaseNode):
         return self._json_attrs.software
 
     @software.setter
+    @beartype
     def software(self, new_software: Union[Software, None]) -> None:
         """
         set the Software used
@@ -130,6 +135,7 @@ class SoftwareConfiguration(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def algorithm(self) -> List[Algorithm]:
         """
         list of Algorithms used
@@ -150,6 +156,7 @@ class SoftwareConfiguration(BaseNode):
         return self._json_attrs.algorithm.copy()
 
     @algorithm.setter
+    @beartype
     def algorithm(self, new_algorithm: List[Algorithm]) -> None:
         """
         set the list of Algorithms
@@ -167,6 +174,7 @@ class SoftwareConfiguration(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def notes(self) -> str:
         """
         miscellaneous information, or custom data structure (e.g.; JSON). Notes can be written in plain text or JSON
@@ -191,6 +199,7 @@ class SoftwareConfiguration(BaseNode):
         return self._json_attrs.notes
 
     @notes.setter
+    @beartype
     def notes(self, new_notes: str) -> None:
         """
         set notes for Software_configuration
@@ -208,6 +217,7 @@ class SoftwareConfiguration(BaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def citation(self) -> List[Citation]:
         """
         list of Citation sub-objects for the Software_Configuration
@@ -247,6 +257,7 @@ class SoftwareConfiguration(BaseNode):
         return self._json_attrs.citation.copy()
 
     @citation.setter
+    @beartype
     def citation(self, new_citation: List[Citation]) -> None:
         """
         set the Citation sub-object

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, replace
 
+from beartype import beartype
+
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -67,6 +69,7 @@ class File(UUIDBaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(self, source: str, type: str, extension: str = "", data_dictionary: str = "", **kwargs):
         """
         create a File node
@@ -128,6 +131,7 @@ class File(UUIDBaseNode):
 
     # --------------- Properties ---------------
     @property
+    @beartype
     def source(self) -> str:
         """
         The File node source can be set to be either a path to a local file on disk
@@ -153,6 +157,7 @@ class File(UUIDBaseNode):
         return self._json_attrs.source
 
     @source.setter
+    @beartype
     def source(self, new_source: str) -> None:
         """
         sets the source of the file node
@@ -194,6 +199,7 @@ class File(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def type(self) -> str:
         """
         The [File type]() must come from [CRIPT controlled vocabulary]()
@@ -212,6 +218,7 @@ class File(UUIDBaseNode):
         return self._json_attrs.type
 
     @type.setter
+    @beartype
     def type(self, new_type: str) -> None:
         """
         set the file type
@@ -238,6 +245,7 @@ class File(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def extension(self) -> str:
         """
         The file extension property explicitly states what is the file extension of the file node.
@@ -256,6 +264,7 @@ class File(UUIDBaseNode):
         return self._json_attrs.extension
 
     @extension.setter
+    @beartype
     def extension(self, new_extension) -> None:
         """
         sets the new file extension
@@ -279,6 +288,7 @@ class File(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
+    @beartype
     def data_dictionary(self) -> str:
         # TODO data dictionary needs documentation describing it and how to use it
         """
@@ -303,6 +313,7 @@ class File(UUIDBaseNode):
         return self._json_attrs.data_dictionary
 
     @data_dictionary.setter
+    @beartype
     def data_dictionary(self, new_data_dictionary: str) -> None:
         """
         Sets the data dictionary for the file node.

--- a/src/cript/nodes/supporting_nodes/user.py
+++ b/src/cript/nodes/supporting_nodes/user.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, replace
 
+from beartype import beartype
+
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -57,6 +59,7 @@ class User(UUIDBaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
+    @beartype
     def __init__(self, username: str, email: str, orcid: str, **kwargs):
         """
         Json from CRIPT API to be converted to a node
@@ -76,13 +79,13 @@ class User(UUIDBaseNode):
 
         self.validate()
 
-    # ------------------ properties ------------------
-
     @property
+    @beartype
     def created_at(self) -> str:
         return self._json_attrs.created_at
 
     @property
+    @beartype
     def email(self) -> str:
         """
         user's email
@@ -99,10 +102,12 @@ class User(UUIDBaseNode):
         return self._json_attrs.email
 
     @property
+    @beartype
     def model_version(self) -> str:
         return self._json_attrs.model_version
 
     @property
+    @beartype
     def orcid(self) -> str:
         """
         users [ORCID](https://orcid.org/)
@@ -119,14 +124,17 @@ class User(UUIDBaseNode):
         return self._json_attrs.orcid
 
     @property
+    @beartype
     def picture(self) -> str:
         return self._json_attrs.picture
 
     @property
+    @beartype
     def updated_at(self) -> str:
         return self._json_attrs.updated_at
 
     @property
+    @beartype
     def username(self) -> str:
         """
         username of the User node


### PR DESCRIPTION
# Description
I noticed that within [fix_mypy_types branch](https://github.com/C-Accel-CRIPT/Python-SDK/tree/fix_mypy_types) there was some `@beartype` but some not, so I left the ones that were in there and created a separate branch to put 
added [@beartype](https://github.com/beartype/beartype) to all the nodes and merge them back into [fix_mypy_types branch](https://github.com/C-Accel-CRIPT/Python-SDK/tree/fix_mypy_types)

## Changes
* added [@beartype](https://github.com/beartype/beartype) to all the nodes that were missing it

## Tests

## Known Issues
* there is probably some functions/methods within nodes that this is missing
    * I'm thinking it's not crucial for v1 if it is missing in a couple of places, but if we can catch all of them then all the better

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
