### PR TITLE
Added `Screenshots` section to PR templates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,10 @@
 
 ## Tests
 
+<!-- Screenshots if applicable
+## Screenshots
+-->
+
 ## Known Issues
 
 ## Notes


### PR DESCRIPTION
# Description
Added a screenshots section to the PR template, this way if developers update the documentation and want to add a screenshot for other developers to quickly see the outcome of the new changes, they can see it quickly from the PR, and they can run the documentation or any UI locally as well and see the changes.

> Note sure if this is fully needed or not, but I think it could be a good idea. I am also open to not adding this to the PR template as well.

## Changes
* added a screenshots section to PR templates, but is commented out
    * telling developers to show screenshots if applicable

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
