### PR TITLE
updated db schema to validate with `POST` and `PATCH`

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -437,7 +437,7 @@ class API:
             return self._db_schema
 
     @beartype
-    def _is_node_schema_valid(self, node_json: str) -> bool:
+    def _is_node_schema_valid(self, node_json: str, is_patch: bool = False) -> bool:
         """
         checks a node JSON schema against the db schema to return if it is valid or not.
 
@@ -484,8 +484,16 @@ class API:
         else:
             raise CRIPTJsonNodeError(node_list, str(node_list))
 
+        # set the schema to test against http POST or PATCH of DB Schema
+        schema_http_method: str
+
+        if is_patch:
+            schema_http_method = "Patch"
+        else:
+            schema_http_method = "Post"
+
         # set which node you are using schema validation for
-        db_schema["$ref"] = f"#/$defs/{node_type}Post"
+        db_schema["$ref"] = f"#/$defs/{node_type}{schema_http_method}"
 
         try:
             jsonschema.validate(instance=node_dict, schema=db_schema)

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -452,6 +452,8 @@ class API:
         ----------
         node_json: str
             a node in JSON form string
+        is_patch: bool
+            a boolean flag checking if it needs to validate against `NodePost` or `NodePatch`
 
         Notes
         -----

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -134,20 +134,22 @@ def test_is_node_schema_valid(cript_api: cript.API) -> None:
     -----
     * does not test if serialization/deserialization works correctly,
     just tests if the node schema can work correctly if serialization was correct
+
+    # TODO the tests here only test POST db schema and not PATCH yet, those tests must be added
     """
 
     # ------ invalid node schema------
     invalid_schema = {"invalid key": "invalid value", "node": ["Material"]}
 
     with pytest.raises(CRIPTNodeSchemaError):
-        cript_api._is_node_schema_valid(node_json=json.dumps(invalid_schema))
+        cript_api._is_node_schema_valid(node_json=json.dumps(invalid_schema), is_patch=False)
 
     # ------ valid material schema ------
     # valid material node
     valid_material_dict = {"node": ["Material"], "name": "0.053 volume fraction CM gel", "uid": "_:0.053 volume fraction CM gel"}
 
     # convert dict to JSON string because method expects JSON string
-    assert cript_api._is_node_schema_valid(node_json=json.dumps(valid_material_dict)) is True
+    assert cript_api._is_node_schema_valid(node_json=json.dumps(valid_material_dict), is_patch=False) is True
     # ------ valid file schema ------
     valid_file_dict = {
         "node": ["File"],
@@ -158,7 +160,7 @@ def test_is_node_schema_valid(cript_api: cript.API) -> None:
     }
 
     # convert dict to JSON string because method expects JSON string
-    assert cript_api._is_node_schema_valid(node_json=json.dumps(valid_file_dict)) is True
+    assert cript_api._is_node_schema_valid(node_json=json.dumps(valid_file_dict), is_patch=False) is True
 
 
 def test_get_vocabulary_by_category(cript_api: cript.API) -> None:


### PR DESCRIPTION
# Description
Previously the db schema only ran against `NodePost`, but with this method it will work with `NodePatch` as well

## Changes
* added an optional Boolean flag in `cript.API._is_node_schema_valid` of `is_patch` and if it is then it will use the `NodePatch` and if not then it will use a `NodePost`

## Tests
* updated API DB Schema tests to work correctly with the new optional parameter

## Known Issues
* if there will also be a `NodeDelete` in the future, then we will need to update it
    * in that instance, I will opt for an enum and allow users to choose from that
* need tests for PATCH schema in the future
    * ticket: https://trello.com/c/P1KCbHZ6

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
