### PR TITLE
API documentation side navigation is fixed

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -143,7 +143,7 @@ class API:
             pass
         ```
 
-        ### Create API Client with `None`
+        ### Create API Client with None
         Alternatively you can configure your system to have an environment variable of
         `CRIPT_TOKEN` for the API token and `CRIPT_STORAGE_TOKEN` for the storage token, then
         initialize `cript.API` `api_token` and `storage_token` with `None`.


### PR DESCRIPTION
# Description
adding `None` in header escapes the html and looks weird on the right side navigation

## Changes
* removed back ticks from `None` in the header

## Screenshots
<details>

<summary>click to see changes</summary>

### Before
![old api broken docs](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/dae06c6c-d722-48aa-a158-f2e86c845b7f)

### After
![fixed api docs](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/3c8ae5f7-5162-48c8-a0af-c14ef76ca4c8)

</details>

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
