### PR TITLE
Knocking out `TODO` comments where possible

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -74,7 +74,7 @@ class API:
     # trunk-ignore-end(cspell)
 
     @beartype
-    def __init__(self, host: Union[str, None] = None, api_token: Union[str, None] = None, storage_token: Union[str, None] = None, config_file_path: str = ""):
+    def __init__(self, host: Union[str, None] = None, api_token: Union[str, None] = None, storage_token: Union[str, None] = None, config_file_path: Union[str, Path] = ""):
         """
         Initialize CRIPT API client with host and token.
         Additionally, you can  use a config.json file and specify the file path.
@@ -164,8 +164,7 @@ class API:
         self._api_token = api_token  # type: ignore
         self._storage_token = storage_token  # type: ignore
 
-        # assign headers
-        # add Bearer to token for HTTP, but keep it bare for AWS S3 file uploads and downloads
+        # add Bearer to token for HTTP requests
         self._http_headers = {"Authorization": f"Bearer {self._api_token}", "Content-Type": "application/json"}
 
         # check that api can connect to CRIPT with host and token

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -409,7 +409,7 @@ class File(PrimaryBaseNode):
         new_attrs = replace(self._json_attrs, data_dictionary=new_data_dictionary)
         self._update_json_attrs_if_valid(new_attrs)
 
-    # TODO get file name from node itself as default and allow for customization as well optional
+    @beartype
     def download(
         self,
         destination_directory_path: Union[str, Path] = ".",

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -115,9 +115,8 @@ def test_get_db_schema_from_api(cript_api: cript.API) -> None:
     assert bool(db_schema)
     assert isinstance(db_schema, dict)
 
-    # TODO this is constantly changing, so we can't check it for now.
-    # total_fields_in_db_schema = 69
-    # assert len(db_schema["$defs"]) == total_fields_in_db_schema
+    # db schema should have at least 30 fields
+    assert len(db_schema["$defs"]) > 30
 
 
 def test_is_node_schema_valid(cript_api: cript.API) -> None:

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -41,11 +41,10 @@ def test_api_with_invalid_host() -> None:
         cript.API(host="no_http_host.org", api_token="123456789", storage_token="987654321")
 
 
-# TODO commented out for now because it needs an API container
+@pytest.mark.skip(reason="skipping for now because it needs an API container")
 def test_api_context(cript_api: cript.API) -> None:
-    #     assert cript.api.api._global_cached_api is not None
-    #     assert cript.api.api._get_global_cached_api() is not None
-    pass
+    assert cript.api.api._global_cached_api is not None
+    assert cript.api.api._get_global_cached_api() is not None
 
 
 def test_api_cript_env_vars() -> None:

--- a/tests/fixtures/primary_nodes.py
+++ b/tests/fixtures/primary_nodes.py
@@ -163,7 +163,7 @@ def simple_process_node() -> cript.Process:
 
 
 @pytest.fixture(scope="function")
-def complex_process_node(complex_ingredient_node, simple_equipment_node, complex_citation_node, simple_property_node, simple_condition_node, simple_material_node, simple_process_node, complex_equipment_node, complex_condition_node) -> None:
+def complex_process_node(complex_ingredient_node, simple_equipment_node, complex_citation_node, simple_property_node, simple_condition_node, simple_material_node, simple_process_node) -> None:
     """
     create a process node with all possible arguments
 
