### PR TITLE
added `is_local_file` boolean flag to File node

### DIFF
--- a/docs/examples/simulation.md
+++ b/docs/examples/simulation.md
@@ -244,10 +244,10 @@ experiment.computation += [init, equilibration, bulk, ana]
 New we'd like to upload files associated with our simulation. First, we'll instantiate our File nodes under a specific project.
 
 ```python
-packing_file = cript.File("Initial simulation box snapshot with roughly packed molecules", type="computation_snapshot", source="path/to/local/file")
-forcefield_file = cript.File(name="Forcefield definition file", type="data", source="path/to/local/file")
-snap_file = cript.File("Bulk measurement initial system snap shot", type="computation_snapshot", source="path/to/local/file")
-final_file = cript.File("Final snapshot of the system at the end the simulations", type="computation_snapshot", source="path/to/local/file")
+packing_file = cript.File("Initial simulation box snapshot with roughly packed molecules", type="computation_snapshot", source="path/to/local/file", is_local_file=True)
+forcefield_file = cript.File(name="Forcefield definition file", type="data", source="path/to/local/file", is_local_file=True)
+snap_file = cript.File("Bulk measurement initial system snap shot", type="computation_snapshot", source="path/to/local/file", is_local_file=True)
+final_file = cript.File("Final snapshot of the system at the end the simulations", type="computation_snapshot", source="path/to/local/file", is_local_file=True)
 ```
 
 !!! note

--- a/tests/fixtures/supporting_nodes.py
+++ b/tests/fixtures/supporting_nodes.py
@@ -11,7 +11,7 @@ def complex_file_node() -> cript.File:
     """
     complex file node with only required arguments
     """
-    my_file = cript.File(name="my complex file node fixture", source="https://criptapp.org", type="calibration", extension=".csv", data_dictionary="my file's data dictionary")
+    my_file = cript.File(name="my complex file node fixture", source="https://criptapp.org", type="calibration", extension=".csv", data_dictionary="my file's data dictionary", is_local_file=False)
 
     return my_file
 

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -13,7 +13,7 @@ def test_create_file() -> None:
     """
     tests that a simple file with only required attributes can be created
     """
-    file_node = cript.File(name="my file name", source="https://google.com", type="calibration")
+    file_node = cript.File(name="my file name", source="https://google.com", type="calibration", is_local_file=False)
 
     assert isinstance(file_node, cript.File)
 
@@ -151,7 +151,7 @@ def test_file_getters_and_setters(complex_file_node) -> None:
     new_data_dictionary = "new data dictionary"
 
     # ------- set properties -------
-    complex_file_node.source = new_source
+    complex_file_node.source_setter(new_source=new_source, is_local_file=False)
     complex_file_node.type = new_file_type
     complex_file_node.extension = new_file_extension
     complex_file_node.data_dictionary = new_data_dictionary


### PR DESCRIPTION
# Description
added `is_local_file` boolean flag to File node so the user can specify if their file is local or not manually

## Changes
* this effects the constructor to file node during creation
 * the source property setter is replaced with a function

## Tests
 * changed tests for it to work well, however, there is an issue where deep_copy will not work for the file node
 * did not run an entire complete test, but just ran the file tests to be sure it is working well

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
