### PR TITLE
renamed the parameter for `cript.API.download_file` from `object_name` to `file_source`

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -644,7 +644,7 @@ class API:
         return object_name
 
     @beartype
-    def download_file(self, object_name: str, destination_path: str = ".") -> None:
+    def download_file(self, file_source: str, destination_path: str = ".") -> None:
         """
         download a file from AWS S3 and save it to the specified path on local storage
 
@@ -652,10 +652,10 @@ class API:
 
         Parameters
         ----------
-        object_name: str
-            object_name within AWS S3 the extension e.g. "my_file_name.txt
+        file_source: str
+            object_name: within AWS S3 the extension e.g. "my_file_name.txt
             the file is then searched within "Data/{file_name}" and saved to local storage
-            In case of the file source is a URL then it is the file source URL
+            URL file source: In case of the file source is a URL then it is the file source URL
                 starting with "https://"
         destination_path: str
             please provide a path with file name of where you would like the file to be saved
@@ -682,12 +682,12 @@ class API:
         """
 
         # if the file source is a URL
-        if object_name.startswith("http"):
-            download_file_from_url(url=object_name, destination_path=Path(destination_path).resolve())
+        if file_source.startswith("http"):
+            download_file_from_url(url=file_source, destination_path=Path(destination_path).resolve())
             return
 
         # the file is stored in cloud storage and must be retrieved via object_name
-        self._s3_client.download_file(Bucket=self._BUCKET_NAME, Key=object_name, Filename=destination_path)  # type: ignore
+        self._s3_client.download_file(Bucket=self._BUCKET_NAME, Key=file_source, Filename=destination_path)  # type: ignore
 
     @beartype
     def search(

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -442,4 +442,4 @@ class File(PrimaryBaseNode):
 
         absolute_file_path = str((existing_folder_path / file_name).resolve())
 
-        api.download_file(object_name=self.source, destination_path=absolute_file_path)
+        api.download_file(file_source=self.source, destination_path=absolute_file_path)

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -237,7 +237,7 @@ def test_download_file_from_url(cript_api: cript.API, tmp_path) -> None:
     # the path it will save it to will be `tmp_path/downloaded_file_name.json`
     path_to_save_file: Path = tmp_path / "downloaded_file_name"
 
-    cript_api.download_file(object_name=url_to_download_file, destination_path=str(path_to_save_file))
+    cript_api.download_file(file_source=url_to_download_file, destination_path=str(path_to_save_file))
 
     # add file extension to file path and convert it to file path object
     path_to_read_file = Path(str(path_to_save_file) + ".json").resolve()
@@ -283,7 +283,7 @@ def test_upload_and_download_local_file(cript_api, tmp_path_factory) -> None:
     download_test_file = tmp_path_factory.mktemp("test_api_file_download") / "temp_download_file.txt"
 
     # download file from cloud storage
-    cript_api.download_file(object_name=my_file_cloud_storage_object_name, destination_path=str(download_test_file))
+    cript_api.download_file(file_source=my_file_cloud_storage_object_name, destination_path=str(download_test_file))
 
     # read file contents
     downloaded_file_contents = download_test_file.read_text()


### PR DESCRIPTION
# Description
before `cript.API.download_file()` had `object_name` as parameter, which made sense because it could only download files from AWS S3, but since it can work with file URLs as well then that no longer makes sense. Changed the parameter name to `file_source`


## Changes

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