@@ -171,7 +171,6 @@ def complex_process_node(complex_ingredient_node, simple_equipment_node, complex
     -----
     * indirectly tests the vocabulary as well, as it gives it valid vocabulary
     """
-    # TODO clean up this test and use fixtures from conftest.py
 
     my_process_name = "my complex process node name"
     my_process_type = "affinity_pure"
@@ -186,23 +185,19 @@ def complex_process_node(complex_ingredient_node, simple_equipment_node, complex
         "annealing_sol",
     ]
 
-    # create complex process
-    citation = copy.deepcopy(complex_citation_node)
-    prop = cript.Property("n_neighbor", "value", 2.0, None)
-
     my_complex_process = cript.Process(
         name=my_process_name,
         type=my_process_type,
         ingredient=[complex_ingredient_node],
         description=my_process_description,
-        equipment=[complex_equipment_node],
+        equipment=[simple_equipment_node],
         product=[simple_material_node],
         waste=process_waste,
         prerequisite_process=[simple_process_node],
-        condition=[complex_condition_node],
-        property=[prop],
+        condition=[simple_condition_node],
+        property=[simple_property_node],
         keyword=my_process_keywords,
-        citation=[citation],
+        citation=[complex_citation_node],
     )
 
     return my_complex_process

--- a/tests/fixtures/primary_nodes.py
+++ b/tests/fixtures/primary_nodes.py
@@ -159,7 +159,7 @@ def simple_process_node() -> cript.Process:
     """
     my_process = cript.Process(name="my process name", type="affinity_pure")
 
-    return copy.deepcopy(my_process)
+    return my_process
 
 
 @pytest.fixture(scope="function")

--- a/tests/fixtures/subobjects.py
+++ b/tests/fixtures/subobjects.py
@@ -165,13 +165,13 @@ def complex_property_dict(complex_material_node, complex_condition_dict, complex
 
 @pytest.fixture(scope="function")
 def simple_property_node() -> cript.Property:
-    p = cript.Property(
-        "modulus_shear",
-        "value",
-        5.0,
-        "GPa",
+    my_property = cript.Property(
+        key="modulus_shear",
+        type="value",
+        value=5.0,
+        unit="GPa",
     )
-    return p
+    return my_property
 
 
 @pytest.fixture(scope="function")

--- a/tests/fixtures/subobjects.py
+++ b/tests/fixtures/subobjects.py
@@ -26,7 +26,7 @@ def complex_parameter_dict() -> dict:
 
 # TODO this fixture should be renamed because it is simple_algorithm_subobject not complex
 @pytest.fixture(scope="function")
-def complex_algorithm_node() -> cript.Algorithm:
+def simple_algorithm_node() -> cript.Algorithm:
     """
     minimal algorithm sub-object
     """
@@ -36,7 +36,7 @@ def complex_algorithm_node() -> cript.Algorithm:
 
 
 @pytest.fixture(scope="function")
-def complex_algorithm_dict() -> dict:
+def simple_algorithm_dict() -> dict:
     ret_dict = {"node": ["Algorithm"], "key": "mc_barostat", "type": "barostat"}
     return ret_dict
 
@@ -165,11 +165,13 @@ def complex_property_dict(complex_material_node, complex_condition_dict, complex
 
 @pytest.fixture(scope="function")
 def simple_property_node() -> cript.Property:
-    """
-    minimalist property node that only has the required attributes
-    """
-    my_property = cript.Property(key="modulus_shear", type="value", value=5.0, unit="GPa")
-    return my_property
+    p = cript.Property(
+        "modulus_shear",
+        "value",
+        5.0,
+        "GPa",
+    )
+    return p
 
 
 @pytest.fixture(scope="function")
@@ -322,20 +324,20 @@ def complex_computational_forcefield_dict(simple_data_node, complex_citation_dic
 
 
 @pytest.fixture(scope="function")
-def complex_software_configuration_node(complex_software_node, complex_algorithm_node, complex_citation_node) -> cript.SoftwareConfiguration:
+def complex_software_configuration_node(complex_software_node, simple_algorithm_node, complex_citation_node) -> cript.SoftwareConfiguration:
     """
     maximal software_configuration sub-object with all possible attributes
     """
-    my_complex_software_configuration_node = cript.SoftwareConfiguration(software=complex_software_node, algorithm=[complex_algorithm_node], notes="my_complex_software_configuration_node notes", citation=[complex_citation_node])
+    my_complex_software_configuration_node = cript.SoftwareConfiguration(software=complex_software_node, algorithm=[simple_algorithm_node], notes="my_complex_software_configuration_node notes", citation=[complex_citation_node])
     return my_complex_software_configuration_node
 
 
 @pytest.fixture(scope="function")
-def complex_software_configuration_dict(complex_software_dict, complex_algorithm_dict, complex_citation_dict) -> dict:
+def complex_software_configuration_dict(complex_software_dict, simple_algorithm_dict, complex_citation_dict) -> dict:
     ret_dict = {
         "node": ["SoftwareConfiguration"],
         "software": complex_software_dict,
-        "algorithm": [complex_algorithm_dict],
+        "algorithm": [simple_algorithm_dict],
         "notes": "my_complex_software_configuration_node notes",
         "citation": [complex_citation_dict],
     }

--- a/tests/fixtures/subobjects.py
+++ b/tests/fixtures/subobjects.py
@@ -165,13 +165,11 @@ def complex_property_dict(complex_material_node, complex_condition_dict, complex
 
 @pytest.fixture(scope="function")
 def simple_property_node() -> cript.Property:
-    p = cript.Property(
-        "modulus_shear",
-        "value",
-        5.0,
-        "GPa",
-    )
-    return p
+    """
+    minimalist property node that only has the required attributes
+    """
+    my_property = cript.Property(key="modulus_shear", type="value", value=5.0, unit="GPa")
+    return my_property
 
 
 @pytest.fixture(scope="function")

--- a/tests/nodes/subobjects/test_algorithm.py
+++ b/tests/nodes/subobjects/test_algorithm.py
@@ -7,8 +7,8 @@ from util import strip_uid_from_dict
 import cript
 
 
-def test_setter_getter(complex_algorithm_node, complex_citation_node):
-    a = complex_algorithm_node
+def test_setter_getter(simple_algorithm_node, complex_citation_node):
+    a = simple_algorithm_node
     a.key = "berendsen"
     assert a.key == "berendsen"
     a.type = "integration"
@@ -17,16 +17,16 @@ def test_setter_getter(complex_algorithm_node, complex_citation_node):
     assert strip_uid_from_dict(json.loads(a.citation[0].json)) == strip_uid_from_dict(json.loads(complex_citation_node.json))
 
 
-def test_json(complex_algorithm_node, complex_algorithm_dict, complex_citation_node):
-    a = complex_algorithm_node
+def test_json(simple_algorithm_node, simple_algorithm_dict, complex_citation_node):
+    a = simple_algorithm_node
     a_dict = json.loads(a.json)
-    assert strip_uid_from_dict(a_dict) == complex_algorithm_dict
+    assert strip_uid_from_dict(a_dict) == simple_algorithm_dict
     print(a.get_json(indent=2).json)
     a2 = cript.load_nodes_from_json(a.json)
     assert strip_uid_from_dict(json.loads(a2.json)) == strip_uid_from_dict(a_dict)
 
 
-def test_integration_algorithm(cript_api, simple_project_node, simple_collection_node, simple_experiment_node, simple_computation_node, simple_software_configuration, complex_algorithm_node):
+def test_integration_algorithm(cript_api, simple_project_node, simple_collection_node, simple_experiment_node, simple_computation_node, simple_software_configuration, simple_algorithm_node):
     """
     integration test between Python SDK and API Client
 
@@ -42,7 +42,7 @@ def test_integration_algorithm(cript_api, simple_project_node, simple_collection
     simple_project_node.collection[0].experiment = [simple_experiment_node]
     simple_project_node.collection[0].experiment[0].computation = [simple_computation_node]
     simple_project_node.collection[0].experiment[0].computation[0].software_configuration = [simple_software_configuration]
-    simple_project_node.collection[0].experiment[0].computation[0].software_configuration[0].algorithm = [complex_algorithm_node]
+    simple_project_node.collection[0].experiment[0].computation[0].software_configuration[0].algorithm = [simple_algorithm_node]
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
 

--- a/tests/nodes/subobjects/test_parameter.py
+++ b/tests/nodes/subobjects/test_parameter.py
@@ -26,7 +26,7 @@ def test_parameter_json_serialization(complex_parameter_node, complex_parameter_
     assert p2.json == p.json
 
 
-def test_integration_parameter(cript_api, simple_project_node, simple_collection_node, simple_experiment_node, simple_computation_node, simple_software_configuration, complex_algorithm_node, complex_parameter_node):
+def test_integration_parameter(cript_api, simple_project_node, simple_collection_node, simple_experiment_node, simple_computation_node, simple_software_configuration, simple_algorithm_node, complex_parameter_node):
     """
     integration test between Python SDK and API Client
 
@@ -41,7 +41,7 @@ def test_integration_parameter(cript_api, simple_project_node, simple_collection
     simple_project_node.collection[0].experiment = [simple_experiment_node]
     simple_project_node.collection[0].experiment[0].computation = [simple_computation_node]
     simple_project_node.collection[0].experiment[0].computation[0].software_configuration = [simple_software_configuration]
-    simple_project_node.collection[0].experiment[0].computation[0].software_configuration[0].algorithm = [complex_algorithm_node]
+    simple_project_node.collection[0].experiment[0].computation[0].software_configuration[0].algorithm = [simple_algorithm_node]
     simple_project_node.collection[0].experiment[0].computation[0].software_configuration[0].algorithm[0].parameter = [complex_parameter_node]
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)

--- a/tests/nodes/subobjects/test_software_configuration.py
+++ b/tests/nodes/subobjects/test_software_configuration.py
@@ -17,14 +17,14 @@ def test_json(complex_software_configuration_node, complex_software_configuratio
     assert strip_uid_from_dict(json.loads(sc2.json)) == strip_uid_from_dict(json.loads(sc.json))
 
 
-def test_setter_getter(complex_software_configuration_node, complex_algorithm_node, complex_citation_node):
+def test_setter_getter(complex_software_configuration_node, simple_algorithm_node, complex_citation_node):
     sc2 = complex_software_configuration_node
     software2 = copy.deepcopy(sc2.software)
     sc2.software = software2
     assert sc2.software is software2
 
     # assert len(sc2.algorithm) == 1
-    # al2 = complex_algorithm_node
+    # al2 = simple_algorithm_node
     # print(sc2.get_json(indent=2,sortkeys=False).json)
     # print(al2.get_json(indent=2,sortkeys=False).json)
     # sc2.algorithm += [al2]

--- a/tests/test_node_util.py
+++ b/tests/test_node_util.py
@@ -19,16 +19,16 @@ from cript.nodes.exceptions import (
 )
 
 
-def test_removing_nodes(complex_algorithm_node, complex_parameter_node, complex_algorithm_dict):
-    a = complex_algorithm_node
+def test_removing_nodes(simple_algorithm_node, complex_parameter_node, simple_algorithm_dict):
+    a = simple_algorithm_node
     p = complex_parameter_node
     a.parameter += [p]
-    assert strip_uid_from_dict(json.loads(a.json)) != complex_algorithm_dict
+    assert strip_uid_from_dict(json.loads(a.json)) != simple_algorithm_dict
     a.remove_child(p)
-    assert strip_uid_from_dict(json.loads(a.json)) == complex_algorithm_dict
+    assert strip_uid_from_dict(json.loads(a.json)) == simple_algorithm_dict
 
 
-def test_uid_deserialization(complex_algorithm_node, complex_parameter_node, complex_algorithm_dict):
+def test_uid_deserialization(simple_algorithm_node, complex_parameter_node, simple_algorithm_dict):
     identifiers = [{"bigsmiles": "123456"}]
     material = cript.Material(name="my material", identifiers=identifiers)
 
@@ -149,8 +149,8 @@ def test_json_error(complex_parameter_node):
         parameter.json
 
 
-def test_local_search(complex_algorithm_node, complex_parameter_node):
-    a = complex_algorithm_node
+def test_local_search(simple_algorithm_node, complex_parameter_node):
+    a = simple_algorithm_node
     # Check if we can use search to find the algorithm node, but specifying node and key
     find_algorithms = a.find_children({"node": "Algorithm", "key": "mc_barostat"})
     assert find_algorithms == [a]


### PR DESCRIPTION
# Description
Knocked out a few small TODO that was left. Not a huge improvement to the project, but helps knock out some things that we've been putting aside

## Changes
* changing TODO comment with `pytest.skip`
* changed checking db schema length in test_api.py
   * instead of checking if the db schema is the exact same length, I am checking if it has more than `30` fields
   * > db schema is always changing so this test will break often, but it should have more than `30` fields because there are at least `24` nodes
* renamed `complex_algorithm_node` to `simple_algorithm_node`
  * because it was minimalistic and not maximal node with all required arguments
  *  made changes across all the tests that were using it
* changed `simple_property_node` fixture to named arguments, and added docstrings to it
* cleaned up complex_process_node fixture
  * using simple fixtures for it
  * using fixtures instead of making nodes
  * avoiding `deep_copy` as that causes issues
* allowing for Path object in api constructor for config file 
  * removed unneeded comment
* `simple_process_node` does not need deep_copy within the fixture as is more straight forward and all tests work fine without it and 

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
