### PR TITLE
Upgrade: Importing Fixtures Automatically into conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@ The fixtures are all functional fixtures that stay consistent between all tests.
 """
 
 import pytest
-
 from fixtures.primary_nodes import *
 from fixtures.subobjects import *
 from fixtures.supporting_nodes import *

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,69 +9,11 @@ and keeping all nodes in one file makes it easier/cleaner to create tests.
 The fixtures are all functional fixtures that stay consistent between all tests.
 """
 
-import json
-
 import pytest
-from fixtures.primary_nodes import (
-    complex_collection_node,
-    complex_data_node,
-    complex_material_dict,
-    complex_material_node,
-    complex_process_node,
-    complex_project_dict,
-    complex_project_node,
-    simple_collection_node,
-    simple_computation_node,
-    simple_computation_process_node,
-    simple_computational_process_node,
-    simple_data_node,
-    simple_experiment_node,
-    simple_inventory_node,
-    simple_material_dict,
-    simple_material_node,
-    simple_process_node,
-    simple_project_node,
-    simplest_computational_process_node,
-)
-from fixtures.subobjects import (
-    complex_algorithm_dict,
-    complex_algorithm_node,
-    complex_citation_dict,
-    complex_citation_node,
-    complex_computational_forcefield_dict,
-    complex_computational_forcefield_node,
-    complex_condition_dict,
-    complex_condition_node,
-    complex_equipment_dict,
-    complex_equipment_node,
-    complex_ingredient_dict,
-    complex_ingredient_node,
-    complex_parameter_dict,
-    complex_parameter_node,
-    complex_property_dict,
-    complex_property_node,
-    complex_quantity_dict,
-    complex_quantity_node,
-    complex_reference_dict,
-    complex_reference_node,
-    complex_software_configuration_dict,
-    complex_software_configuration_node,
-    complex_software_dict,
-    complex_software_node,
-    simple_computational_forcefield_node,
-    simple_condition_node,
-    simple_equipment_node,
-    simple_ingredient_node,
-    simple_property_dict,
-    simple_property_node,
-    simple_software_configuration,
-)
-from fixtures.supporting_nodes import (
-    complex_file_node,
-    complex_user_dict,
-    complex_user_node,
-)
-from util import strip_uid_from_dict
+
+from fixtures.primary_nodes import *
+from fixtures.subobjects import *
+from fixtures.supporting_nodes import *
 
 import cript
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# trunk-ignore-all(ruff/F401)
 """
 This conftest file contains simple nodes (nodes with minimal required arguments)
 and complex node (nodes that have all possible arguments), to use for testing.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(ruff/F403)
 """
 This conftest file contains simple nodes (nodes with minimal required arguments)
 and complex node (nodes that have all possible arguments), to use for testing.


### PR DESCRIPTION
# Description
import all fixtures in primary, subobject, and supporting nodes. This way it is imported automatically instead of being imported one at a time and if we make a new fixture, we don't have to remember to import it into conftest.py, as it will automatically get imported in

## Changes
* importing fixtures in with wildcard instead of one at a time

## Tests
* tested a few nodes to be sure there is no fixture or path error and they worked fine

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
