### PR TITLE
file node inheriting from PrimaryBaseNode.py

### DIFF
--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, replace
 
+from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -21,7 +22,7 @@ def _is_local_file(file_source: str) -> bool:
         return True
 
 
-class File(UUIDBaseNode):
+class File(PrimaryBaseNode):
     """
     ## Definition
 
@@ -55,7 +56,7 @@ class File(UUIDBaseNode):
     """
 
     @dataclass(frozen=True)
-    class JsonAttributes(UUIDBaseNode.JsonAttributes):
+    class JsonAttributes(PrimaryBaseNode.JsonAttributes):
         """
         all file attributes
         """
@@ -67,7 +68,7 @@ class File(UUIDBaseNode):
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
-    def __init__(self, source: str, type: str, extension: str = "", data_dictionary: str = "", **kwargs):
+    def __init__(self, name: str, source: str, type: str, extension: str = "", data_dictionary: str = "", notes: str = "", **kwargs):
         """
         create a File node
 
@@ -107,7 +108,7 @@ class File(UUIDBaseNode):
             ```
         """
 
-        super().__init__(**kwargs)
+        super().__init__(name=name,notes=notes, **kwargs)
 
         # TODO check if vocabulary is valid or not
         # is_vocab_valid("file type", type)

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -73,6 +73,8 @@ class File(PrimaryBaseNode):
 
         Parameters
         ----------
+        name: str
+            File node name
         source: str
             link or path to local file
         type: str
@@ -81,6 +83,8 @@ class File(PrimaryBaseNode):
             file extension
         data_dictionary:str
             extra information describing the file
+        notes: str
+            notes for the file node
         **kwargs:dict
             for internal use. Any extra data needed to create this file node
             when deserializing the JSON response from the API

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass, replace
 
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
-from cript.nodes.uuid_base import UUIDBaseNode
 
 
 def _is_local_file(file_source: str) -> bool:
