### PR TITLE
Feature: Download `file.source` that is URL

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -639,6 +639,7 @@ class API:
         # return the object_name within AWS S3 for easy retrieval
         return object_name
 
+    @beartype
     def download_file(self, object_name: str, destination_path: str = ".") -> None:
         """
         download a file from AWS S3 and save it to the specified path on local storage

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -22,6 +22,7 @@ from cript.api.exceptions import (
 from cript.api.paginator import Paginator
 from cript.api.utils.get_host_token import resolve_host_and_token
 from cript.api.utils.save_helper import fix_node_save
+from cript.api.utils.web_file_downloader import download_file_from_url
 from cript.api.valid_search_modes import SearchModes
 from cript.api.vocabulary_categories import ControlledVocabularyCategories
 from cript.nodes.exceptions import CRIPTJsonNodeError, CRIPTNodeSchemaError
@@ -674,6 +675,11 @@ class API:
         None
             just downloads the file to the specified path
         """
+
+        # if the file source is a URL
+        if object_name.startswith("http"):
+            download_file_from_url(url=object_name, destination_path=destination_path)
+            return
 
         # the file is stored in cloud storage and must be retrieved via object_name
         self._s3_client.download_file(Bucket=self._BUCKET_NAME, Key=object_name, Filename=destination_path)  # type: ignore

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -679,7 +679,7 @@ class API:
 
         # if the file source is a URL
         if object_name.startswith("http"):
-            download_file_from_url(url=object_name, destination_path=destination_path)
+            download_file_from_url(url=object_name, destination_path=Path(destination_path).resolve())
             return
 
         # the file is stored in cloud storage and must be retrieved via object_name

--- a/src/cript/api/utils/web_file_downloader.py
+++ b/src/cript/api/utils/web_file_downloader.py
@@ -88,7 +88,7 @@ def write_file_to_disk(destination_path: [str, Path], file_contents: bytes) -> N
     Raises
     ------
     FileNotFoundError
-        In case the destination given does not exist
+        In case the destination given to write the file to was not found or does not exist
     """
     # convert any type of path to a Path object
     destination_path = Path(destination_path)

--- a/src/cript/api/utils/web_file_downloader.py
+++ b/src/cript/api/utils/web_file_downloader.py
@@ -69,7 +69,7 @@ def get_file_extension_from_url(url: str) -> str:
     return file_extension
 
 
-def write_file_to_disk(destination_path: [str, Path], file_contents: bytes) -> None:
+def write_file_to_disk(destination_path: Union[str, Path], file_contents: bytes) -> None:
     """
     simply writes the file to the given destination
 

--- a/src/cript/api/utils/web_file_downloader.py
+++ b/src/cript/api/utils/web_file_downloader.py
@@ -1,6 +1,6 @@
 import os
-from typing import Union
 from pathlib import Path
+from typing import Union
 
 import requests
 

--- a/src/cript/api/utils/web_file_downloader.py
+++ b/src/cript/api/utils/web_file_downloader.py
@@ -1,0 +1,98 @@
+import os
+from typing import Union
+from pathlib import Path
+
+import requests
+
+
+def download_file_from_url(url: str, destination_path: Union[str, Path]) -> None:
+    """
+    downloads a file from URL
+
+    Warnings
+    ---------
+    This is a very basic implementation that does not handle all URL files,
+    and will likely throw errors.
+    For example, some file URLs require a session or JS enabled to navigate to them
+    such as "https://pubs.acs.org/doi/suppl/10.1021/acscentsci.3c00011/suppl_file/oc3c00011_si_001.pdf"
+    in those cases this implementation will fail.
+
+    Parameters
+    ----------
+    url: str
+        web URL to download the file from
+        example: https://criptscripts.org/cript_graph/graph_ppt/CRIPT_Data_Structure_Template.pptx
+    destination_path: Union[str, Path]
+        which directory and file name the file should be written to after gotten from the web
+
+    Returns
+    -------
+    None
+        just downloads the file
+    """
+
+    response = requests.get(url=url)
+
+    # if not HTTP 200, then throw error
+    response.raise_for_status()
+
+    # get extension from URL
+    file_extension = get_file_extension_from_url(url=url)
+
+    # add file extension to file path
+    destination_path = str(destination_path) + file_extension
+
+    destination_path = Path(destination_path)
+
+    # write contents to a file on user disk
+    write_file_to_disk(destination_path=destination_path, file_contents=response.content)
+
+
+def get_file_extension_from_url(url: str) -> str:
+    """
+    takes a file url and returns only the extension with the dot
+
+    Parameters
+    ----------
+    url: str
+        web URL
+        example: "https://criptscripts.org/cript_graph/graph_ppt/CRIPT_Data_Structure_Template.pptx"
+
+    Returns
+    -------
+    file extension: str
+        file extension with dot
+        example: ".pptx"
+    """
+    file_extension = os.path.splitext(url)[1]
+
+    return file_extension
+
+
+def write_file_to_disk(destination_path: [str, Path], file_contents: bytes) -> None:
+    """
+    simply writes the file to the given destination
+
+    Parameters
+    ----------
+    destination_path: Union[str, Path]
+        which directory and file name the file should be written to after gotten from the web
+    file_contents: bytes
+        content of file to write to disk
+
+    Returns
+    -------
+    None
+        just writes the file to disk
+
+    Raises
+    ------
+    FileNotFoundError
+        In case the destination given does not exist
+    """
+    # convert any type of path to a Path object
+    destination_path = Path(destination_path)
+
+    with open(file=destination_path, mode="wb") as file_handle:
+        file_handle.write(file_contents)
+

