### PR TITLE
refactor enum name from `ControlledVocabularyCategories` to `VocabCategories`

### DIFF
--- a/docs/api/controlled_vocabulary_categories.md
+++ b/docs/api/controlled_vocabulary_categories.md
@@ -1,1 +1,1 @@
-::: cript.ControlledVocabularyCategories
+::: cript.VocabCategories

--- a/src/cript/__init__.py
+++ b/src/cript/__init__.py
@@ -8,7 +8,7 @@ from beartype.roar import BeartypeDecorHintPep585DeprecationWarning
 
 filterwarnings("ignore", category=BeartypeDecorHintPep585DeprecationWarning)
 
-from cript.api import API, VocabCategories, SearchModes
+from cript.api import API, SearchModes, VocabCategories
 from cript.exceptions import CRIPTException
 from cript.nodes import (
     Algorithm,

--- a/src/cript/__init__.py
+++ b/src/cript/__init__.py
@@ -8,7 +8,7 @@ from beartype.roar import BeartypeDecorHintPep585DeprecationWarning
 
 filterwarnings("ignore", category=BeartypeDecorHintPep585DeprecationWarning)
 
-from cript.api import API, ControlledVocabularyCategories, SearchModes
+from cript.api import API, VocabCategories, SearchModes
 from cript.exceptions import CRIPTException
 from cript.nodes import (
     Algorithm,

--- a/src/cript/api/__init__.py
+++ b/src/cript/api/__init__.py
@@ -2,4 +2,4 @@
 
 from cript.api.api import API
 from cript.api.valid_search_modes import SearchModes
-from cript.api.vocabulary_categories import ControlledVocabularyCategories
+from cript.api.vocabulary_categories import VocabCategories

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -31,7 +31,7 @@ from cript.api.utils.save_helper import (
 )
 from cript.api.utils.web_file_downloader import download_file_from_url
 from cript.api.valid_search_modes import SearchModes
-from cript.api.vocabulary_categories import ControlledVocabularyCategories
+from cript.api.vocabulary_categories import VocabCategories
 from cript.nodes.exceptions import CRIPTNodeSchemaError
 from cript.nodes.primary_nodes.project import Project
 
@@ -387,7 +387,7 @@ class API:
 
         # loop through all vocabulary categories and make a request to each vocabulary category
         # and put them all inside of self._vocab with the keys being the vocab category name
-        for category in ControlledVocabularyCategories:
+        for category in VocabCategories:
             if category in self._vocabulary:
                 continue
 
@@ -396,7 +396,7 @@ class API:
         return self._vocabulary
 
     @beartype
-    def get_vocab_by_category(self, category: ControlledVocabularyCategories) -> List[dict]:
+    def get_vocab_by_category(self, category: VocabCategories) -> List[dict]:
         """
         get the CRIPT controlled vocabulary by category
 
@@ -428,7 +428,7 @@ class API:
         return self._vocabulary[category.value]
 
     @beartype
-    def _is_vocab_valid(self, vocab_category: ControlledVocabularyCategories, vocab_word: str) -> bool:
+    def _is_vocab_valid(self, vocab_category: VocabCategories, vocab_word: str) -> bool:
         """
         checks if the vocabulary is valid within the CRIPT controlled vocabulary.
         Either returns True or InvalidVocabulary Exception
@@ -440,7 +440,7 @@ class API:
 
         Parameters
         ----------
-        vocab_category: ControlledVocabularyCategories
+        vocab_category: VocabCategories
             ControlledVocabularyCategories enums
         vocab_word: str
             the vocabulary word e.g. "CAS", "SMILES", "BigSmiles", "+my_custom_key"

--- a/src/cript/api/vocabulary_categories.py
+++ b/src/cript/api/vocabulary_categories.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class ControlledVocabularyCategories(Enum):
     """
-    All available CRIPT controlled vocabulary categories
+    All available [CRIPT controlled vocabulary categories](https://www.mycriptapp.org/vocab/)
 
     Controlled vocabulary categories are used to classify data.
 
@@ -66,7 +66,7 @@ class ControlledVocabularyCategories(Enum):
     --------
     ```python
     algorithm_vocabulary = api.get_vocabulary_by_category(
-        ControlledVocabularyCategories.ALGORITHM_KEY
+        cript.ControlledVocabularyCategories.ALGORITHM_KEY
         )
     ```
     """

--- a/src/cript/api/vocabulary_categories.py
+++ b/src/cript/api/vocabulary_categories.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class ControlledVocabularyCategories(Enum):
+class VocabCategories(Enum):
     """
     All available [CRIPT controlled vocabulary categories](https://www.mycriptapp.org/vocab/)
 
@@ -66,7 +66,7 @@ class ControlledVocabularyCategories(Enum):
     --------
     ```python
     algorithm_vocabulary = api.get_vocabulary_by_category(
-        cript.ControlledVocabularyCategories.ALGORITHM_KEY
+        cript.VocabCategories.ALGORITHM_KEY
         )
     ```
     """

--- a/src/cript/nodes/util/material_deserialization.py
+++ b/src/cript/nodes/util/material_deserialization.py
@@ -55,7 +55,7 @@ def _deserialize_flattened_material_identifiers(json_dict: Dict) -> Dict:
 
     # get material identifiers keys from API and create a simple list
     # eg ["smiles", "bigsmiles", etc.]
-    all_identifiers_list: List[str] = [identifier.get("name") for identifier in api.get_vocab_by_category(cript.ControlledVocabularyCategories.MATERIAL_IDENTIFIER_KEY)]
+    all_identifiers_list: List[str] = [identifier.get("name") for identifier in api.get_vocab_by_category(cript.VocabCategories.MATERIAL_IDENTIFIER_KEY)]
 
     # pop "name" from identifiers list because the node has to have a name
     all_identifiers_list.remove("name")

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -175,7 +175,7 @@ def test_get_vocabulary_by_category(cript_api: cript.API) -> None:
     CRIPT controlled vocabulary
     """
 
-    material_identifier_vocab_list = cript_api.get_vocab_by_category(cript.ControlledVocabularyCategories.MATERIAL_IDENTIFIER_KEY)
+    material_identifier_vocab_list = cript_api.get_vocab_by_category(cript.VocabCategories.MATERIAL_IDENTIFIER_KEY)
 
     # test response is a list of dicts
     assert isinstance(material_identifier_vocab_list, list)
@@ -215,16 +215,16 @@ def test_is_vocab_valid(cript_api: cript.API) -> None:
     tests invalid category and invalid vocabulary word
     """
     # custom vocab
-    assert cript_api._is_vocab_valid(vocab_category=cript.ControlledVocabularyCategories.ALGORITHM_KEY, vocab_word="+my_custom_key") is True
+    assert cript_api._is_vocab_valid(vocab_category=cript.VocabCategories.ALGORITHM_KEY, vocab_word="+my_custom_key") is True
 
     # valid vocab category and valid word
-    assert cript_api._is_vocab_valid(vocab_category=cript.ControlledVocabularyCategories.FILE_TYPE, vocab_word="calibration") is True
-    assert cript_api._is_vocab_valid(vocab_category=cript.ControlledVocabularyCategories.QUANTITY_KEY, vocab_word="mass") is True
-    assert cript_api._is_vocab_valid(vocab_category=cript.ControlledVocabularyCategories.UNCERTAINTY_TYPE, vocab_word="fwhm") is True
+    assert cript_api._is_vocab_valid(vocab_category=cript.VocabCategories.FILE_TYPE, vocab_word="calibration") is True
+    assert cript_api._is_vocab_valid(vocab_category=cript.VocabCategories.QUANTITY_KEY, vocab_word="mass") is True
+    assert cript_api._is_vocab_valid(vocab_category=cript.VocabCategories.UNCERTAINTY_TYPE, vocab_word="fwhm") is True
 
     # valid vocab category but invalid vocab word
     with pytest.raises(InvalidVocabulary):
-        cript_api._is_vocab_valid(vocab_category=cript.ControlledVocabularyCategories.FILE_TYPE, vocab_word="some_invalid_word")
+        cript_api._is_vocab_valid(vocab_category=cript.VocabCategories.FILE_TYPE, vocab_word="some_invalid_word")
 
 
 def test_download_file_from_url(cript_api: cript.API, tmp_path) -> None:


### PR DESCRIPTION
# Description
I think the enum class name of `ControlledVocabularyCategories` is just too long and makes the code look less clean I think. I think if we change it to a shorter like `VocabCategories` it will still create the same meaning for the user and keep the code clean and concise.

## Changes
* changed documentation in controlled_vocabulary_categories.md
* changed example documentation
* changed how it is imported into __init__.py
* changed the test_api.py for it
* changed how it is used in api.py
* changed how it is used in material_deserialization.py

## Tests

## Known Issues

## Notes
I think for the most accurate results, we would have to ask users about it what they thought and if they liked it we keep it, otherwise we remove it. I think this is something that is large and I am guessing users will either want it shorter or will not miss it if it becomes shorter.

## Screenshots
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/36eda68f-85bb-4d3b-9404-d6314c888fbd)

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
