### PR TITLE
making file extension mandatory on file.py

### DIFF
--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -125,7 +125,7 @@ class File(PrimaryBaseNode):
     _json_attrs: JsonAttributes = JsonAttributes()
 
     @beartype
-    def __init__(self, name: str, source: str, type: str, extension: str = "", data_dictionary: str = "", notes: str = "", **kwargs):
+    def __init__(self, name: str, source: str, type: str, extension: str, data_dictionary: str = "", notes: str = "", **kwargs):
         """
         create a File node
 

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -412,7 +412,6 @@ class File(PrimaryBaseNode):
     # TODO get file name from node itself as default and allow for customization as well optional
     def download(
         self,
-        file_name: str,
         destination_directory_path: Union[str, Path] = ".",
     ) -> None:
         """
@@ -420,8 +419,6 @@ class File(PrimaryBaseNode):
 
         Parameters
         ----------
-        file_name: str
-            what you want to name the file node on your computer
         destination_directory_path: Union[str, Path]
             where you want the file to be stored and what you want the name to be
             by default it is the current working directory
@@ -434,11 +431,11 @@ class File(PrimaryBaseNode):
 
         api = _get_global_cached_api()
 
-        existing_folder_path = Path(destination_directory_path)
+        existing_folder_path = Path(destination_directory_path).resolve()
 
         # TODO automatically add the correct file extension to it from the node
         #  and be sure that it is always `.csv` and never just `csv`
-        file_name = f"{file_name}"
+        file_name = f"{self.name}"
 
         absolute_file_path = str((existing_folder_path / file_name).resolve())
 

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -1,8 +1,10 @@
 import copy
+import datetime
 import json
 import os
 import uuid
 
+import pytest
 from test_integration import integrate_nodes_helper
 from util import strip_uid_from_dict
 
@@ -55,6 +57,7 @@ def test_source_is_local(tmp_path, tmp_path_factory) -> None:
     assert _is_local_file(file_source=relative_file_path) is True
 
 
+@pytest.mark.skip(reason="test needs to be updated to be uploaded on api.save() instead")
 def test_local_file_source_upload_and_download(tmp_path_factory) -> None:
     """
     upload a file and download it and be sure the contents are the same
@@ -68,8 +71,6 @@ def test_local_file_source_upload_and_download(tmp_path_factory) -> None:
     1. download the file to a temporary path
         1. read that file text and assert that the string written and read are the same
     """
-    # import uuid
-    # import datetime
     # file_text: str = (
     #     f"This is an automated test from the Python SDK within "
     #     f"`tests/nodes/supporting_nodes/test_file.py/test_local_file_source_upload_and_download()` "
@@ -107,32 +108,29 @@ def test_local_file_source_upload_and_download(tmp_path_factory) -> None:
     pass
 
 
-def test_create_file_local_source(tmp_path) -> None:
+@pytest.mark.skip(reason="test needs to be updated to be uploaded on api.save() instead")
+def test_create_file_local_source(tmp_path, cript_api, simple_project_node, simple_data_node) -> None:
     """
     tests that a simple file with only required attributes can be created
     with source pointing to a local file on storage
 
     create a temporary directory with temporary file
     """
-
-    # TODO since no S3 client token for GitHub CI this test will always fail. Commenting it out so tests run well
     # create a temporary file in the temporary directory to test with
+    # TODO files are now processed on save
     # file_path = tmp_path / "test.txt"
     # with open(file_path, "w") as temporary_file:
     #     temporary_file.write("hello world!")
     #
-    # assert cript.File(name="my file node with local source", source=str(file_path), type="calibration")
-    pass
-
-
-def test_file_type_invalid_vocabulary() -> None:
-    """
-    tests that setting the file type to an invalid vocabulary word gives the expected error
-
-    Returns
-    -------
-    None
-    """
+    # my_local_file = cript.File(name="my file node with local source", source=str(file_path), type="calibration")
+    #
+    # simple_project_node.name = f"test_integration_file_{uuid.uuid4().hex}"
+    #
+    # simple_project_node.collection[0].experiment[0].data = [simple_data_node]
+    #
+    # simple_project_node.collection[0].experiment[0].data[0].file = [my_local_file]
+    #
+    # cript_api.save(simple_project_node)
     pass
 
 

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -15,7 +15,7 @@ def test_create_file() -> None:
     """
     tests that a simple file with only required attributes can be created
     """
-    file_node = cript.File(name="my file name", source="https://google.com", type="calibration")
+    file_node = cript.File(name="my file name", source="https://google.com", type="calibration", extension=".csv")
 
     assert isinstance(file_node, cript.File)
 

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -58,7 +58,7 @@ def test_source_is_local(tmp_path, tmp_path_factory) -> None:
 
 
 @pytest.mark.skip(reason="test needs to be updated to be uploaded on api.save() instead")
-def test_local_file_source_upload_and_download(tmp_path_factory) -> None:
+def test_local_file_source_upload_and_download(tmp_path_factory, cript_api, simple_project_node, simple_data_node) -> None:
     """
     upload a file and download it and be sure the contents are the same
 
@@ -85,17 +85,24 @@ def test_local_file_source_upload_and_download(tmp_path_factory) -> None:
     # local_file_path.write_text(file_text)
     #
     # # create a file node with a local file path
-    # my_file = cript.File(name="my local file source node", source=str(local_file_path), type="data")
+    # my_local_file_node = cript.File(name="my local file source node", source=str(local_file_path), type="data")
+    #
+    # # assemble project to upload
+    # simple_project_node.name = f"test_file_upload_download_{uuid.uuid4().hex}"
+    #
+    # simple_project_node.collection[0].experiment[0].data = [simple_data_node]
+    #
+    # simple_project_node.collection[0].experiment[0].data[0].file = [my_local_file_node]
     #
     # # check that the file source has been uploaded to cloud storage and source has changed to reflect that
-    # assert my_file.source.startswith("tests/")
+    # assert my_local_file_node.source.startswith("tests/")
     #
     # # Get the temporary directory path and clean up handled by pytest
     # download_file_dir = tmp_path_factory.mktemp("file_test_download_file_dir")
     # download_file_name = "my_downloaded_file.txt"
     #
     # # download file
-    # my_file.download(destination_directory_path=download_file_dir, file_name=download_file_name)
+    # my_local_file_node.download(destination_directory_path=download_file_dir, file_name=download_file_name)
     #
     # # the path the file was downloaded to and can be read from
     # downloaded_local_file_path = download_file_dir / download_file_name
@@ -105,7 +112,6 @@ def test_local_file_source_upload_and_download(tmp_path_factory) -> None:
     #
     # # assert file contents for upload and download are the same
     # assert downloaded_file_contents == file_text
-    pass
 
 
 @pytest.mark.skip(reason="test needs to be updated to be uploaded on api.save() instead")
@@ -131,7 +137,6 @@ def test_create_file_local_source(tmp_path, cript_api, simple_project_node, simp
     # simple_project_node.collection[0].experiment[0].data[0].file = [my_local_file]
     #
     # cript_api.save(simple_project_node)
-    pass
 
 
 def test_file_getters_and_setters(complex_file_node) -> None:


### PR DESCRIPTION
# Description

## Changes
* made file node mandatory and every file node must have an extension
* updating tests that were not updated after refactoring of saving file during save instead of during script
* making file extension mandatory on file.py
* during download gets file name from file node instead of requiring it from the user

## Tests
* updated the tests to work with the new style of uploading during save
* using pytest.skip to ignore tests that cannot be ran during CI
* 

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