--- a/src/cript/api/utils/web_file_downloader.py
+++ b/src/cript/api/utils/web_file_downloader.py
@@ -95,4 +95,3 @@ def write_file_to_disk(destination_path: [str, Path], file_contents: bytes) -> N
 
     with open(file=destination_path, mode="wb") as file_handle:
         file_handle.write(file_contents)
-

--- a/src/cript/api/utils/web_file_downloader.py
+++ b/src/cript/api/utils/web_file_downloader.py
@@ -39,7 +39,7 @@ def download_file_from_url(url: str, destination_path: Union[str, Path]) -> None
     # get extension from URL
     file_extension = get_file_extension_from_url(url=url)
 
-    # add file extension to file path and file name
+    # add the file extension to file path and file name
     destination_path = str(destination_path) + file_extension
 
     destination_path = Path(destination_path)

--- a/src/cript/api/utils/web_file_downloader.py
+++ b/src/cript/api/utils/web_file_downloader.py
@@ -39,7 +39,7 @@ def download_file_from_url(url: str, destination_path: Union[str, Path]) -> None
     # get extension from URL
     file_extension = get_file_extension_from_url(url=url)
 
-    # add file extension to file path
+    # add file extension to file path and file name
     destination_path = str(destination_path) + file_extension
 
     destination_path = Path(destination_path)

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -180,7 +180,18 @@ def test_is_vocab_valid(cript_api: cript.API) -> None:
 
     # valid vocab category but invalid vocab word
     with pytest.raises(InvalidVocabulary):
-        cript_api._is_vocab_valid(vocab_category=cript.ControlledVocabularyCategories.FILE_TYPE, vocab_word="some_invalid_word")
+        cript_api._is_vocab_valid(vocab_category=cript.ControlledVocabularyCategories.FILE_TYPE,
+                                  vocab_word="some_invalid_word")
+
+
+def test_download_file_from_url(cript_api: cript.API) -> None:
+    """
+    downloads the file from a URL and writes it to disk
+    """
+    cript_api.download_file(
+        object_name="https://criptscripts.org/cript_graph/graph_ppt/CRIPT_Data_Structure_Template.pptx",
+        destination_path=r"C:\Users\navid\Downloads\download_file_test"
+        )
 
 
 # -------------- Start: Must be tested with API Container --------------------
@@ -351,6 +362,5 @@ def test_get_my_projects_from_api(cript_api: cript.API) -> None:
     get a page of project nodes that is associated with the API token
     """
     pass
-
 
 # -------------- End: Must be tested with API Container --------------------

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -182,8 +182,7 @@ def test_is_vocab_valid(cript_api: cript.API) -> None:
 
     # valid vocab category but invalid vocab word
     with pytest.raises(InvalidVocabulary):
-        cript_api._is_vocab_valid(vocab_category=cript.ControlledVocabularyCategories.FILE_TYPE,
-                                  vocab_word="some_invalid_word")
+        cript_api._is_vocab_valid(vocab_category=cript.ControlledVocabularyCategories.FILE_TYPE, vocab_word="some_invalid_word")
 
 
 def test_download_file_from_url(cript_api: cript.API, tmp_path) -> None:
@@ -381,5 +380,6 @@ def test_get_my_projects_from_api(cript_api: cript.API) -> None:
     get a page of project nodes that is associated with the API token
     """
     pass
+
 
 # -------------- End: Must be tested with API Container --------------------


### PR DESCRIPTION
# Description
In the past the SDK could only download files from AWS S3 cloud storage, but now it has the rough ability to download files from URL as well.

## Changes

## Tests

## Known Issues
* if the URL needs JS enabled, needs sessions, has extra needs, then the downloader throws an error
* the error needs to be tested to be sure that it is user friendly
* refactoring needed: https://trello.com/c/qLaN2hqR

## Checklist
- [ ] I have updated the documentation to reflect my changes.
