### PR TITLE
test/develop optional node attributes can be removed

### DIFF
--- a/src/cript/nodes/primary_nodes/material.py
+++ b/src/cript/nodes/primary_nodes/material.py
@@ -272,7 +272,7 @@ class Material(PrimaryBaseNode):
 
     @parent_material.setter
     @beartype
-    def parent_material(self, new_parent_material: "Material") -> None:
+    def parent_material(self, new_parent_material: Optional["Material"]) -> None:
         """
         set the [parent materials](./) for this material
 

--- a/src/cript/nodes/subobjects/condition.py
+++ b/src/cript/nodes/subobjects/condition.py
@@ -365,7 +365,7 @@ class Condition(UUIDBaseNode):
         return self._json_attrs.uncertainty
 
     @beartype
-    def set_uncertainty(self, new_uncertainty: Union[Number, str], new_uncertainty_type: str) -> None:
+    def set_uncertainty(self, new_uncertainty: Union[Number, str, None], new_uncertainty_type: str) -> None:
         """
         set uncertainty and uncertainty type
 
@@ -520,7 +520,7 @@ class Condition(UUIDBaseNode):
 
     @data.setter
     @beartype
-    def data(self, new_data: List[Data]) -> None:
+    def data(self, new_data: Optional[List[Data]]) -> None:
         """
         set the data node for this Condition Subobject
 

--- a/src/cript/nodes/subobjects/condition.py
+++ b/src/cript/nodes/subobjects/condition.py
@@ -520,7 +520,7 @@ class Condition(UUIDBaseNode):
 
     @data.setter
     @beartype
-    def data(self, new_data: Optional[List[Data]]) -> None:
+    def data(self, new_data: List[Data]) -> None:
         """
         set the data node for this Condition Subobject
 

--- a/src/cript/nodes/subobjects/property.py
+++ b/src/cript/nodes/subobjects/property.py
@@ -278,7 +278,7 @@ class Property(UUIDBaseNode):
         return self._json_attrs.value
 
     @beartype
-    def set_value(self, new_value: Union[Number, str], new_unit: str) -> None:
+    def set_value(self, new_value: Union[Number, str, None], new_unit: str) -> None:
         """
         set the value attribute of the Property subobject
 
@@ -329,7 +329,7 @@ class Property(UUIDBaseNode):
         return self._json_attrs.uncertainty
 
     @beartype
-    def set_uncertainty(self, new_uncertainty: Number, new_uncertainty_type: str) -> None:
+    def set_uncertainty(self, new_uncertainty: Optional[Number], new_uncertainty_type: str) -> None:
         """
         set the uncertainty value and type
 

--- a/src/cript/nodes/subobjects/quantity.py
+++ b/src/cript/nodes/subobjects/quantity.py
@@ -229,7 +229,7 @@ class Quantity(UUIDBaseNode):
         return self._json_attrs.uncertainty_type
 
     @beartype
-    def set_uncertainty(self, uncertainty: Number, type: str) -> None:
+    def set_uncertainty(self, uncertainty: Optional[Number], type: str) -> None:
         """
         set the `uncertainty value` and `uncertainty_type`
 

--- a/tests/nodes/primary_nodes/test_collection.py
+++ b/tests/nodes/primary_nodes/test_collection.py
@@ -89,6 +89,7 @@ def test_collection_getters_and_setters(simple_experiment_node, simple_inventory
     my_collection.doi = ""
     my_collection.citation = []
 
+    # assert users can remove optional attributes
     assert my_collection.name == new_collection_name
     assert my_collection.experiment == []
     assert my_collection.inventory == []

--- a/tests/nodes/primary_nodes/test_collection.py
+++ b/tests/nodes/primary_nodes/test_collection.py
@@ -61,6 +61,7 @@ def test_collection_getters_and_setters(simple_experiment_node, simple_inventory
     2. use the setter to set the Collection node's attributes
     3. use the getter to get the Collection's attributes
     4. assert that what was set and what was gotten are the same
+    5. test that the attributes can also be removed as well from the node (either None, empty list, or empty str)
     """
     my_collection = cript.Collection(name="my collection name")
 
