### PR TITLE
code clean up: `cript.API._is_node_schema_valid` getting node type from utility function

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -31,7 +31,7 @@ from cript.api.utils.save_helper import (
 from cript.api.utils.web_file_downloader import download_file_from_url
 from cript.api.valid_search_modes import SearchModes
 from cript.api.vocabulary_categories import ControlledVocabularyCategories
-from cript.nodes.exceptions import CRIPTJsonNodeError, CRIPTNodeSchemaError
+from cript.nodes.exceptions import CRIPTNodeSchemaError
 from cript.nodes.primary_nodes.project import Project
 
 # Do not use this directly! That includes devs.

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -21,6 +21,7 @@ from cript.api.exceptions import (
 )
 from cript.api.paginator import Paginator
 from cript.api.utils.get_host_token import resolve_host_and_token
+from cript.api.utils.helper_functions import _get_node_type_from_json
 from cript.api.utils.save_helper import (
     _fix_node_save,
     _get_uuid_from_error_message,
@@ -477,18 +478,9 @@ class API:
 
         db_schema = self._get_db_schema()
 
-        node_dict = json.loads(node_json)
-        try:
-            node_list = node_dict["node"]
-        except KeyError:
-            raise CRIPTJsonNodeError(node_list=node_dict["node"], json_str=json.dumps(node_dict))
+        node_type: str = _get_node_type_from_json(node_json=node_json)
 
-        # TODO should use the `_is_node_field_valid()` function from utils.py to keep the code DRY
-        # checking the node field "node": "Material"
-        if isinstance(node_list, list) and len(node_list) == 1 and isinstance(node_list[0], str):
-            node_type = node_list[0]
-        else:
-            raise CRIPTJsonNodeError(node_list, str(node_list))
+        node_dict = json.loads(node_json)
 
         # set the schema to test against http POST or PATCH of DB Schema
         schema_http_method: str

--- a/src/cript/api/utils/__init__.py
+++ b/src/cript/api/utils/__init__.py
@@ -1,3 +1,4 @@
 # trunk-ignore-all(ruff/F401)
 
 from .get_host_token import resolve_host_and_token
+from .helper_functions import _get_node_type_from_json

--- a/src/cript/api/utils/helper_functions.py
+++ b/src/cript/api/utils/helper_functions.py
@@ -1,0 +1,44 @@
+import json
+from typing import Dict, List, Union
+
+from cript.nodes.exceptions import CRIPTJsonNodeError
+from cript.nodes.util import _is_node_field_valid
+
+
+def _get_node_type_from_json(node_json: Union[Dict, str]) -> str:
+    """
+    takes a node JSON and output the node_type `Project`, `Material`, etc.
+
+    1. convert node JSON dict or str to dict
+    1. do check the node list to be sure it only has a single type in it
+    1. get the node type and return it
+
+    Parameters
+    ----------
+    node_json: [Dict, str]
+
+    Notes
+    -----
+    Takes a str or dict to be more versatile
+
+    Returns
+    -------
+    str:
+        node type
+    """
+    # convert all JSON node strings to dict for easier handling
+    if isinstance(node_json, str):
+        node_json: Dict = json.loads(node_json)
+
+    try:
+        node_type_list: List[str] = node_json["node"]
+    except KeyError:
+        raise CRIPTJsonNodeError(node_list=node_json["node"], json_str=json.dumps(node_json))
+
+    # check to be sure the node list has a single type "node": ["Material"]
+    if _is_node_field_valid(node_type_list=node_type_list):
+        return node_type_list[0]
+
+    # if invalid then raise error
+    else:
+        raise CRIPTJsonNodeError(node_list=node_type_list, json_str=str(node_json))

--- a/src/cript/api/utils/helper_functions.py
+++ b/src/cript/api/utils/helper_functions.py
@@ -28,12 +28,11 @@ def _get_node_type_from_json(node_json: Union[Dict, str]) -> str:
     """
     # convert all JSON node strings to dict for easier handling
     if isinstance(node_json, str):
-        node_json: Dict = json.loads(node_json)
-
+        node_json = json.loads(node_json)
     try:
-        node_type_list: List[str] = node_json["node"]
+        node_type_list: List[str] = node_json["node"]   # type: ignore
     except KeyError:
-        raise CRIPTJsonNodeError(node_list=node_json["node"], json_str=json.dumps(node_json))
+        raise CRIPTJsonNodeError(node_list=node_json["node"], json_str=json.dumps(node_json))   # type: ignore
 
     # check to be sure the node list has a single type "node": ["Material"]
     if _is_node_field_valid(node_type_list=node_type_list):

--- a/src/cript/api/utils/helper_functions.py
+++ b/src/cript/api/utils/helper_functions.py
@@ -30,9 +30,9 @@ def _get_node_type_from_json(node_json: Union[Dict, str]) -> str:
     if isinstance(node_json, str):
         node_json = json.loads(node_json)
     try:
-        node_type_list: List[str] = node_json["node"]   # type: ignore
+        node_type_list: List[str] = node_json["node"]  # type: ignore
     except KeyError:
-        raise CRIPTJsonNodeError(node_list=node_json["node"], json_str=json.dumps(node_json))   # type: ignore
+        raise CRIPTJsonNodeError(node_list=node_json["node"], json_str=json.dumps(node_json))  # type: ignore
 
     # check to be sure the node list has a single type "node": ["Material"]
     if _is_node_field_valid(node_type_list=node_type_list):


### PR DESCRIPTION
# Description
refactoring `cript.API._is_node_schema_valid`

## Changes
taking the getting of node type from JSON and putting it into its own function that can be easily called and make the code cleaner

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
