### PR TITLE
Fix documentation broken links

### DIFF
--- a/docs/examples/simulation.md
+++ b/docs/examples/simulation.md
@@ -251,7 +251,7 @@ final_file = cript.File("Final snapshot of the system at the end the simulations
 ```
 
 !!! note
-    The [source field](field should point to any ) should point to any file on your local filesystem.
+    The [source field](../../nodes/supporting_nodes/file/#cript.nodes.supporting_nodes.file.File.source) should point to any file on your local filesystem.
 
 !!! info
     Depending on the file size, there could be a delay while the checksum is generated.
@@ -381,7 +381,7 @@ polystyrene.computational_forcefield = forcefield
 ```
 
 !!! note "Computational forcefield keys"
-    The allowed [`ComputationalForcefield`](../../subobjects/computational_forcefield/) keys are listed under the [computational forcefield keys](https://criptapp.org/keys/computational-forcefield-key/) in the CRIPT controlled vocabulary.
+    The allowed [`ComputationalForcefield`](../../nodes/subobjects/computational_forcefield/) keys are listed under the [computational forcefield keys](https://criptapp.org/keys/computational-forcefield-key/) in the CRIPT controlled vocabulary.
 
 Now we can save the project to CRIPT (and upload the files) or inspect the JSON output
 

--- a/docs/examples/synthesis.md
+++ b/docs/examples/synthesis.md
@@ -188,7 +188,7 @@ workup_qty = cript.Quantity(key="volume", value=0.1, unit="m**3")
 
 Now we can create an [Ingredient](../../nodes/subobjects/ingredient)
 node for each ingredient using the [Material](../../nodes/primary_nodes/material)
-and [quantities](../../nodes/subobjects/quantities) attributes.
+and [quantities](../../nodes/subobjects/quantity) attributes.
 
 ```python
 initiator = cript.Ingredient(

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,6 @@ CRIPT offers multiple options to upload data, and scientists can pick the method
 
 Another great option can be the [Excel Uploader](https://c-accel-cript.github.io/cript-excel-uploader/) for scientists that do not have past Python experience or would rather easily input their data into the CRIPT Excel Template.
 
-This documentation shows how to [quickly get started](./quickstart/) with the SDK, describes the various Python methods for interacting with the [API](./api/), and provides definitions and source code for [Nodes](./data_model/nodes/) and [Subobjects](./data_model/subobjects/) from the CRIPT Data Model.
-
 ---
 
 ## Resources
@@ -16,8 +14,6 @@ This documentation shows how to [quickly get started](./quickstart/) with the SD
 
     - [CRIPT Data Model](https://chemrxiv.org/engage/api-gateway/chemrxiv/assets/orp/resource/item/6322994103e27d9176d5b10c/original/main-supporting-information.pdf)
         - The CRIPT Data Model is the back bone of the whole CRIPT project. Understanding it will make it a lot easier to use any part of the system
-    - [CRIPT Manual](https://criptapp.org/docs/manual/)
-        -  Full in depth and complete tutorial of everything CRIPT has to offer
     - [CRIPT Scripts Research paper](https://pubs.acs.org/doi/10.1021/acscentsci.3c00011)
         - Learn about the CRIPT platform
     - [CRIPTScripts](https://criptscripts.org/)

--- a/src/cript/nodes/primary_nodes/collection.py
+++ b/src/cript/nodes/primary_nodes/collection.py
@@ -18,11 +18,11 @@ class Collection(PrimaryBaseNode):
     A Collection node can be thought as a folder/bucket that can hold [experiment](../experiment)
     or [Inventories](../inventory) node.
 
-    | attribute   | type             | example             | description                                                                    |
-    |-------------|------------------|---------------------|--------------------------------------------------------------------------------|
-    | experiment | list[Experiment] |                     | experiment that relate to the collection                                      |
-    | inventory | list[Inventory]  |                     | inventory owned by the collection                                              |
-    | doi       | str              | `10.1038/1781168a0` | DOI: digital object identifier for a published collection; CRIPT generated DOI |
+    | attribute  | type             | example             | description                                                                    |
+    |------------|------------------|---------------------|--------------------------------------------------------------------------------|
+    | experiment | list[Experiment] |                     | experiment that relate to the collection                                       |
+    | inventory  | list[Inventory]  |                     | inventory owned by the collection                                              |
+    | doi        | str              | `10.1038/1781168a0` | DOI: digital object identifier for a published collection; CRIPT generated DOI |
     | citation   | list[Citation]   |                     | reference to a book, paper, or scholarly work                                  |
 
 
@@ -37,9 +37,7 @@ class Collection(PrimaryBaseNode):
      "experiment":[
         {
            "name":"my experiment name",
-           "node":[
-              "Experiment"
-           ],
+           "node":["Experiment"],
            "uid":"_:8256b75b-1f4e-4f69-9fe6-3bcb2298e470",
            "uuid":"8256b75b-1f4e-4f69-9fe6-3bcb2298e470"
         }

--- a/src/cript/nodes/primary_nodes/experiment.py
+++ b/src/cript/nodes/primary_nodes/experiment.py
@@ -15,15 +15,15 @@ class Experiment(PrimaryBaseNode):
 
     ## Attributes
 
-    | attribute                | type                         | description                                               | required |
-    |--------------------------|------------------------------|-----------------------------------------------------------|----------|
-    | collection               | Collection                   | collection associated with the experiment                 | True     |
-    | process                | List[Process]                | process nodes associated with this experiment             | False     |
-    | computations             | List[Computation]            | computation method nodes associated with this experiment  | False     |
-    | computation_process | List[Computational  Process] | computation process nodes associated with this experiment | False     |
-    | data                     | List[Data]                   | data nodes associated with this experiment                | False     |
-    | funding                  | List[str]                    | funding source for experiment                             | False     |
-    | citation                | List[Citation]               | reference to a book, paper, or scholarly work             | False     |
+    | attribute           | type                         | description                                               | required |
+    |---------------------|------------------------------|-----------------------------------------------------------|----------|
+    | collection          | Collection                   | collection associated with the experiment                 | True     |
+    | process             | List[Process]                | process nodes associated with this experiment             | False    |
+    | computations        | List[Computation]            | computation method nodes associated with this experiment  | False    |
+    | computation_process | List[Computational  Process] | computation process nodes associated with this experiment | False    |
+    | data                | List[Data]                   | data nodes associated with this experiment                | False    |
+    | funding             | List[str]                    | funding source for experiment                             | False    |
+    | citation            | List[Citation]               | reference to a book, paper, or scholarly work             | False    |
 
 
     ## Subobjects

--- a/src/cript/nodes/primary_nodes/experiment.py
+++ b/src/cript/nodes/primary_nodes/experiment.py
@@ -33,10 +33,10 @@ class Experiment(PrimaryBaseNode):
 
     * [Process](../process)
     * [Computations](../computation)
-    * [Computation_Process](../computational_process)
+    * [Computation_Process](../computation_process)
     * [Data](../data)
-    * [Funding](../funding)
-    * [Citation](../citation)
+    * [Funding](./#cript.nodes.primary_nodes.experiment.Experiment.funding)
+    * [Citation](../../subobjects/citation)
 
 
     Warnings

--- a/src/cript/nodes/primary_nodes/experiment.py
+++ b/src/cript/nodes/primary_nodes/experiment.py
@@ -234,7 +234,7 @@ class Experiment(PrimaryBaseNode):
     @beartype
     def computation_process(self) -> List[Any]:
         """
-        List of [computation_process](../computational_process) for this experiment
+        List of [computation_process](../computation_process) for this experiment
 
         Examples
         --------

--- a/src/cript/nodes/primary_nodes/experiment.py
+++ b/src/cript/nodes/primary_nodes/experiment.py
@@ -364,7 +364,7 @@ class Experiment(PrimaryBaseNode):
     @beartype
     def citation(self) -> List[Any]:
         """
-        List of [citation](../citation) for this experiment
+        List of [citation](../../subobjects/citation) for this experiment
 
         Examples
         --------

--- a/src/cript/nodes/primary_nodes/material.py
+++ b/src/cript/nodes/primary_nodes/material.py
@@ -16,15 +16,15 @@ class Material(PrimaryBaseNode):
     is just the materials used within an project/experiment.
 
     ## Attributes
-    | attribute                 | type                                                   | example                                           | description                                  | required    | vocab |
-    |---------------------------|--------------------------------------------------------|---------------------------------------------------|----------------------------------------------|-------------|-------|
-    | identifiers               | list[Identifier]                                       |                                                   | material identifiers                         | True        |       |
-    | component                 | list[[Material](./)]                                   |                                                   | list of component that make up the mixture   |             |       |
-    | property                  | list[[Property](../subobjects/property)]               |                                                   | material properties                          |             |       |
-    | process                   | [Process](../process)                                  |                                                   | process node that made this material         |             |       |
-    | parent_material           | [Material](./)                                         |                                                   | material node that this node was copied from |             |       |
-    | computational_ forcefield | [Computation  Forcefield](../computational_forcefield) |                                                   | computation forcefield                       | Conditional |       |
-    | keyword                   | list[str]                                              | [thermoplastic, homopolymer, linear, polyolefins] | words that classify the material             |             | True  |
+    | attribute                 | type                                                                 | example                                           | description                                  | required    | vocab |
+    |---------------------------|----------------------------------------------------------------------|---------------------------------------------------|----------------------------------------------|-------------|-------|
+    | identifiers               | list[Identifier]                                                     |                                                   | material identifiers                         | True        |       |
+    | component                 | list[[Material](./)]                                                 |                                                   | list of component that make up the mixture   |             |       |
+    | property                  | list[[Property](../../subobjects/property)]                          |                                                   | material properties                          |             |       |
+    | process                   | [Process](../process)                                                |                                                   | process node that made this material         |             |       |
+    | parent_material           | [Material](./)                                                       |                                                   | material node that this node was copied from |             |       |
+    | computational_ forcefield | [Computation  Forcefield](../../subobjects/computational_forcefield) |                                                   | computation forcefield                       | Conditional |       |
+    | keyword                   | list[str]                                                            | [thermoplastic, homopolymer, linear, polyolefins] | words that classify the material             |             | True  |
 
     ## Navigating to Material
     Materials can be easily found on the [CRIPT](https://criptapp.org) home screen in the

--- a/src/cript/nodes/primary_nodes/process.py
+++ b/src/cript/nodes/primary_nodes/process.py
@@ -212,7 +212,7 @@ class Process(PrimaryBaseNode):
     @beartype
     def ingredient(self) -> List[Any]:
         """
-        List of [ingredient](../../subobjects/ingredients) for this process
+        List of [ingredient](../../subobjects/ingredient) for this process
 
         Examples
         ---------

--- a/src/cript/nodes/primary_nodes/project.py
+++ b/src/cript/nodes/primary_nodes/project.py
@@ -15,7 +15,7 @@ class Project(PrimaryBaseNode):
     A [Project](https://pubs.acs.org/doi/suppl/10.1021/acscentsci.3c00011/suppl_file/oc3c00011_si_001.pdf#page=7)
     is the highest level node that is Not nested inside any other node.
     A Project can be thought of as a folder that can contain [Collections](../collection) and
-    [Materials](../materials).
+    [Materials](../material).
 
 
     | attribute   | type             | description                            |


### PR DESCRIPTION
# Description
Fixed Broken links found within the documentation

## Changes
* found and fixed broken links
* formatted attribution tables
* removed last section from home page of documentation because there was nothing for me to replace it with currently

## Tests

## Known Issues

## Notes
Wrote a [wiki section on discovering and fixing broken links within the documentation](https://github.com/C-Accel-CRIPT/Python-SDK/wiki/Documentation#fixing-broken-links). This strategy works for now, however, ideally, we'd want to check all broken links in CI and get a notification as soon as something breaks for us to fix, so there will never be a broken link in the documentation pages

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
