### PR TITLE
Keep track of already validated nodes

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -513,6 +513,10 @@ class API:
         None
             Just sends a `POST` or `Patch` request to the API
         """
+
+        # Ensure, that the project is valid with this API.
+        project.validate(api=self, sloppy=False)
+
         response: Dict = requests.post(url=f"{self._host}/{project.node_type.lower()}", headers=self._http_headers, data=project.json).json()
 
         # if http response is not 200 then show the API error to the user

--- a/src/cript/nodes/core.py
+++ b/src/cript/nodes/core.py
@@ -4,7 +4,7 @@ import json
 import uuid
 from abc import ABC
 from dataclasses import dataclass, replace
-from typing import List, Optional, Set
+from typing import Any, List, Optional, Set
 
 from cript.nodes.exceptions import (
     CRIPTAttributeModificationError,
@@ -135,9 +135,9 @@ class BaseNode(ABC):
             raise exc
 
     # Store validated JSON attributes by hash, to accelerate verification.
-    _validated_hashes = set()
+    _validated_hashes: Set = set()
 
-    def validate(self, api=None, sloppy=True) -> None:
+    def validate(self, api: Optional[Any] = None, sloppy: bool = True) -> None:
         """
         Validate this node (and all its children) against the schema provided by the data bank.
 
@@ -426,7 +426,7 @@ class BaseNode(ABC):
         self._update_json_attrs_if_valid(new_attrs)
         return True
 
-    def _string_hash(self):
+    def _string_hash(self) -> int:
         """
         Calculate a hash value for the current JSON attributes.
 

--- a/src/cript/nodes/primary_nodes/project.py
+++ b/src/cript/nodes/primary_nodes/project.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field, replace
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from beartype import beartype
 
@@ -71,14 +71,17 @@ class Project(PrimaryBaseNode):
         self._json_attrs = replace(self._json_attrs, name=name, collection=collection, material=material)
         self.validate()
 
-    def validate(self, api=None):
+    def validate(self, api: Optional[Any] = None, sloppy: bool = True) -> None:
         from cript.nodes.exceptions import (
             CRIPTOrphanedMaterialError,
             get_orphaned_experiment_exception,
         )
 
         # First validate like other nodes
-        super().validate(api=api)
+        super().validate(api=api, sloppy=sloppy)
+        # In sloppy validate mode, we can skip further evaluations
+        if sloppy:
+            return
 
         # Check graph for orphaned nodes, that should be listed in project
         # Project.materials should contain all material nodes
@@ -205,7 +208,7 @@ class Project(PrimaryBaseNode):
         new_attrs = replace(self._json_attrs, material=new_materials)
         self._update_json_attrs_if_valid(new_attrs)
 
-    def _string_hash(self):
+    def _string_hash(self) -> int:
         """
         Contrary to all other nodes is the validity of projects only possible to determine with a full graph traversal.
         Hence, we have to use the full JSON for validity checks to include the full graph.

--- a/src/cript/nodes/primary_nodes/project.py
+++ b/src/cript/nodes/primary_nodes/project.py
@@ -71,14 +71,14 @@ class Project(PrimaryBaseNode):
         self._json_attrs = replace(self._json_attrs, name=name, collection=collection, material=material)
         self.validate()
 
-    def validate(self):
+    def validate(self, api=None):
         from cript.nodes.exceptions import (
             CRIPTOrphanedMaterialError,
             get_orphaned_experiment_exception,
         )
 
         # First validate like other nodes
-        super().validate()
+        super().validate(api=api)
 
         # Check graph for orphaned nodes, that should be listed in project
         # Project.materials should contain all material nodes
