### PR TITLE
updated _is_local_file to handle `URL`, `AWS S3 object_name`, `absolute file path`, `relative file path`

### DIFF
--- a/.trunk/configs/.cspell.json
+++ b/.trunk/configs/.cspell.json
@@ -72,7 +72,7 @@
     "buildscript",
     "markdownlint",
     "Numpy",
-    "ipynb"
+    "ipynb",
     "boto",
     "beartype",
     "mypy",

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Union
@@ -11,18 +12,35 @@ def _is_local_file(file_source: str) -> bool:
     """
     Determines if the file the user is uploading is a local file or a link.
 
-    Args:
-        file_source (str): The source of the file.
+    It basically tests if the path exists, and it is specifically a file
+    on the local storage and not just a valid directory
 
-    Returns:
-        bool: True if the file is local, False if it's a link.
+    Notes
+    -----
+    since checking for URL is very easy because it has to start with HTTP it checks that as well
+    if it starts with http then it makes the work easy, and it is automatically web URL
+
+    Parameters
+    ----------
+    file_source: str
+        The source of the file.
+
+    Returns
+    -------
+    bool
+        True if the file is local, False if it's a link or s3 object_name.
     """
 
+    # convert local or relative file path str into a path object and resolve it to always get an absolute path
+    file_source_abs_path: str = str(Path(file_source).resolve())
+
+    # if it doesn't start with HTTP and exists on disk
     # checking "http" so it works with both "https://" and "http://"
-    if file_source.startswith("http"):
-        return False
-    else:
+    if not file_source.startswith("http") and os.path.isfile(file_source_abs_path):
         return True
+
+    else:
+        return False
 
 
 def _upload_file_and_get_object_name(source: Union[str, Path], api=None) -> str:

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -188,7 +188,8 @@ def test_is_vocab_valid(cript_api: cript.API) -> None:
 def test_upload_and_download_local_file(cript_api, tmp_path_factory) -> None:
     """
     tests file upload to cloud storage
-    test by uploading a local file and then downloading the same file and checking their contents are the same
+    test by uploading a local file to AWS S3 using cognito mode
+    and then downloading the same file and checking their contents are the same
     proving that the file was uploaded and downloaded correctly
 
     1. create a temporary file

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -185,10 +185,10 @@ def test_is_vocab_valid(cript_api: cript.API) -> None:
 
 # -------------- Start: Must be tested with API Container --------------------
 # TODO get save to work with the API
-def test_upload_and_download_file(cript_api, tmp_path_factory) -> None:
+def test_upload_and_download_local_file(cript_api, tmp_path_factory) -> None:
     """
     tests file upload to cloud storage
-    test by uploading a file and then downloading the same file and checking their contents are the same
+    test by uploading a local file and then downloading the same file and checking their contents are the same
     proving that the file was uploaded and downloaded correctly
 
     1. create a temporary file


### PR DESCRIPTION
# Description
updated _is_local_file to handle file source URL links and S3 object_name
created a good test for it with good test cases

## Changes
* within `_is_local_file` I am checking if the file exists on the file path specified, and if it does, then it is a local file, otherwise it is a S3 object_name
    * checking if the file_source starts with `http` first because that is an easy check that can speed up the test and make it more accurate
* noticed that the docstrings are in Google style so switched them to numpy style, I think that is the only one that was like that
* renamed `test_upload_and_download_local_file` and updated docstrings to avoid confusion as to what kind of upload it is doing
    * > this is unrelated to this PR, but it is a very small change and didn't want to make a new PR for it

## Test Cases
* HTTP URL
* fake AWS S3 object_name
* absolute file path (str)
* relative file path (str)
> I would have also tested Path object, but we are only allowing for str in that function, and I do not want to refactor right now

## Known Issues
* not tested on Mac or Linux, only tested on windows
* this would give a false negative if a file path is inputted incorrectly
    * it'll try to get the file, it won't exist, it'll think it must be a object_name and it'll put it as the file source
        * I can maybe try to check if the directory exists, maybe check the common things that a path starts with but that seems like over engineering at this moment. I'm thinking those are better to be added if the use case and issues arise
        * we could also give a terminal output that we found a file and are uploading it to cript storage, so if the user doesn't get that output, they'll grow suspicious and check their path and do further debugging
            * this seems more like an upgrade that we add later than essential feature for right now

## Notes
if you can think of a test case that I am not covering any test cases feel free to let me know

> this same type of test should be done for api config file to be sure that it works with absolute file path, relative file path, and Path object later
