### PR TITLE
UX: Node Validation Output

### DIFF
--- a/.trunk/configs/.cspell.json
+++ b/.trunk/configs/.cspell.json
@@ -99,6 +99,7 @@
     "openmm",
     "equi",
     "Navid",
-    "ipykernel"
+    "ipykernel",
+    "levelname"
   ]
 }

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import logging
 import os
 import uuid
 import warnings
@@ -475,8 +476,6 @@ class API:
             whether the node JSON is valid or not
         """
 
-        print("validating nodes")
-
         db_schema = self._get_db_schema()
 
         node_dict = json.loads(node_json)
@@ -491,6 +490,10 @@ class API:
             node_type = node_list[0]
         else:
             raise CRIPTJsonNodeError(node_list, str(node_list))
+
+        # logging out info to the terminal for the user feedback (improve UX because the program is currently slow)
+        logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
+        logging.info(f"Validating {node_type} graph...")
 
         # set the schema to test against http POST or PATCH of DB Schema
         schema_http_method: str

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -497,7 +497,7 @@ class API:
         if self.verbose:
             # logging out info to the terminal for the user feedback
             # (improve UX because the program is currently slow)
-            logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
+            logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
             logging.info(f"Validating {node_type} graph...")
 
         # set the schema to test against http POST or PATCH of DB Schema

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -55,6 +55,7 @@ class API:
     API Client class to communicate with the CRIPT API
     """
 
+    # dictates whether the user wants to see terminal log statements or not
     verbose: bool = True
 
     _host: str = ""

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -55,6 +55,8 @@ class API:
     API Client class to communicate with the CRIPT API
     """
 
+    verbose: bool = True
+
     _host: str = ""
     _api_token: str = ""
     _storage_token: str = ""
@@ -491,9 +493,11 @@ class API:
         else:
             raise CRIPTJsonNodeError(node_list, str(node_list))
 
-        # logging out info to the terminal for the user feedback (improve UX because the program is currently slow)
-        logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
-        logging.info(f"Validating {node_type} graph...")
+        if self.verbose:
+            # logging out info to the terminal for the user feedback
+            # (improve UX because the program is currently slow)
+            logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
+            logging.info(f"Validating {node_type} graph...")
 
         # set the schema to test against http POST or PATCH of DB Schema
         schema_http_method: str

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -475,6 +475,8 @@ class API:
             whether the node JSON is valid or not
         """
 
+        print("validating nodes")
+
         db_schema = self._get_db_schema()
 
         node_dict = json.loads(node_json)

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -53,6 +53,23 @@ class API:
     """
     ## Definition
     API Client class to communicate with the CRIPT API
+
+    Attributes
+    ----------
+    verbose : bool
+        A boolean flag that controls whether verbose logging is enabled or not.
+
+        When `verbose` is set to `True`, the class will provide additional detailed logging
+        to the terminal. This can be useful for debugging and understanding the internal
+        workings of the class.
+
+        When `verbose` is set to `False`, the class will only provide essential and concise
+        logging information, making the terminal output less cluttered and more user-friendly.
+
+        ```python
+        # turn off the terminal logs
+        api.verbose = False
+        ```
     """
 
     # dictates whether the user wants to see terminal log statements or not


### PR DESCRIPTION
# Description
Putting in a log statement in the package to show that the program is working in the background as the user is waiting for it to load.

## Changes
* wrote an INFO log statement to show things are happening in the background and it is not just standing still
* wrote an option to turn off the log statements if you don't want to see them
  * using the variable name of `verbose` because it is standard and well known that it is responsible for terminal logs


## Screenshots
### Terminal Output
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/1057e03e-9e91-42f9-a113-fe3041ce9b6d)

### Documentation
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/cd273afb-1640-457f-a710-188c6b7596e3)


## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
