### PR TITLE
removing print statement from `cript.API.search()`

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -826,7 +826,6 @@ class API:
 
         # get node typ from class
         node_type = node_type.node_type_snake_case
-        print(node_type)
 
         # always putting a page parameter of 0 for all search URLs
         page_number = 0


### PR DESCRIPTION
# Description
found a print statement that was left in from development and was unintentionally printing to terminal

## Changes

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
