### PR TITLE
Add type hints to `cript.API.upload_file()`

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -569,8 +569,10 @@ class API:
         """
         # trunk-ignore-end(cspell)
 
+        # TODO consider using a new variable when converting `file_path` from parameter
+        #  to a Path object with a new type
         # convert file path from whatever the user passed in to a pathlib object
-        file_path: Path = Path(file_path).resolve()
+        file_path = Path(file_path).resolve()
 
         # get file_name and file_extension from absolute file path
         # file_extension includes the dot, e.g. ".txt"

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -627,7 +627,7 @@ class API:
             just downloads the file to the specified path
         """
 
-        # file is stored in cloud storage and must be retrieved via object_name
+        # the file is stored in cloud storage and must be retrieved via object_name
         self._s3_client.download_file(Bucket=self._BUCKET_NAME, Key=object_name, Filename=destination_path)  # type: ignore
 
     @beartype

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -570,19 +570,19 @@ class API:
         # trunk-ignore-end(cspell)
 
         # convert file path from whatever the user passed in to a pathlib object
-        file_path = Path(file_path).resolve()
+        file_path: Path = Path(file_path).resolve()
 
         # get file_name and file_extension from absolute file path
         # file_extension includes the dot, e.g. ".txt"
         file_name, file_extension = os.path.splitext(os.path.basename(file_path))
 
         # generate a UUID4 string without dashes, making a cleaner file name
-        uuid_str = str(uuid.uuid4().hex)
+        uuid_str: str = str(uuid.uuid4().hex)
 
         new_file_name: str = f"{file_name}_{uuid_str}{file_extension}"
 
         # e.g. "directory/file_name_uuid.extension"
-        object_name = f"{self._BUCKET_DIRECTORY_NAME}/{new_file_name}"
+        object_name: str = f"{self._BUCKET_DIRECTORY_NAME}/{new_file_name}"
 
         # upload file to AWS S3
         self._s3_client.upload_file(Filename=file_path, Bucket=self._BUCKET_NAME, Key=object_name)  # type: ignore


### PR DESCRIPTION
# Description
Noticed I missed some type hints when I originally wrote it, so I quickly added them here. Was not sure how to type hint this line so I left it as is for now, but both should be type `str`

```python
file_name, file_extension = os.path.splitext(os.path.basename(file_path))
```

## Changes
* added type hinting to `cript.API.upload_file()`
* fixed grammar of comment

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