@@ -81,6 +82,18 @@ def test_collection_getters_and_setters(simple_experiment_node, simple_inventory
     assert my_collection.inventory == [simple_inventory_node]
     assert my_collection.doi == new_cript_doi
     assert my_collection.citation == [complex_citation_node]
+
+    # remove Collection attributes
+    my_collection.experiment = []
+    my_collection.inventory = []
+    my_collection.doi = ""
+    my_collection.citation = []
+
+    assert my_collection.name == new_collection_name
+    assert my_collection.experiment == []
+    assert my_collection.inventory == []
+    assert my_collection.doi == ""
+    assert my_collection.citation == []
 
 
 def test_serialize_collection_to_json(complex_user_node) -> None:

--- a/tests/nodes/primary_nodes/test_computation.py
+++ b/tests/nodes/primary_nodes/test_computation.py
@@ -80,10 +80,8 @@ def test_computation_getters_and_setters(simple_computation_node, simple_data_no
     simple_computation_node.input_data = [simple_data_node]
     simple_computation_node.output_data = [simple_data_node]
     simple_computation_node.software_configuration = [complex_software_configuration_node]
-    condition = copy.deepcopy(complex_condition_node)
-    simple_computation_node.condition = [condition]
-    citation = copy.deepcopy(complex_citation_node)
-    simple_computation_node.citation = [citation]
+    simple_computation_node.condition = [complex_condition_node]
+    simple_computation_node.citation = [complex_citation_node]
     simple_computation_node.notes = new_notes
 
     # assert getter and setter are same
@@ -91,9 +89,26 @@ def test_computation_getters_and_setters(simple_computation_node, simple_data_no
     assert simple_computation_node.input_data == [simple_data_node]
     assert simple_computation_node.output_data == [simple_data_node]
     assert simple_computation_node.software_configuration == [complex_software_configuration_node]
-    assert simple_computation_node.condition == [condition]
-    assert simple_computation_node.citation == [citation]
+    assert simple_computation_node.condition == [complex_condition_node]
+    assert simple_computation_node.citation == [complex_citation_node]
     assert simple_computation_node.notes == new_notes
+
+    # remove node attributes
+    simple_computation_node.type = ""
+    simple_computation_node.input_data = []
+    simple_computation_node.output_data = []
+    simple_computation_node.software_configuration = []
+    simple_computation_node.condition = []
+    simple_computation_node.citation = []
+    simple_computation_node.notes = ""
+
+    # assert users can remove optional attributes
+    assert simple_computation_node.input_data == []
+    assert simple_computation_node.output_data == []
+    assert simple_computation_node.software_configuration == []
+    assert simple_computation_node.condition == []
+    assert simple_computation_node.citation == []
+    assert simple_computation_node.notes == ""
 
 
 def test_serialize_computation_to_json(simple_computation_node) -> None:

--- a/tests/nodes/primary_nodes/test_computational_process.py
+++ b/tests/nodes/primary_nodes/test_computational_process.py
@@ -68,6 +68,34 @@ def test_create_complex_computational_process(
     assert my_computational_process.citation == [complex_citation_node]
 
 
+def test_computational_process_getters_and_setters(simple_computation_process_node, simple_data_node, simple_ingredient_node, simple_software_configuration, simple_condition_node, simple_property_node, complex_citation_node) -> None:
+    """
+    tests that all the getters and setters are working fine
+    """
+    computation_process_type = "hybrid_dynamics"
+    computation_process_notes = "my awesome notes"
+
+    simple_computation_process_node.type = computation_process_type
+    simple_computation_process_node.input_data = [simple_data_node]
+    simple_computation_process_node.output_data = [simple_data_node]
+    simple_computation_process_node.ingredient = [simple_ingredient_node]
+    simple_computation_process_node.software_configuration = [simple_software_configuration]
+    simple_computation_process_node.condition = [simple_condition_node]
+    simple_computation_process_node.property = [simple_property_node]
+    simple_computation_process_node.citation = [complex_citation_node]
+    simple_computation_process_node.notes = computation_process_notes
+
+    assert simple_computation_process_node.type == computation_process_type
+    assert simple_computation_process_node.input_data == [simple_data_node]
+    assert simple_computation_process_node.output_data == [simple_data_node]
+    assert simple_computation_process_node.ingredient == [simple_ingredient_node]
+    assert simple_computation_process_node.software_configuration == [simple_software_configuration]
+    assert simple_computation_process_node.condition == [simple_condition_node]
+    assert simple_computation_process_node.property == [simple_property_node]
+    assert simple_computation_process_node.citation == [complex_citation_node]
+    assert simple_computation_process_node.notes == computation_process_notes
+
+
 def test_serialize_computational_process_to_json(simple_computational_process_node) -> None:
     """
     tests that a computational process node can be correctly serialized to JSON

--- a/tests/nodes/primary_nodes/test_computational_process.py
+++ b/tests/nodes/primary_nodes/test_computational_process.py
@@ -75,6 +75,7 @@ def test_computational_process_getters_and_setters(simple_computation_process_no
     computation_process_type = "hybrid_dynamics"
     computation_process_notes = "my awesome notes"
 
+    # set all computation_process attributes
     simple_computation_process_node.type = computation_process_type
     simple_computation_process_node.input_data = [simple_data_node]
     simple_computation_process_node.output_data = [simple_data_node]
@@ -85,6 +86,7 @@ def test_computational_process_getters_and_setters(simple_computation_process_no
     simple_computation_process_node.citation = [complex_citation_node]
     simple_computation_process_node.notes = computation_process_notes
 
+    # test what was set via setters and what was gotten via getters are the same
     assert simple_computation_process_node.type == computation_process_type
     assert simple_computation_process_node.input_data == [simple_data_node]
     assert simple_computation_process_node.output_data == [simple_data_node]
@@ -94,6 +96,22 @@ def test_computational_process_getters_and_setters(simple_computation_process_no
     assert simple_computation_process_node.property == [simple_property_node]
     assert simple_computation_process_node.citation == [complex_citation_node]
     assert simple_computation_process_node.notes == computation_process_notes
+
+    # remove all optional computation_process attributes
+    simple_computation_process_node.output_data = []
+    simple_computation_process_node.software_configuration = []
+    simple_computation_process_node.condition = []
+    simple_computation_process_node.property = []
+    simple_computation_process_node.citation = []
+    simple_computation_process_node.notes = ""
+
+    # test computation process attributes can be removed correctly
+    assert simple_computation_process_node.output_data == []
+    assert simple_computation_process_node.software_configuration == []
+    assert simple_computation_process_node.condition == []
+    assert simple_computation_process_node.property == []
+    assert simple_computation_process_node.citation == []
+    assert simple_computation_process_node.notes == ""
 
 
 def test_serialize_computational_process_to_json(simple_computational_process_node) -> None:

--- a/tests/nodes/primary_nodes/test_data.py
+++ b/tests/nodes/primary_nodes/test_data.py
@@ -70,6 +70,7 @@ def test_data_getters_and_setters(
 ) -> None:
     """
     tests that all the getters and setters are working fine
+    and they can be removed as well
 
     Notes
     -----
@@ -112,6 +113,22 @@ def test_data_getters_and_setters(
     assert simple_data_node.material == [simple_material_node]
     assert simple_data_node.process == [simple_process_node]
     assert simple_data_node.citation == [complex_citation_node]
+
+    # remove optional attributes
+    simple_data_node.sample_preparation = []
+    simple_data_node.computation = []
+    simple_data_node.computation_process = []
+    simple_data_node.material = []
+    simple_data_node.process = []
+    simple_data_node.citation = []
+    
+    # assert that optional attributes have been removed from data node
+    assert simple_data_node.sample_preparation == []
+    assert simple_data_node.computation == []
+    assert simple_data_node.computation_process == []
+    assert simple_data_node.material == []
+    assert simple_data_node.process == []
+    assert simple_data_node.citation == []
 
 
 def test_serialize_data_to_json(simple_data_node) -> None:

--- a/tests/nodes/primary_nodes/test_data.py
+++ b/tests/nodes/primary_nodes/test_data.py
@@ -121,7 +121,7 @@ def test_data_getters_and_setters(
     simple_data_node.material = []
     simple_data_node.process = []
     simple_data_node.citation = []
-    
+
     # assert that optional attributes have been removed from data node
     assert simple_data_node.sample_preparation == []
     assert simple_data_node.computation == []

--- a/tests/nodes/primary_nodes/test_experiment.py
+++ b/tests/nodes/primary_nodes/test_experiment.py
@@ -94,7 +94,7 @@ def test_all_getters_and_setters_for_experiment(
     simple_experiment_node.data = []
     simple_experiment_node.funding = []
     simple_experiment_node.citation = []
-    
+
     # assert that optional attributes can be removed
     assert simple_experiment_node.process == []
     assert simple_experiment_node.computation == []

--- a/tests/nodes/primary_nodes/test_experiment.py
+++ b/tests/nodes/primary_nodes/test_experiment.py
@@ -75,8 +75,7 @@ def test_all_getters_and_setters_for_experiment(
     simple_experiment_node.computation_process = [simple_computational_process_node]
     simple_experiment_node.data = [simple_data_node]
     simple_experiment_node.funding = experiment_funders
-    citation = copy.deepcopy(complex_citation_node)
-    simple_experiment_node.citation = [citation]
+    simple_experiment_node.citation = [complex_citation_node]
 
     # assert getters and setters are equal
     assert isinstance(simple_experiment_node, cript.Experiment)
@@ -86,7 +85,23 @@ def test_all_getters_and_setters_for_experiment(
     assert simple_experiment_node.computation_process == [simple_computational_process_node]
     assert simple_experiment_node.data == [simple_data_node]
     assert simple_experiment_node.funding == experiment_funders
-    assert simple_experiment_node.citation[-1] == citation
+    assert simple_experiment_node.citation[-1] == complex_citation_node
+
+    # test experiment attributes can be removed
+    simple_experiment_node.process = []
+    simple_experiment_node.computation = []
+    simple_experiment_node.computation_process = []
+    simple_experiment_node.data = []
+    simple_experiment_node.funding = []
+    simple_experiment_node.citation = []
+    
+    # assert that optional attributes can be removed
+    assert simple_experiment_node.process == []
+    assert simple_experiment_node.computation == []
+    assert simple_experiment_node.computation_process == []
+    assert simple_experiment_node.data == []
+    assert simple_experiment_node.funding == []
+    assert simple_experiment_node.citation == []
 
 
 def test_experiment_json(simple_process_node, simple_computation_node, simple_computational_process_node, simple_data_node, complex_citation_node, complex_citation_dict) -> None:

--- a/tests/nodes/primary_nodes/test_inventory.py
+++ b/tests/nodes/primary_nodes/test_inventory.py
@@ -27,6 +27,12 @@ def test_get_and_set_inventory(simple_inventory_node) -> None:
     assert isinstance(simple_inventory_node, cript.Inventory)
     assert simple_inventory_node.material[-1] == material_1
 
+    # remove optional attributes
+    simple_inventory_node.material = []
+
+    # assert that optional attributes have been removed
+    assert simple_inventory_node.material == []
+
 
 def test_inventory_serialization(simple_inventory_node, simple_material_dict) -> None:
     """

--- a/tests/nodes/primary_nodes/test_material.py
+++ b/tests/nodes/primary_nodes/test_material.py
@@ -95,7 +95,8 @@ def test_all_getters_and_setters(simple_material_node, simple_property_node, sim
     simple_material_node.parent_material = None
     simple_material_node.computational_forcefield = None
     simple_material_node.component = []
-    
+
+    # assert optional attributes have been removed
     assert simple_material_node.property == []
     assert simple_material_node.parent_material == None
     assert simple_material_node.computational_forcefield == None

--- a/tests/nodes/primary_nodes/test_material.py
+++ b/tests/nodes/primary_nodes/test_material.py
@@ -98,8 +98,8 @@ def test_all_getters_and_setters(simple_material_node, simple_property_node, sim
 
     # assert optional attributes have been removed
     assert simple_material_node.property == []
-    assert simple_material_node.parent_material == None
-    assert simple_material_node.computational_forcefield == None
+    assert simple_material_node.parent_material is None
+    assert simple_material_node.computational_forcefield is None
     assert simple_material_node.component == []
 
 

--- a/tests/nodes/primary_nodes/test_material.py
+++ b/tests/nodes/primary_nodes/test_material.py
@@ -90,6 +90,17 @@ def test_all_getters_and_setters(simple_material_node, simple_property_node, sim
     assert simple_material_node.keyword == new_material_keywords
     assert simple_material_node.component == new_components
 
+    # remove optional attributes
+    simple_material_node.property = []
+    simple_material_node.parent_material = None
+    simple_material_node.computational_forcefield = None
+    simple_material_node.component = []
+    
+    assert simple_material_node.property == []
+    assert simple_material_node.parent_material == None
+    assert simple_material_node.computational_forcefield == None
+    assert simple_material_node.component == []
+
 
 def test_serialize_material_to_json(complex_material_dict, complex_material_node) -> None:
     """

--- a/tests/nodes/primary_nodes/test_process.py
+++ b/tests/nodes/primary_nodes/test_process.py
@@ -147,7 +147,7 @@ def test_process_getters_and_setters(
     simple_process_node.property = []
     simple_process_node.keyword = []
     simple_process_node.citation = []
-    
+
     # assert that optional attributes have been removed
     assert simple_process_node.ingredient == []
     assert simple_process_node.description == ""

--- a/tests/nodes/primary_nodes/test_process.py
+++ b/tests/nodes/primary_nodes/test_process.py
@@ -136,6 +136,30 @@ def test_process_getters_and_setters(
     assert simple_process_node.keyword == [new_process_keywords]
     assert simple_process_node.citation[-1] == citation
 
+    # test that optional attributes can be successfully removed
+    simple_process_node.ingredient = []
+    simple_process_node.description = ""
+    simple_process_node.equipment = []
+    simple_process_node.product = []
+    simple_process_node.waste = []
+    simple_process_node.prerequisite_process = []
+    simple_process_node.condition = []
+    simple_process_node.property = []
+    simple_process_node.keyword = []
+    simple_process_node.citation = []
+    
+    # assert that optional attributes have been removed
+    assert simple_process_node.ingredient == []
+    assert simple_process_node.description == ""
+    assert simple_process_node.equipment == []
+    assert simple_process_node.product == []
+    assert simple_process_node.waste == []
+    assert simple_process_node.prerequisite_process == []
+    assert simple_process_node.condition == []
+    assert simple_process_node.property == []
+    assert simple_process_node.keyword == []
+    assert simple_process_node.citation == []
+
 
 def test_serialize_process_to_json(simple_process_node) -> None:
     """

--- a/tests/nodes/primary_nodes/test_project.py
+++ b/tests/nodes/primary_nodes/test_project.py
@@ -42,6 +42,14 @@ def test_project_getters_and_setters(simple_project_node, simple_collection_node
     assert simple_project_node.collection == [complex_collection_node]
     assert simple_project_node.material == [simple_material_node]
 
+    # remove optional attributes
+    simple_project_node.collection = []
+    simple_project_node.material = []
+
+    # assert optional attributes have been removed
+    assert simple_project_node.collection == []
+    assert simple_project_node.material == []
+
 
 def test_serialize_project_to_json(complex_project_node, complex_project_dict) -> None:
     """

--- a/tests/nodes/primary_nodes/test_reference.py
+++ b/tests/nodes/primary_nodes/test_reference.py
@@ -146,7 +146,7 @@ def test_getters_and_setters_reference(complex_reference_node) -> None:
     complex_reference_node.arxiv_id = ""
     complex_reference_node.pmid = None
     complex_reference_node.website = ""
-    
+
     # assert optional attributes have been removed
     assert complex_reference_node.author == []
     assert complex_reference_node.journal == ""

--- a/tests/nodes/primary_nodes/test_reference.py
+++ b/tests/nodes/primary_nodes/test_reference.py
@@ -106,7 +106,6 @@ def test_getters_and_setters_reference(complex_reference_node) -> None:
     complex_reference_node.author = authors
     complex_reference_node.journal = journal
     complex_reference_node.publisher = publisher
-    complex_reference_node.publisher = publisher
     complex_reference_node.year = year
     complex_reference_node.volume = volume
     complex_reference_node.issue = issue
@@ -124,7 +123,6 @@ def test_getters_and_setters_reference(complex_reference_node) -> None:
     assert complex_reference_node.author == authors
     assert complex_reference_node.journal == journal
     assert complex_reference_node.publisher == publisher
-    assert complex_reference_node.publisher == publisher
     assert complex_reference_node.year == year
     assert complex_reference_node.volume == volume
     assert complex_reference_node.issue == issue
@@ -134,6 +132,34 @@ def test_getters_and_setters_reference(complex_reference_node) -> None:
     assert complex_reference_node.arxiv_id == arxiv_id
     assert complex_reference_node.pmid == pmid
     assert complex_reference_node.website == website
+
+    # remove optional attributes
+    complex_reference_node.author = []
+    complex_reference_node.journal = ""
+    complex_reference_node.publisher = ""
+    complex_reference_node.year = None
+    complex_reference_node.volume = None
+    complex_reference_node.issue = None
+    complex_reference_node.pages = []
+    complex_reference_node.doi = ""
+    complex_reference_node.issn = ""
+    complex_reference_node.arxiv_id = ""
+    complex_reference_node.pmid = None
+    complex_reference_node.website = ""
+    
+    # assert optional attributes have been removed
+    assert complex_reference_node.author == []
+    assert complex_reference_node.journal == ""
+    assert complex_reference_node.publisher == ""
+    assert complex_reference_node.year == None
+    assert complex_reference_node.volume == None
+    assert complex_reference_node.issue == None
+    assert complex_reference_node.pages == []
+    assert complex_reference_node.doi == ""
+    assert complex_reference_node.issn == ""
+    assert complex_reference_node.arxiv_id == ""
+    assert complex_reference_node.pmid == None
+    assert complex_reference_node.website == ""
 
 
 def test_reference_vocabulary() -> None:

--- a/tests/nodes/primary_nodes/test_reference.py
+++ b/tests/nodes/primary_nodes/test_reference.py
@@ -151,14 +151,14 @@ def test_getters_and_setters_reference(complex_reference_node) -> None:
     assert complex_reference_node.author == []
     assert complex_reference_node.journal == ""
     assert complex_reference_node.publisher == ""
-    assert complex_reference_node.year == None
-    assert complex_reference_node.volume == None
-    assert complex_reference_node.issue == None
+    assert complex_reference_node.year is None
+    assert complex_reference_node.volume is None
+    assert complex_reference_node.issue is None
     assert complex_reference_node.pages == []
     assert complex_reference_node.doi == ""
     assert complex_reference_node.issn == ""
     assert complex_reference_node.arxiv_id == ""
-    assert complex_reference_node.pmid == None
+    assert complex_reference_node.pmid is None
     assert complex_reference_node.website == ""
 
 

--- a/tests/nodes/subobjects/test_algorithm.py
+++ b/tests/nodes/subobjects/test_algorithm.py
@@ -7,14 +7,29 @@ from util import strip_uid_from_dict
 import cript
 
 
-def test_setter_getter(simple_algorithm_node, complex_citation_node):
-    a = simple_algorithm_node
-    a.key = "berendsen"
-    assert a.key == "berendsen"
-    a.type = "integration"
-    assert a.type == "integration"
-    a.citation += [complex_citation_node]
-    assert strip_uid_from_dict(json.loads(a.citation[0].json)) == strip_uid_from_dict(json.loads(complex_citation_node.json))
+def test_setter_getter(simple_algorithm_node, complex_citation_node, complex_parameter_node):
+    """
+    test that getters and setters are working correctly in algorithm sub-object
+    """
+    simple_algorithm_node.key = "berendsen"
+    assert simple_algorithm_node.key == "berendsen"
+
+    simple_algorithm_node.type = "integration"
+    assert simple_algorithm_node.type == "integration"
+
+    simple_algorithm_node.parameter = [complex_parameter_node]
+    assert simple_algorithm_node.parameter == [complex_parameter_node]
+
+    simple_algorithm_node.citation += [complex_citation_node]
+    assert strip_uid_from_dict(json.loads(simple_algorithm_node.citation[0].json)) == strip_uid_from_dict(json.loads(complex_citation_node.json))
+
+    # remove optional attributes
+    simple_algorithm_node.parameter = []
+    simple_algorithm_node.citation = []
+    
+    # assert the optional attributes have been removed
+    assert simple_algorithm_node.parameter == []
+    assert simple_algorithm_node.citation == []
 
 
 def test_json(simple_algorithm_node, simple_algorithm_dict, complex_citation_node):

--- a/tests/nodes/subobjects/test_algorithm.py
+++ b/tests/nodes/subobjects/test_algorithm.py
@@ -26,7 +26,7 @@ def test_setter_getter(simple_algorithm_node, complex_citation_node, complex_par
     # remove optional attributes
     simple_algorithm_node.parameter = []
     simple_algorithm_node.citation = []
-    
+
     # assert the optional attributes have been removed
     assert simple_algorithm_node.parameter == []
     assert simple_algorithm_node.citation == []

--- a/tests/nodes/subobjects/test_citation.py
+++ b/tests/nodes/subobjects/test_citation.py
@@ -17,13 +17,16 @@ def test_json(complex_citation_node, complex_citation_dict):
 
 
 def test_setter_getter(complex_citation_node, complex_reference_node):
-    c = complex_citation_node
-    c.type = "replicated"
-    assert c.type == "replicated"
+    """
+    test getters and setters are working fine
+    """
+    complex_citation_node.type = "replicated"
+    assert complex_citation_node.type == "replicated"
+
     new_ref = complex_reference_node
     new_ref.title = "foo bar"
-    c.reference = new_ref
-    assert c.reference == new_ref
+    complex_citation_node.reference = new_ref
+    assert complex_citation_node.reference == new_ref
 
 
 def test_integration_citation(cript_api, simple_project_node, simple_collection_node, complex_citation_node):

--- a/tests/nodes/subobjects/test_computational_forcefiled.py
+++ b/tests/nodes/subobjects/test_computational_forcefiled.py
@@ -17,30 +17,48 @@ def test_computational_forcefield(complex_computational_forcefield_node, complex
 
 
 def test_setter_getter(complex_computational_forcefield_node, complex_citation_node, simple_data_node):
-    cf2 = complex_computational_forcefield_node
-    cf2.key = "opls_ua"
-    assert cf2.key == "opls_ua"
+    """
+    test getters and setters are working correctly
+    """
+    complex_computational_forcefield_node.key = "opls_ua"
+    assert complex_computational_forcefield_node.key == "opls_ua"
 
-    cf2.building_block = "united_atoms"
-    assert cf2.building_block == "united_atoms"
+    complex_computational_forcefield_node.building_block = "united_atoms"
+    assert complex_computational_forcefield_node.building_block == "united_atoms"
 
-    cf2.implicit_solvent = ""
-    assert cf2.implicit_solvent == ""
+    complex_computational_forcefield_node.implicit_solvent = ""
+    assert complex_computational_forcefield_node.implicit_solvent == ""
 
-    cf2.source = "Iterative Boltzmann inversion"
-    assert cf2.source == "Iterative Boltzmann inversion"
+    complex_computational_forcefield_node.source = "Iterative Boltzmann inversion"
+    assert complex_computational_forcefield_node.source == "Iterative Boltzmann inversion"
 
-    cf2.description = "generic polymer model"
-    assert cf2.description == "generic polymer model"
+    complex_computational_forcefield_node.description = "generic polymer model"
+    assert complex_computational_forcefield_node.description == "generic polymer model"
 
     data = simple_data_node
-    cf2.data += [data]
-    assert cf2.data[-1] is data
+    complex_computational_forcefield_node.data += [data]
+    assert complex_computational_forcefield_node.data[-1] is data
 
-    assert len(cf2.citation) == 1
+    assert len(complex_computational_forcefield_node.citation) == 1
     citation2 = copy.deepcopy(complex_citation_node)
-    cf2.citation += [citation2]
-    assert cf2.citation[1] == citation2
+    complex_computational_forcefield_node.citation += [citation2]
+    assert complex_computational_forcefield_node.citation[1] == citation2
+
+    # remove optional attributes
+    complex_computational_forcefield_node.coarse_grained_mapping = ""
+    complex_computational_forcefield_node.implicit_solvent = ""
+    complex_computational_forcefield_node.source = ""
+    complex_computational_forcefield_node.description = ""
+    complex_computational_forcefield_node.data = []
+    complex_computational_forcefield_node.citation = []
+    
+    # assert optional attributes have been removed
+    assert complex_computational_forcefield_node.coarse_grained_mapping == ""
+    assert complex_computational_forcefield_node.implicit_solvent == ""
+    assert complex_computational_forcefield_node.source == ""
+    assert complex_computational_forcefield_node.description == ""
+    assert complex_computational_forcefield_node.data == []
+    assert complex_computational_forcefield_node.citation == []
 
 
 def test_integration_computational_forcefield(cript_api, simple_project_node, simple_material_node, simple_computational_forcefield_node):

--- a/tests/nodes/subobjects/test_computational_forcefiled.py
+++ b/tests/nodes/subobjects/test_computational_forcefiled.py
@@ -51,7 +51,7 @@ def test_setter_getter(complex_computational_forcefield_node, complex_citation_n
     complex_computational_forcefield_node.description = ""
     complex_computational_forcefield_node.data = []
     complex_computational_forcefield_node.citation = []
-    
+
     # assert optional attributes have been removed
     assert complex_computational_forcefield_node.coarse_grained_mapping == ""
     assert complex_computational_forcefield_node.implicit_solvent == ""

--- a/tests/nodes/subobjects/test_condition.py
+++ b/tests/nodes/subobjects/test_condition.py
@@ -51,9 +51,9 @@ def test_setter_getters(complex_condition_node, complex_data_node):
 
     # assert the optional node attributes have been removed
     assert complex_condition_node.descriptor == ""
-    assert complex_condition_node.set_id is Non
-    assert complex_condition_node.measurement_id is Non
-    assert complex_condition_node.uncertainty is Non
+    assert complex_condition_node.set_id is None
+    assert complex_condition_node.measurement_id is None
+    assert complex_condition_node.uncertainty is None
     assert complex_condition_node.uncertainty_type == ""
     # assert complex_condition_node.data is Non
 

--- a/tests/nodes/subobjects/test_condition.py
+++ b/tests/nodes/subobjects/test_condition.py
@@ -16,30 +16,46 @@ def test_json(complex_condition_node, complex_condition_dict):
 
 
 def test_setter_getters(complex_condition_node, complex_data_node):
-    c2 = complex_condition_node
-    c2.key = "pressure"
-    assert c2.key == "pressure"
-    c2.type = "avg"
-    assert c2.type == "avg"
+    complex_condition_node.key = "pressure"
+    assert complex_condition_node.key == "pressure"
+    complex_condition_node.type = "avg"
+    assert complex_condition_node.type == "avg"
 
-    c2.set_value(1, "bar")
-    assert c2.value == 1
-    assert c2.unit == "bar"
+    complex_condition_node.set_value(1, "bar")
+    assert complex_condition_node.value == 1
+    assert complex_condition_node.unit == "bar"
 
-    c2.descriptor = "ambient pressure"
-    assert c2.descriptor == "ambient pressure"
+    complex_condition_node.descriptor = "ambient pressure"
+    assert complex_condition_node.descriptor == "ambient pressure"
 
-    c2.set_uncertainty(0.1, "stdev")
-    assert c2.uncertainty == 0.1
-    assert c2.uncertainty_type == "stdev"
+    complex_condition_node.set_uncertainty(0.1, "stdev")
+    assert complex_condition_node.uncertainty == 0.1
+    assert complex_condition_node.uncertainty_type == "stdev"
 
-    c2.set_id = None
-    assert c2.set_id is None
-    c2.measurement_id = None
-    assert c2.measurement_id is None
+    complex_condition_node.set_id = None
+    assert complex_condition_node.set_id is None
+    complex_condition_node.measurement_id = None
+    assert complex_condition_node.measurement_id is None
 
-    c2.data = [complex_data_node]
-    assert c2.data[0] is complex_data_node
+    complex_condition_node.data = [complex_data_node]
+    assert complex_condition_node.data[0] is complex_data_node
+
+    # remove optional attributes
+    complex_condition_node.descriptor = ""
+    complex_condition_node.set_id = None
+    complex_condition_node.measurement_id = None
+    complex_condition_node.set_uncertainty(new_uncertainty_type="", new_uncertainty=None)
+
+    # TODO getting `CRIPTNodeSchemaError` when removing this data node from condition
+    # complex_condition_node.data = None
+
+    # assert the optional node attributes have been removed
+    assert complex_condition_node.descriptor == ""
+    assert complex_condition_node.set_id == None
+    assert complex_condition_node.measurement_id == None
+    assert complex_condition_node.uncertainty == None
+    assert complex_condition_node.uncertainty_type == ""
+    # assert complex_condition_node.data == None
 
 
 def test_integration_process_condition(cript_api, simple_project_node, simple_collection_node, simple_experiment_node, simple_computation_node, simple_condition_node):

--- a/tests/nodes/subobjects/test_condition.py
+++ b/tests/nodes/subobjects/test_condition.py
@@ -51,11 +51,11 @@ def test_setter_getters(complex_condition_node, complex_data_node):
 
     # assert the optional node attributes have been removed
     assert complex_condition_node.descriptor == ""
-    assert complex_condition_node.set_id == None
-    assert complex_condition_node.measurement_id == None
-    assert complex_condition_node.uncertainty == None
+    assert complex_condition_node.set_id is Non
+    assert complex_condition_node.measurement_id is Non
+    assert complex_condition_node.uncertainty is Non
     assert complex_condition_node.uncertainty_type == ""
-    # assert complex_condition_node.data == None
+    # assert complex_condition_node.data is Non
 
 
 def test_integration_process_condition(cript_api, simple_project_node, simple_collection_node, simple_experiment_node, simple_computation_node, simple_condition_node):

--- a/tests/nodes/subobjects/test_equipment.py
+++ b/tests/nodes/subobjects/test_equipment.py
@@ -16,25 +16,38 @@ def test_json(complex_equipment_node, complex_equipment_dict):
 
 
 def test_setter_getter(complex_equipment_node, complex_condition_node, complex_file_node, complex_citation_node):
-    e2 = complex_equipment_node
-    e2.key = "glass_beaker"
-    assert e2.key == "glass_beaker"
-    e2.description = "Fancy glassware"
-    assert e2.description == "Fancy glassware"
+    """
+    test that getters and setters are working fine
+    """
+    complex_equipment_node.key = "glass_beaker"
+    assert complex_equipment_node.key == "glass_beaker"
 
-    assert len(e2.condition) == 1
-    c2 = complex_condition_node
-    e2.condition += [c2]
-    assert e2.condition[1] == c2
+    complex_equipment_node.description = "Fancy glassware"
+    assert complex_equipment_node.description == "Fancy glassware"
 
-    assert len(e2.file) == 0
-    e2.file += [complex_file_node]
-    assert e2.file[-1] is complex_file_node
+    assert len(complex_equipment_node.condition) == 1
+    complex_equipment_node.condition += [complex_condition_node]
+    assert complex_equipment_node.condition[1] == complex_condition_node
 
-    cit2 = copy.deepcopy(complex_citation_node)
-    assert len(e2.citation) == 1
-    e2.citation += [cit2]
-    assert e2.citation[1] == cit2
+    assert len(complex_equipment_node.file) == 0
+    complex_equipment_node.file += [complex_file_node]
+    assert complex_equipment_node.file[-1] is complex_file_node
+
+    assert len(complex_equipment_node.citation) == 1
+    complex_equipment_node.citation += [complex_citation_node]
+    assert complex_equipment_node.citation[1] == complex_citation_node
+
+    # remove optional attributes
+    complex_equipment_node.description = ""
+    complex_equipment_node.condition = []
+    complex_equipment_node.file = []
+    complex_equipment_node.citation = []
+
+    # assert that optional attributes have been removed
+    assert complex_equipment_node.description == ""
+    assert complex_equipment_node.condition == []
+    assert complex_equipment_node.file == []
+    assert complex_equipment_node.citation == []
 
 
 def test_integration_equipment(cript_api, simple_project_node, simple_collection_node, simple_experiment_node, simple_process_node, simple_equipment_node):

--- a/tests/nodes/subobjects/test_ingredient.py
+++ b/tests/nodes/subobjects/test_ingredient.py
@@ -23,14 +23,18 @@ def test_json(complex_ingredient_node, complex_ingredient_dict):
 
 
 def test_getter_setter(complex_ingredient_node, complex_quantity_node, simple_material_node):
-    i2 = complex_ingredient_node
-    q2 = complex_quantity_node
-    i2.set_material(simple_material_node, [complex_quantity_node])
-    assert i2.material is simple_material_node
-    assert i2.quantity[-1] is q2
+    complex_ingredient_node.set_material(new_material=simple_material_node, new_quantity=[complex_quantity_node])
+    complex_ingredient_node.keyword = ["monomer"]
 
-    i2.keyword = ["monomer"]
-    assert i2.keyword == ["monomer"]
+    assert complex_ingredient_node.material is simple_material_node
+    assert complex_ingredient_node.quantity[-1] is complex_quantity_node
+    assert complex_ingredient_node.keyword == ["monomer"]
+
+    # remove optional attributes
+    complex_ingredient_node.keyword = []
+
+    # removed optional attributes
+    assert complex_ingredient_node.keyword == []
 
 
 def test_integration_ingredient(cript_api, simple_project_node, simple_collection_node, simple_experiment_node, simple_process_node, simple_ingredient_node, simple_material_node):

--- a/tests/nodes/subobjects/test_parameter.py
+++ b/tests/nodes/subobjects/test_parameter.py
@@ -8,13 +8,20 @@ import cript
 
 
 def test_parameter_setter_getter(complex_parameter_node):
-    p = complex_parameter_node
-    p.key = "damping_time"
-    assert p.key == "damping_time"
-    p.value = 15.0
-    assert p.value == 15.0
-    p.unit = "m"
-    assert p.unit == "m"
+    complex_parameter_node.key = "damping_time"
+    complex_parameter_node.value = 15.0
+    complex_parameter_node.unit = "m"
+
+    assert complex_parameter_node.value == 15.0
+    assert complex_parameter_node.key == "damping_time"
+    assert complex_parameter_node.unit == "m"
+
+    # remove optional attributes
+    complex_parameter_node.unit = ""
+
+    # assert optional attributes have been removed
+    assert complex_parameter_node.unit == ""
+
 
 
 def test_parameter_json_serialization(complex_parameter_node, complex_parameter_dict):

--- a/tests/nodes/subobjects/test_parameter.py
+++ b/tests/nodes/subobjects/test_parameter.py
@@ -23,7 +23,6 @@ def test_parameter_setter_getter(complex_parameter_node):
     assert complex_parameter_node.unit == ""
 
 
-
 def test_parameter_json_serialization(complex_parameter_node, complex_parameter_dict):
     p = complex_parameter_node
     p_str = p.json

--- a/tests/nodes/subobjects/test_property.py
+++ b/tests/nodes/subobjects/test_property.py
@@ -74,7 +74,7 @@ def test_setter_getter(complex_property_node, simple_material_node, simple_proce
     complex_property_node.computation = []
     complex_property_node.citation = []
     complex_property_node.notes = ""
-    
+
     # assert optional attributes have been removed
     assert complex_property_node.value is None
     assert complex_property_node.unit == ""

--- a/tests/nodes/subobjects/test_property.py
+++ b/tests/nodes/subobjects/test_property.py
@@ -76,14 +76,14 @@ def test_setter_getter(complex_property_node, simple_material_node, simple_proce
     complex_property_node.notes = ""
     
     # assert optional attributes have been removed
-    assert complex_property_node.value == None
+    assert complex_property_node.value is None
     assert complex_property_node.unit == ""
-    assert complex_property_node.uncertainty == None
+    assert complex_property_node.uncertainty is None
     assert complex_property_node.uncertainty_type == ""
     assert complex_property_node.component == []
     assert complex_property_node.structure == ""
     assert complex_property_node.method == ""
-    assert complex_property_node.sample_preparation == None
+    assert complex_property_node.sample_preparation is None
     assert complex_property_node.condition == []
     assert complex_property_node.data == []
     assert complex_property_node.computation == []

--- a/tests/nodes/subobjects/test_property.py
+++ b/tests/nodes/subobjects/test_property.py
@@ -18,45 +18,77 @@ def test_json(complex_property_node, complex_property_dict):
 
 
 def test_setter_getter(complex_property_node, simple_material_node, simple_process_node, complex_condition_node, simple_data_node, simple_computation_node, complex_citation_node):
-    p2 = complex_property_node
-    p2.key = "modulus_loss"
-    assert p2.key == "modulus_loss"
-    p2.type = "min"
-    assert p2.type == "min"
-    p2.set_value(600.1, "MPa")
-    assert p2.value == 600.1
-    assert p2.unit == "MPa"
+    complex_property_node.key = "modulus_loss"
+    assert complex_property_node.key == "modulus_loss"
 
-    p2.set_uncertainty(10.5, "stdev")
-    assert p2.uncertainty == 10.5
-    assert p2.uncertainty_type == "stdev"
+    complex_property_node.type = "min"
+    assert complex_property_node.type == "min"
 
-    p2.component += [simple_material_node]
-    assert p2.component[-1] is simple_material_node
-    p2.structure = "structure2"
-    assert p2.structure == "structure2"
+    complex_property_node.set_value(600.1, "MPa")
+    assert complex_property_node.value == 600.1
+    assert complex_property_node.unit == "MPa"
 
-    p2.method = "scale"
-    assert p2.method == "scale"
+    complex_property_node.set_uncertainty(10.5, "stdev")
+    assert complex_property_node.uncertainty == 10.5
+    assert complex_property_node.uncertainty_type == "stdev"
 
-    p2.sample_preparation = simple_process_node
-    assert p2.sample_preparation is simple_process_node
-    assert len(p2.condition) == 1
-    p2.condition += [complex_condition_node]
-    assert len(p2.condition) == 2
-    p2.data = [simple_data_node]
-    assert p2.data[0] is simple_data_node
+    complex_property_node.component += [simple_material_node]
+    assert complex_property_node.component[-1] is simple_material_node
+    complex_property_node.structure = "structure2"
+    assert complex_property_node.structure == "structure2"
 
-    p2.computation += [simple_computation_node]
-    assert p2.computation[-1] is simple_computation_node
+    complex_property_node.method = "scale"
+    assert complex_property_node.method == "scale"
 
-    assert len(p2.citation) == 1
+    complex_property_node.sample_preparation = simple_process_node
+    assert complex_property_node.sample_preparation is simple_process_node
+
+    assert len(complex_property_node.condition) == 1
+    complex_property_node.condition += [complex_condition_node]
+    assert len(complex_property_node.condition) == 2
+
+    complex_property_node.data = [simple_data_node]
+    assert complex_property_node.data[0] is simple_data_node
+
+    complex_property_node.computation += [simple_computation_node]
+    assert complex_property_node.computation[-1] is simple_computation_node
+
+    assert len(complex_property_node.citation) == 1
     cit2 = copy.deepcopy(complex_citation_node)
-    p2.citation += [cit2]
-    assert len(p2.citation) == 2
-    assert p2.citation[-1] == cit2
-    p2.notes = "notes2"
-    assert p2.notes == "notes2"
+    complex_property_node.citation += [cit2]
+    assert len(complex_property_node.citation) == 2
+    assert complex_property_node.citation[-1] == cit2
+
+    complex_property_node.notes = "notes2"
+    assert complex_property_node.notes == "notes2"
+
+    # remove optional attributes
+    complex_property_node.set_value(new_value=None, new_unit="")
+    complex_property_node.set_uncertainty(new_uncertainty=None, new_uncertainty_type="")
+    complex_property_node.component = []
+    complex_property_node.structure = ""
+    complex_property_node.method = ""
+    complex_property_node.sample_preparation = None
+    complex_property_node.condition = []
+    complex_property_node.data = []
+    complex_property_node.computation = []
+    complex_property_node.citation = []
+    complex_property_node.notes = ""
+    
+    # assert optional attributes have been removed
+    assert complex_property_node.value == None
+    assert complex_property_node.unit == ""
+    assert complex_property_node.uncertainty == None
+    assert complex_property_node.uncertainty_type == ""
+    assert complex_property_node.component == []
+    assert complex_property_node.structure == ""
+    assert complex_property_node.method == ""
+    assert complex_property_node.sample_preparation == None
+    assert complex_property_node.condition == []
+    assert complex_property_node.data == []
+    assert complex_property_node.computation == []
+    assert complex_property_node.citation == []
+    assert complex_property_node.notes == ""
 
 
 def test_integration_material_property(cript_api, simple_project_node, simple_material_node, simple_property_node):

--- a/tests/nodes/subobjects/test_quantity.py
+++ b/tests/nodes/subobjects/test_quantity.py
@@ -16,16 +16,24 @@ def test_json(complex_quantity_node, complex_quantity_dict):
 
 
 def test_getter_setter(complex_quantity_node):
-    q = complex_quantity_node
-    q.value = 0.5
-    assert q.value == 0.5
-    q.set_uncertainty(0.1, "stderr")
-    assert q.uncertainty == 0.1
-    assert q.uncertainty_type == "stderr"
+    complex_quantity_node.value = 0.5
+    assert complex_quantity_node.value == 0.5
 
-    q.set_key_unit("volume", "m**3")
-    assert q.key == "volume"
-    assert q.unit == "m**3"
+    complex_quantity_node.set_uncertainty(uncertainty=0.1, type="stderr")
+    assert complex_quantity_node.uncertainty == 0.1
+    assert complex_quantity_node.uncertainty_type == "stderr"
+
+    complex_quantity_node.set_key_unit(new_key="volume", new_unit="m**3")
+    assert complex_quantity_node.key == "volume"
+    assert complex_quantity_node.unit == "m**3"
+
+    # remove optional attributes
+    complex_quantity_node.set_uncertainty(uncertainty=None, type="")
+
+    # assert optional attributes have been removed
+    assert complex_quantity_node.uncertainty is None
+    assert complex_quantity_node.uncertainty_type == ""
+
 
 
 def test_integration_quantity(cript_api, simple_project_node, simple_collection_node, simple_experiment_node, simple_process_node, simple_ingredient_node, simple_material_node):

--- a/tests/nodes/subobjects/test_quantity.py
+++ b/tests/nodes/subobjects/test_quantity.py
@@ -35,7 +35,6 @@ def test_getter_setter(complex_quantity_node):
     assert complex_quantity_node.uncertainty_type == ""
 
 
-
 def test_integration_quantity(cript_api, simple_project_node, simple_collection_node, simple_experiment_node, simple_process_node, simple_ingredient_node, simple_material_node):
     """
     integration test between Python SDK and API Client

--- a/tests/nodes/subobjects/test_software.py
+++ b/tests/nodes/subobjects/test_software.py
@@ -17,13 +17,20 @@ def test_json(complex_software_node, complex_software_dict):
 
 
 def test_setter_getter(complex_software_node):
-    s2 = complex_software_node
-    s2.name = "PySAGES"
-    assert s2.name == "PySAGES"
-    s2.version = "v0.3.0"
-    assert s2.version == "v0.3.0"
-    s2.source = "https://github.com/SSAGESLabs/PySAGES"
-    assert s2.source == "https://github.com/SSAGESLabs/PySAGES"
+    complex_software_node.name = "PySAGES"
+    assert complex_software_node.name == "PySAGES"
+
+    complex_software_node.version = "v0.3.0"
+    assert complex_software_node.version == "v0.3.0"
+
+    complex_software_node.source = "https://github.com/SSAGESLabs/PySAGES"
+    assert complex_software_node.source == "https://github.com/SSAGESLabs/PySAGES"
+
+    # remove optional attributes
+    complex_software_node.source = ""
+
+    # assert optional attributes have been removed
+    assert complex_software_node.source == ""
 
 
 def test_uuid(complex_software_node):

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -158,6 +158,14 @@ def test_file_getters_and_setters(complex_file_node) -> None:
     assert complex_file_node.extension == new_file_extension
     assert complex_file_node.data_dictionary == new_data_dictionary
 
+    # remove optional attributes
+    complex_file_node.extension = ""
+    complex_file_node.data_dictionary = ""
+
+    # assert optional attributes have been removed
+    assert complex_file_node.extension == ""
+    assert complex_file_node.data_dictionary == ""
+
 
 def test_serialize_file_to_json(complex_file_node) -> None:
     """


### PR DESCRIPTION
# Description
removing optional attributes from nodes to be sure that it works correctly

## Changes
* refactored and clean up some tests
* removed `copy.deep_copy` to make tests simpler
* renamed some variable names from `c2` to `complex_condition_node` to be easier to read and more self documenting
    * added logical spacing between some tests to be easier to read

## Tests

## Known Issues
* `test_condition.py` was having issues with removal of `Data` node, which [data model](https://pubs.acs.org/doi/suppl/10.1021/acscentsci.3c00011/suppl_file/oc3c00011_si_001.pdf) says that it should be optional, but when removing it the DB Schema gives me an error
* `test_software_configuration` is missing some tests in `test_setter_getter`
   * the tests will be added in future PR

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