@@ -204,3 +204,10 @@ class Project(PrimaryBaseNode):
         """
         new_attrs = replace(self._json_attrs, material=new_materials)
         self._update_json_attrs_if_valid(new_attrs)
+
+    def _string_hash(self):
+        """
+        Contrary to all other nodes is the validity of projects only possible to determine with a full graph traversal.
+        Hence, we have to use the full JSON for validity checks to include the full graph.
+        """
+        return hash(self.get_json(condense_to_uuid={}).json)

--- a/src/cript/nodes/util/__init__.py
+++ b/src/cript/nodes/util/__init__.py
@@ -326,7 +326,7 @@ def add_orphaned_nodes_to_project(project: Project, active_experiment: Experimen
         if counter > max_iteration >= 0:
             break  # Emergency stop
         try:
-            project.validate()
+            project.validate(sloppy=False)
         except CRIPTOrphanedMaterialError as exc:
             # because calling the setter calls `validate` we have to force add the material.
             project._json_attrs.material.append(exc.orphaned_node)

--- a/tests/test_node_util.py
+++ b/tests/test_node_util.py
@@ -254,7 +254,7 @@ def test_invalid_project_graphs(simple_project_node, simple_material_node, simpl
     # Invalid graph
     project.collection[0].experiment[0].process += [process]
     with pytest.raises(CRIPTOrphanedMaterialError):
-        project.validate()
+        project.validate(sloppy=False)
 
     # First fix add material to inventory
     project.collection[0].inventory += [cript.Inventory("test_inventory", material=[material])]
@@ -262,18 +262,18 @@ def test_invalid_project_graphs(simple_project_node, simple_material_node, simpl
     # Reverse this fix
     project.collection[0].inventory = []
     with pytest.raises(CRIPTOrphanedMaterialError):
-        project.validate()
+        project.validate(sloppy=False)
 
     # Fix by add to the materials list instead.
     # Using the util helper function for this.
     cript.add_orphaned_nodes_to_project(project, active_experiment=None, max_iteration=10)
-    project.validate()
+    project.validate(sloppy=False)
 
     # Now add an orphan process to the graph
     process2 = copy.deepcopy(simple_process_node)
     process.prerequisite_process += [process2]
     with pytest.raises(CRIPTOrphanedProcessError):
-        project.validate()
+        project.validate(sloppy=False)
 
     # Wrong fix it helper node
     dummy_experiment = copy.deepcopy(project.collection[0].experiment[0])
@@ -281,10 +281,10 @@ def test_invalid_project_graphs(simple_project_node, simple_material_node, simpl
         cript.add_orphaned_nodes_to_project(project, dummy_experiment)
     # Problem still persists
     with pytest.raises(CRIPTOrphanedProcessError):
-        project.validate()
+        project.validate(sloppy=False)
     # Fix by using the helper function correctly
     cript.add_orphaned_nodes_to_project(project, project.collection[0].experiment[0], 10)
-    project.validate()
+    project.validate(sloppy=False)
 
     # We add property to the material, because that adds the opportunity for orphaned data and computation
     property = copy.deepcopy(simple_property_node)
@@ -294,19 +294,19 @@ def test_invalid_project_graphs(simple_project_node, simple_material_node, simpl
     data = copy.deepcopy(simple_data_node)
     property.data = [data]
     with pytest.raises(CRIPTOrphanedDataError):
-        project.validate()
+        project.validate(sloppy=False)
     # Fix with the helper function
     cript.add_orphaned_nodes_to_project(project, project.collection[0].experiment[0], 10)
-    project.validate()
+    project.validate(sloppy=False)
 
     # Add an orphan Computation
     computation = copy.deepcopy(simple_computation_node)
     property.computation += [computation]
     with pytest.raises(CRIPTOrphanedComputationError):
-        project.validate()
+        project.validate(sloppy=False)
     # Fix with the helper function
     cript.add_orphaned_nodes_to_project(project, project.collection[0].experiment[0], 10)
-    project.validate()
+    project.validate(sloppy=False)
 
     # Add orphan computational process
     comp_proc = copy.deepcopy(simple_computation_process_node)
@@ -314,7 +314,7 @@ def test_invalid_project_graphs(simple_project_node, simple_material_node, simpl
     with pytest.raises(CRIPTOrphanedComputationalProcessError):
         while True:
             try:  # Do trigger not orphan materials
-                project.validate()
+                project.validate(sloppy=False)
             except CRIPTOrphanedMaterialError as exc:
                 project._json_attrs.material.append(exc.orphaned_node)
             except CRIPTOrphanedProcessError as exc:
@@ -323,4 +323,4 @@ def test_invalid_project_graphs(simple_project_node, simple_material_node, simpl
                 break
 
     cript.add_orphaned_nodes_to_project(project, project.collection[0].experiment[0], 10)
-    project.validate()
+    project.validate(sloppy=False)


### PR DESCRIPTION
# Description
This may lead to a smaller performance boost.

This keeps track of already validated node, by storing a simplified hash value of already validated JSON attributes.

## Changes

Added a `sloppy` argument to `validate` that can disable the hash based accelerated validation.
Added additional `validate` before projects are saved.

## Tests

our usual tests, should cover this functionality.
I have not performed explicit testing to measure the acceleration.
The possible acceleration depends on the specific situation, especially validating large graphs multiple times, can be accelerated this way. 

## Known Issues

The hash value is intentionally set up, to not include a full graph traversal.
Breaking changes beyond the immediate children are possibly not detected.

For project, a special treatment is used, where the full graph is traversed, since project nodes have to be fully traversed to detect orphan nodes.
## Notes

## Checklist

- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
