### PR TITLE
added vocabulary links to all nodes in documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,8 @@ nav:
       - API Exceptions: exceptions/api_exceptions.md
       - Node Exceptions: exceptions/node_exceptions.md
   - FAQ: faq.md
+  - Internal Wiki Documentation: https://github.com/C-Accel-CRIPT/Python-SDK/wiki
+  - CRIPT Python SDK Discussions: https://github.com/C-Accel-CRIPT/Python-SDK/discussions
 
 theme:
   name: material

--- a/src/cript/nodes/primary_nodes/computation.py
+++ b/src/cript/nodes/primary_nodes/computation.py
@@ -163,7 +163,8 @@ class Computation(PrimaryBaseNode):
         """
         The type of computation
 
-        the computation type must come from CRIPT controlled vocabulary
+        The [computation type](https://www.mycriptapp.org/vocab/computation_type)
+        must come from CRIPT controlled vocabulary
 
         Examples
         --------

--- a/src/cript/nodes/primary_nodes/computation_process.py
+++ b/src/cript/nodes/primary_nodes/computation_process.py
@@ -252,7 +252,8 @@ class ComputationProcess(PrimaryBaseNode):
     @beartype
     def type(self) -> str:
         """
-        The computational process type must come from CRIPT Controlled vocabulary
+        The [computational process type](https://www.mycriptapp.org/vocab/computational_process_type)
+        must come from CRIPT Controlled vocabulary
 
         Examples
         --------

--- a/src/cript/nodes/primary_nodes/data.py
+++ b/src/cript/nodes/primary_nodes/data.py
@@ -144,7 +144,7 @@ class Data(PrimaryBaseNode):
     @beartype
     def type(self) -> str:
         """
-        Type of data node. The data type must come from [CRIPT data type vocabulary]()
+        The data type must come from [CRIPT data type vocabulary](https://www.mycriptapp.org/vocab/data_type)
 
         Example
         -------

--- a/src/cript/nodes/primary_nodes/material.py
+++ b/src/cript/nodes/primary_nodes/material.py
@@ -174,6 +174,9 @@ class Material(PrimaryBaseNode):
         my_material.identifier = {"alternative_names": "my material alternative name"}
         ```
 
+        [material identifier key](https://www.mycriptapp.org/vocab/material_identifier_key)
+        must come from CRIPT controlled vocabulary
+
         Returns
         -------
         List[Dict[str, str]]

--- a/src/cript/nodes/primary_nodes/material.py
+++ b/src/cript/nodes/primary_nodes/material.py
@@ -322,7 +322,7 @@ class Material(PrimaryBaseNode):
         List of keyword for this material
 
         the material keyword must come from the
-        [CRIPT controlled vocabulary](https://criptapp.org/keys/material-keyword/)
+        [CRIPT controlled vocabulary](https://www.mycriptapp.org/vocab/material_keyword)
 
         ```python
         identifiers = [{"alternative_names": "my material alternative name"}]

--- a/src/cript/nodes/primary_nodes/process.py
+++ b/src/cript/nodes/primary_nodes/process.py
@@ -178,7 +178,7 @@ class Process(PrimaryBaseNode):
     @beartype
     def type(self) -> str:
         """
-        Process type must come from the [CRIPT controlled vocabulary](https://criptapp.org/keys/process-type/)
+        [Process type](https://www.mycriptapp.org/vocab/process_type) must come from the CRIPT controlled vocabulary
 
         Examples
         --------

--- a/src/cript/nodes/primary_nodes/reference.py
+++ b/src/cript/nodes/primary_nodes/reference.py
@@ -178,7 +178,10 @@ class Reference(UUIDBaseNode):
     @beartype
     def type(self) -> str:
         """
-        type of reference. The reference type must come from the CRIPT controlled vocabulary
+        Type of reference.
+
+        The [reference type](https://www.mycriptapp.org/vocab/reference_type)
+        must come from the CRIPT controlled vocabulary
 
         Examples
         --------

--- a/src/cript/nodes/subobjects/algorithm.py
+++ b/src/cript/nodes/subobjects/algorithm.py
@@ -114,7 +114,7 @@ class Algorithm(UUIDBaseNode):
         """
         Algorithm key
 
-        > Algorithm key must come from [CRIPT controlled vocabulary]()
+        Algorithm key must come from [CRIPT controlled vocabulary](https://www.mycriptapp.org/vocab/algorithm_key)
 
         Examples
         --------

--- a/src/cript/nodes/subobjects/citation.py
+++ b/src/cript/nodes/subobjects/citation.py
@@ -115,7 +115,7 @@ class Citation(UUIDBaseNode):
         """
         Citation type subobject
 
-        > Note: Citation type must come from [CRIPT Controlled Vocabulary]()
+        Citation type must come from [CRIPT Controlled Vocabulary](https://www.mycriptapp.org/vocab/citation_type)
 
         Examples
         --------

--- a/src/cript/nodes/subobjects/computational_forcefield.py
+++ b/src/cript/nodes/subobjects/computational_forcefield.py
@@ -158,7 +158,8 @@ class ComputationalForcefield(UUIDBaseNode):
         """
         type of forcefield
 
-        > Computational_Forcefield key must come from [CRIPT Controlled Vocabulary]()
+        Computational_Forcefield key must come from
+        [CRIPT Controlled Vocabulary](https://www.mycriptapp.org/vocab/computational_forcefield_key)
 
         Examples
         --------
@@ -197,7 +198,8 @@ class ComputationalForcefield(UUIDBaseNode):
         """
         type of building block
 
-        > Computational_Forcefield building_block must come from [CRIPT Controlled Vocabulary]()
+        Computational_Forcefield building_block must come from
+        [CRIPT Controlled Vocabulary](https://www.mycriptapp.org/vocab/building_block)
 
         Examples
         --------

--- a/src/cript/nodes/subobjects/condition.py
+++ b/src/cript/nodes/subobjects/condition.py
@@ -174,7 +174,7 @@ class Condition(UUIDBaseNode):
         """
         type of condition
 
-        > Condition key must come from [CRIPT Controlled Vocabulary]()
+        > Condition key must come from [CRIPT Controlled Vocabulary](https://www.mycriptapp.org/vocab/condition_key)
 
         Examples
         --------
@@ -394,6 +394,8 @@ class Condition(UUIDBaseNode):
     def uncertainty_type(self) -> str:
         """
         Uncertainty type for the uncertainty value
+
+        [Uncertainty type](https://www.mycriptapp.org/vocab/uncertainty_type) must come from CRIPT controlled vocabulary
 
         Examples
         --------

--- a/src/cript/nodes/subobjects/equipment.py
+++ b/src/cript/nodes/subobjects/equipment.py
@@ -104,7 +104,7 @@ class Equipment(UUIDBaseNode):
         """
         scientific instrument
 
-        > Equipment key must come from [CRIPT Controlled Vocabulary]()
+        Equipment key must come from [CRIPT Controlled Vocabulary](https://www.mycriptapp.org/vocab/equipment_key)
 
         Examples
         --------

--- a/src/cript/nodes/subobjects/ingredient.py
+++ b/src/cript/nodes/subobjects/ingredient.py
@@ -184,7 +184,8 @@ class Ingredient(UUIDBaseNode):
     @beartype
     def keyword(self) -> List[str]:
         """
-        ingredient keyword must come from the [CRIPT controlled vocabulary]()
+        ingredient keyword must come from the
+        [CRIPT controlled vocabulary](https://www.mycriptapp.org/vocab/ingredient_keyword)
 
         Examples
         --------

--- a/src/cript/nodes/subobjects/parameter.py
+++ b/src/cript/nodes/subobjects/parameter.py
@@ -111,7 +111,7 @@ class Parameter(UUIDBaseNode):
     @beartype
     def key(self) -> str:
         """
-        Parameter key must come from the [CRIPT Controlled Vocabulary]()
+        Parameter key must come from the [CRIPT Controlled Vocabulary](https://www.mycriptapp.org/vocab/parameter_key)
 
         Examples
         --------

--- a/src/cript/nodes/subobjects/property.py
+++ b/src/cript/nodes/subobjects/property.py
@@ -193,7 +193,7 @@ class Property(UUIDBaseNode):
     @beartype
     def key(self) -> str:
         """
-        Property key must come from [CRIPT Controlled Vocabulary]()
+        Property key must come from [CRIPT Controlled Vocabulary](https://www.mycriptapp.org/vocab/)
 
         Examples
         --------
@@ -231,6 +231,8 @@ class Property(UUIDBaseNode):
     def type(self) -> str:
         """
         type of value for this Property sub-object
+
+        [property type](https://www.mycriptapp.org/vocab/) must come from CRIPT controlled vocabulary
 
         Examples
         ```python
@@ -359,7 +361,8 @@ class Property(UUIDBaseNode):
         """
         get the uncertainty_type for this Property subobject
 
-        Uncertainty type must come from [CRIPT Controlled Vocabulary]()
+        [Uncertainty type](https://www.mycriptapp.org/vocab/uncertainty_type)
+        must come from CRIPT Controlled Vocabulary
 
         Returns
         -------
@@ -453,7 +456,7 @@ class Property(UUIDBaseNode):
         """
         approach or source of property data True sample_preparation Process sample preparation
 
-        Property method must come from [CRIPT Controlled Vocabulary]()
+        [Property method](https://www.mycriptapp.org/vocab/property_method) must come from CRIPT Controlled Vocabulary
 
         Examples
         --------

--- a/src/cript/nodes/subobjects/quantity.py
+++ b/src/cript/nodes/subobjects/quantity.py
@@ -141,6 +141,8 @@ class Quantity(UUIDBaseNode):
         """
         get the Quantity sub-object key attribute
 
+        [Quantity type](https://www.mycriptapp.org/vocab/quantity_key) must come from CRIPT controlled vocabulary
+
         Returns
         -------
         str
@@ -217,7 +219,7 @@ class Quantity(UUIDBaseNode):
         """
         get the uncertainty type attribute for the Quantity sub-object
 
-        `uncertainty_type` must come from [CRIPT Controlled Vocabulary]()
+        [Uncertainty type](https://www.mycriptapp.org/vocab/uncertainty_type) must come from CRIPT controlled vocabulary
 
         Returns
         -------

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -280,7 +280,7 @@ class File(PrimaryBaseNode):
     @beartype
     def type(self) -> str:
         """
-        The [File type]() must come from [CRIPT controlled vocabulary]()
+        The [File type](https://www.mycriptapp.org/vocab/file_type) must come from CRIPT controlled vocabulary
 
         Example
         -------


### PR DESCRIPTION
# Description
added vocabulary links to documentation of where users can get the vocab for each attribute.

## Changes

## Tests

## Known Issues

## Notes
If I could make the site url a variable and refer to it instead of having to hardcode it, then that would be the best because I could just change the domain to production and I am simply done. But I could not figure that out.

`mkdocs.yaml`
```yaml
site_domain: https://mycriptapp.org
```

`docstring`
```
[my link]({{ site_domain}}/about/)
```

I tried Jinja, [macro plugin](https://mkdocs-macros-plugin.readthedocs.io/en/latest/) but I was not able to get it to work

I ended up [leaving a question on mkdocs discussion board](https://github.com/squidfunk/mkdocs-material/discussions/5775) for now and will hopefully get an answer soon.

Looked through stackoverflow and found no answers

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
