### PR TITLE
removing downloading of db schema

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,5 @@ def cript_api():
 
     assert cript.api.api._global_cached_api is None
     with cript.API(host=host, token=token) as api:
-        with open("db_schema.json", "w") as file_handle:
-            json.dump(api.schema, file_handle, indent=2)
         yield api
     assert cript.api.api._global_cached_api is None


### PR DESCRIPTION
# Description
I think since @InnocentBug did an amazing job integrating the SDK and API, downloading and saving the db schema on every save will no longer be needed and we can remove it. However, if we need it still I am happy to add it to `.gitignore` and keep it

## Changes
* removing downloading of db schema from `conftest.py`

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
