### PR TITLE
Add example walkthrough to navigation within the SDK documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,9 +6,11 @@ repo_name: C-Accel-CRIPT/Python-SDK
 nav:
   - Home: index.md
   - Tutorial:
-      - Example Code Walkthrough: examples/synthesis.md
       - CRIPT Installation Guide: tutorial/cript_installation_guide.md
       - CRIPT API Token: tutorial/how_to_get_api_token.md
+  - Example Code Walkthrough:
+      - Synthesis: examples/synthesis.md
+      - Simulation: examples/simulation.md
   - API Client:
       - API: api/api.md
       - Search Modes: api/search_modes.md


### PR DESCRIPTION
# Description
Add example walkthrough to navigation within the SDK documentation

## Changes
* changed MKDocs.yaml to include the files
* added a dedicated section for example code walkthroughs

## Screenshots
<details>
  <summary>See Screenshots</summary>
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/0c64dd21-01c7-4c31-bc82-a532083f12ef)
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/7bad302e-eedc-48fd-8725-dc77474205bb)
  </select>
</details>
