### PR TITLE
Pointing file upload tests to staging AWS S3 storage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,8 +49,17 @@ def cript_api():
     storage_token = os.getenv("CRIPT_STORAGE_TOKEN")
 
     assert cript.api.api._global_cached_api is None
+
     with cript.API(host=None, api_token=None, storage_token=storage_token) as api:
+
+        # overriding AWS S3 cognito variables to be sure we do not upload test data to production storage
+        # staging AWS S3 cognito storage variables
+        api._IDENTITY_POOL_ID ="us-east-1:25043452-a922-43af-b8a6-7e938a9e55c1"
+        api._COGNITO_LOGIN_PROVIDER = "cognito-idp.us-east-1.amazonaws.com/us-east-1_vyK1N9p22"
+        api._BUCKET_NAME = "cript-stage-user-data"
         # using the tests folder name within our cloud storage
         api._BUCKET_DIRECTORY_NAME = "tests"
+
         yield api
+
     assert cript.api.api._global_cached_api is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,10 +51,9 @@ def cript_api():
     assert cript.api.api._global_cached_api is None
 
     with cript.API(host=None, api_token=None, storage_token=storage_token) as api:
-
         # overriding AWS S3 cognito variables to be sure we do not upload test data to production storage
         # staging AWS S3 cognito storage variables
-        api._IDENTITY_POOL_ID ="us-east-1:25043452-a922-43af-b8a6-7e938a9e55c1"
+        api._IDENTITY_POOL_ID = "us-east-1:25043452-a922-43af-b8a6-7e938a9e55c1"
         api._COGNITO_LOGIN_PROVIDER = "cognito-idp.us-east-1.amazonaws.com/us-east-1_vyK1N9p22"
         api._BUCKET_NAME = "cript-stage-user-data"
         # using the tests folder name within our cloud storage


### PR DESCRIPTION
# Description
changed cognito variables for API in tests to point to staging storage

## Changes
* changed conftest to override production API object class variables
* spaced out code a bit to be easier to read

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