@@ -108,7 +107,7 @@ class File(PrimaryBaseNode):
             ```
         """
 
-        super().__init__(name=name,notes=notes, **kwargs)
+        super().__init__(name=name, notes=notes, **kwargs)
 
         # TODO check if vocabulary is valid or not
         # is_vocab_valid("file type", type)

--- a/tests/fixtures/supporting_nodes.py
+++ b/tests/fixtures/supporting_nodes.py
@@ -11,7 +11,7 @@ def complex_file_node() -> cript.File:
     """
     complex file node with only required arguments
     """
-    my_file = cript.File(source="https://criptapp.org", type="calibration", extension=".csv", data_dictionary="my file's data dictionary")
+    my_file = cript.File(name="my complex file node fixture", source="https://criptapp.org", type="calibration", extension=".csv", data_dictionary="my file's data dictionary")
 
     return my_file
 

--- a/tests/nodes/primary_nodes/test_computational_process.py
+++ b/tests/nodes/primary_nodes/test_computational_process.py
@@ -75,7 +75,14 @@ def test_serialize_computational_process_to_json(simple_computational_process_no
         "node": ["ComputationProcess"],
         "name": "my computational process node name",
         "type": "cross_linking",
-        "input_data": [{"node": ["Data"], "name": "my data name", "type": "afm_amp", "file": [{"node": ["File"], "source": "https://criptapp.org", "type": "calibration", "extension": ".csv", "data_dictionary": "my file's data dictionary"}]}],
+        "input_data": [
+            {
+                "node": ["Data"],
+                "name": "my data name",
+                "type": "afm_amp",
+                "file": [{"node": ["File"], "name": "my complex file node fixture", "source": "https://criptapp.org", "type": "calibration", "extension": ".csv", "data_dictionary": "my file's data dictionary"}],
+            }
+        ],
         "ingredient": [
             {
                 "node": ["Ingredient"],

--- a/tests/nodes/primary_nodes/test_data.py
+++ b/tests/nodes/primary_nodes/test_data.py
@@ -134,9 +134,10 @@ def test_serialize_data_to_json(simple_data_node) -> None:
         "name": "my data name",
         "file": [
             {
+                "node": ["File"],
+                "name": "my complex file node fixture",
                 "data_dictionary": "my file's data dictionary",
                 "extension": ".csv",
-                "node": ["File"],
                 "source": "https://criptapp.org",
                 "type": "calibration",
             }

--- a/tests/nodes/primary_nodes/test_data.py
+++ b/tests/nodes/primary_nodes/test_data.py
@@ -93,6 +93,7 @@ def test_data_getters_and_setters(
     my_new_files = [
         complex_file_node,
         cript.File(
+            name="my data file node",
             source="https://bing.com",
             type="computation_config",
             extension=".pdf",

--- a/tests/nodes/primary_nodes/test_experiment.py
+++ b/tests/nodes/primary_nodes/test_experiment.py
@@ -130,7 +130,14 @@ def test_experiment_json(simple_process_node, simple_computation_node, simple_co
                 "node": ["ComputationProcess"],
                 "name": "my computational process node name",
                 "type": "cross_linking",
-                "input_data": [{"node": ["Data"], "name": "my data name", "type": "afm_amp", "file": [{"node": ["File"], "name": "my complex file node fixture", "source": "https://criptapp.org", "type": "calibration", "extension": ".csv", "data_dictionary": "my file's data dictionary"}]}],
+                "input_data": [
+                    {
+                        "node": ["Data"],
+                        "name": "my data name",
+                        "type": "afm_amp",
+                        "file": [{"node": ["File"], "name": "my complex file node fixture", "source": "https://criptapp.org", "type": "calibration", "extension": ".csv", "data_dictionary": "my file's data dictionary"}],
+                    }
+                ],
                 "ingredient": [
                     {
                         "node": ["Ingredient"],

--- a/tests/nodes/primary_nodes/test_experiment.py
+++ b/tests/nodes/primary_nodes/test_experiment.py
@@ -130,7 +130,7 @@ def test_experiment_json(simple_process_node, simple_computation_node, simple_co
                 "node": ["ComputationProcess"],
                 "name": "my computational process node name",
                 "type": "cross_linking",
-                "input_data": [{"node": ["Data"], "name": "my data name", "type": "afm_amp", "file": [{"node": ["File"], "source": "https://criptapp.org", "type": "calibration", "extension": ".csv", "data_dictionary": "my file's data dictionary"}]}],
+                "input_data": [{"node": ["Data"], "name": "my data name", "type": "afm_amp", "file": [{"node": ["File"], "name": "my complex file node fixture", "source": "https://criptapp.org", "type": "calibration", "extension": ".csv", "data_dictionary": "my file's data dictionary"}]}],
                 "ingredient": [
                     {
                         "node": ["Ingredient"],

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -1,7 +1,6 @@
 import copy
 import json
 
-import pytest
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -11,7 +11,7 @@ def test_create_file() -> None:
     """
     tests that a simple file with only required attributes can be created
     """
-    file_node = cript.File(source="https://google.com", type="calibration")
+    file_node = cript.File(name="my file name", source="https://google.com", type="calibration")
 
     assert isinstance(file_node, cript.File)
 
@@ -29,7 +29,7 @@ def test_create_file_local_source(tmp_path) -> None:
     with open(file_path, "w") as temporary_file:
         temporary_file.write("hello world!")
 
-    assert cript.File(source=str(file_path), type="calibration")
+    assert cript.File(name="my file node with local source", source=str(file_path), type="calibration")
 
 
 @pytest.fixture(scope="session")
@@ -97,6 +97,7 @@ def test_serialize_file_to_json(complex_file_node) -> None:
 
     expected_file_node_dict = {
         "node": ["File"],
+        "name": "my complex file node fixture",
         "source": "https://criptapp.org",
         "type": "calibration",
         "extension": ".csv",

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -32,26 +32,6 @@ def test_create_file_local_source(tmp_path) -> None:
     assert cript.File(name="my file node with local source", source=str(file_path), type="calibration")
 
 
-@pytest.fixture(scope="session")
-def file_node() -> cript.File:
-    """
-    create a file node for other tests to use
-
-    Returns
-    -------
-    File
-    """
-
-    # create a File node with all fields
-    my_file = cript.File(source="https://criptapp.com", type="calibration", extension=".pdf", data_dictionary="my data dictionary")
-    # use the file node for tests
-    yield my_file
-
-    # clean up file node after each test, so the file test is always uniform
-    # set the file node to original state
-    my_file = cript.File(source="https://criptapp.com", type="calibration", extension=".pdf", data_dictionary="my data dictionary ")
-
-
 def test_file_type_invalid_vocabulary() -> None:
     """
     tests that setting the file type to an invalid vocabulary word gives the expected error


### PR DESCRIPTION
# Description
since [File node inherits from base attributes in the data model](https://pubs.acs.org/doi/suppl/10.1021/acscentsci.3c00011/suppl_file/oc3c00011_si_001.pdf#page=28), I fixed that within the SDK File node and inherited all `PrimaryBaseNode` attributes

## Changes
* removed unused `file_node` fixture within `test_files.py`
* class and data class inheriting from the correct `PrimaryBaseNode`

## Tests
* tests are all passing for file nodes and fixture inheriting from `PrimaryBaseNode`

## Known Issues
* None

## Notes

## Checklist

- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
