### PR TITLE
Remove material identifier keyword validations

### DIFF
--- a/src/cript/nodes/primary_nodes/material.py
+++ b/src/cript/nodes/primary_nodes/material.py
@@ -16,15 +16,15 @@ class Material(PrimaryBaseNode):
     is just the materials used within an project/experiment.
 
     ## Attributes
-    | attribute               | type                                                | example                                           | description                                  | required    | vocab |
-    |-------------------------|-----------------------------------------------------|---------------------------------------------------|----------------------------------------------|-------------|-------|
-    | identifiers             | list[Identifier]                                    |                                                   | material identifiers                         | True        |       |
-    | component              | list[[Material](./)]                                |                                                   | list of component that make up the mixture  |             |       |
-    | property              | list[[Property](../subobjects/property)]            |                                                   | material properties                          |             |       |
-    | process                 | [Process](../process)                               |                                                   | process node that made this material         |             |       |
-    | parent_material         | [Material](./)                                      |                                                   | material node that this node was copied from |             |       |
+    | attribute                 | type                                                   | example                                           | description                                  | required    | vocab |
+    |---------------------------|--------------------------------------------------------|---------------------------------------------------|----------------------------------------------|-------------|-------|
+    | identifiers               | list[Identifier]                                       |                                                   | material identifiers                         | True        |       |
+    | component                 | list[[Material](./)]                                   |                                                   | list of component that make up the mixture   |             |       |
+    | property                  | list[[Property](../subobjects/property)]               |                                                   | material properties                          |             |       |
+    | process                   | [Process](../process)                                  |                                                   | process node that made this material         |             |       |
+    | parent_material           | [Material](./)                                         |                                                   | material node that this node was copied from |             |       |
     | computational_ forcefield | [Computation  Forcefield](../computational_forcefield) |                                                   | computation forcefield                       | Conditional |       |
-    | keyword                | list[str]                                           | [thermoplastic, homopolymer, linear, polyolefins] | words that classify the material             |             | True  |
+    | keyword                   | list[str]                                              | [thermoplastic, homopolymer, linear, polyolefins] | words that classify the material             |             | True  |
 
     ## Navigating to Material
     Materials can be easily found on the [CRIPT](https://criptapp.org) home screen in the
@@ -374,50 +374,6 @@ class Material(PrimaryBaseNode):
 
         new_attrs = replace(self._json_attrs, keyword=new_keyword_list)
         self._update_json_attrs_if_valid(new_attrs)
-
-    # ------------ validation ------------
-    # TODO this can be a function instead of a method
-    def _validate_keyword(self, keyword: List[str]) -> None:
-        """
-        takes a list of material keyword and loops through validating every single one
-
-        this is a simple loop that calls another method, but I thought it needs to be made into a method
-        since both constructor and keyword setter has the same code
-
-        Parameters
-        ----------
-        keyword: List[str]
-
-        Returns
-        -------
-        None
-        """
-        # TODO add this validation in the future
-        # for keyword in keyword:
-        #     is_vocab_valid(keywords)
-        pass
-
-    # TODO this can be a function instead of a method
-    def _validate_identifiers(self, identifiers: List[Dict[str, str]]) -> None:
-        """
-        takes a list of material identifiers and loops through validating every single one
-
-        since validation is needed in both constructor and the setter, this is a simple method for it
-
-        Parameters
-        ----------
-        identifiers: List[Dict[str, str]]
-
-        Returns
-        -------
-        None
-        """
-
-        for identifier_dictionary in identifiers:
-            for key, value in identifier_dictionary.items():
-                # TODO validate keys here
-                # is_vocab_valid("material_identifiers", value)
-                pass
 
     @property
     @beartype

--- a/src/cript/nodes/primary_nodes/material.py
+++ b/src/cript/nodes/primary_nodes/material.py
@@ -127,10 +127,6 @@ class Material(PrimaryBaseNode):
         if keyword is None:
             keyword = []
 
-        # validate keyword if they exist
-        if keyword is not None:
-            self._validate_keyword(keyword=keyword)
-
         self._json_attrs = replace(
             self._json_attrs,
             name=name,
@@ -369,9 +365,6 @@ class Material(PrimaryBaseNode):
         -------
         None
         """
-        # TODO validate keyword before setting them
-        self._validate_keyword(keyword=new_keyword_list)
-
         new_attrs = replace(self._json_attrs, keyword=new_keyword_list)
         self._update_json_attrs_if_valid(new_attrs)
 

--- a/tests/nodes/primary_nodes/test_material.py
+++ b/tests/nodes/primary_nodes/test_material.py
@@ -103,7 +103,7 @@ def test_serialize_material_to_json(complex_material_dict, complex_material_node
 
 
 # ---------- Integration Tests ----------
-def test_save_material_to_api(cript_api, simple_material_node, simple_project_node) -> None:
+def test_save_material_to_api() -> None:
     """
     tests if the material can be saved to the API without errors and status code of 200
     """

--- a/tests/nodes/primary_nodes/test_material.py
+++ b/tests/nodes/primary_nodes/test_material.py
@@ -103,10 +103,12 @@ def test_serialize_material_to_json(complex_material_dict, complex_material_node
 
 
 # ---------- Integration Tests ----------
-def test_save_material_to_api() -> None:
+def test_save_material_to_api(cript_api, simple_material_node, simple_project_node) -> None:
     """
     tests if the material can be saved to the API without errors and status code of 200
     """
+    simple_project_node.material = [simple_material_node]
+    cript_api.save(project=simple_project_node)
     pass
 
 

--- a/tests/nodes/primary_nodes/test_material.py
+++ b/tests/nodes/primary_nodes/test_material.py
@@ -107,8 +107,6 @@ def test_save_material_to_api(cript_api, simple_material_node, simple_project_no
     """
     tests if the material can be saved to the API without errors and status code of 200
     """
-    simple_project_node.material = [simple_material_node]
-    cript_api.save(project=simple_project_node)
     pass
 
 


### PR DESCRIPTION
# Description
Removing unneeded and unused material keyword validation and material identifier validation. 

We are using the db schema for the vocabulary validation, so these methods no longer make sense to be here. 

Originally When I made it I thought we were going to check it manually so I wrote a loop and double for loop to check if the vocabulary existed within the controlled vocabulary, and thankfully that can now be optimized.

## Changes
* removed `_validate_keyword` in materials,py
* removed `_validate_identifiers` in materials.py
* removed `_validate_keyword` from constructor and keywords setter
* formatted the attributes table in the class docstrings

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
