### PR TITLE
raising error for getting db schema via requests

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -517,11 +517,14 @@ class API:
 
         # fetch db_schema from API
         else:
-            # fetch db schema, get the JSON body of it, and get the data of that JSON
-            response = requests.get(url=f"{self.host}/schema/").json()
+            # fetch db schema from API
+            response = requests.get(url=f"{self.host}/schema/")
 
-            if response["code"] != 200:
-                raise APIError(api_error=response.json())
+            # raise error if not HTTP 200
+            response.raise_for_status()
+
+            # if no error, take the JSON from the API response
+            response = response.json()
 
             # get the data from the API JSON response
             self._db_schema = response["data"]

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -13,7 +13,6 @@ import requests
 from beartype import beartype
 
 from cript.api.exceptions import (
-    APIError,
     CRIPTAPIRequiredError,
     CRIPTAPISaveError,
     CRIPTConnectionError,
@@ -518,16 +517,16 @@ class API:
         # fetch db_schema from API
         else:
             # fetch db schema from API
-            response = requests.get(url=f"{self.host}/schema/")
+            response: requests.Response = requests.get(url=f"{self.host}/schema/")
 
             # raise error if not HTTP 200
             response.raise_for_status()
 
             # if no error, take the JSON from the API response
-            response = response.json()
+            response_dict: Dict = response.json()
 
             # get the data from the API JSON response
-            self._db_schema = response["data"]
+            self._db_schema = response_dict["data"]
             return self._db_schema
 
     @beartype


### PR DESCRIPTION
# Description
gives slightly better error if the user is out of USA

## Changes
### Out of USA
#### Before
```bash
       try:
            return complexjson.loads(self.text, **kwargs)
        except JSONDecodeError as e:
            # Catch JSON-related errors and raise as requests.JSONDecodeError
            # This aliases json.JSONDecodeError and simplejson.JSONDecodeError
>           raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
E           requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

..\..\venv\lib\site-packages\requests\models.py:975: JSONDecodeError
```
> this error is because when the API is pinged from outside of USA it returns a text of `"You must be in the US to access Cript app."` and since this is not JSON it gives a bad JSON deserialization error

#### After
After raising error from requests, the error becomes
```bash
        if http_error_msg:
>           raise HTTPError(http_error_msg, response=self)
E           requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://api.criptapp.org/api/v1/schema/

..\..\venv\lib\site-packages\requests\models.py:1021: HTTPError
```

The error is slightly better but I would have preferred `"wrong URL for db schema"` and `"Cannot use CRIPT outside of USA"`

I think this new error should be good enough for now and if we get users complaining then we can change it

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
