### PR TITLE
Refactor/Renamed material `identifiers` to `identifier`

### DIFF
--- a/docs/examples/simulation.md
+++ b/docs/examples/simulation.md
@@ -321,7 +321,7 @@ bulk.output_data = [final_data]
 ## Create a virtual Material
 
 First, we'll create a virtual material and add some
-[`Identifiers`](../../nodes/primary_nodes/material/#cript.nodes.primary_nodes.material.Material.identifiers)
+[`Identifiers`](../../nodes/primary_nodes/material/#cript.nodes.primary_nodes.material.Material.identifier)
 to the material to make it easier to identify and search.
 
 ```python
@@ -331,11 +331,11 @@ identifiers += [{"bigsmiles": "[H]{[>][<]C(C[>])c1ccccc1[<]}C(C)CC"}]
 identifiers += [{"chem_repeat": ["C8H8"]}]
 
 # create a material node object with identifiers
-polystyrene = cript.Material(name="virtual polystyrene", identifiers=identifiers)
+polystyrene = cript.Material(name="virtual polystyrene", identifier=identifiers)
 ```
 
 !!! note "Identifier keys"
-    The allowed [`Identifiers`](../../nodes/primary_nodes/material/#cript.nodes.primary_nodes.material.Material.identifiers) keys are listed in the [material identifier keys](https://app.criptapp.org/vocab/material_identifier_key) in the CRIPT controlled vocabulary.
+    The allowed [`Identifiers`](../../nodes/primary_nodes/material/#cript.nodes.primary_nodes.material.Material.identifier) keys are listed in the [material identifier keys](https://app.criptapp.org/vocab/material_identifier_key) in the CRIPT controlled vocabulary.
 
 ## Add [`Property`](../../nodes/subobjects/property) sub-objects
 Let's also add some [`Property`](../../nodes/subobjects/property) nodes to the [`Material`](../../nodes/primary_nodes/material), which represent its physical or virtual (in the case of a simulated material) properties.

--- a/docs/examples/synthesis.md
+++ b/docs/examples/synthesis.md
@@ -124,7 +124,7 @@ my_solution_material_identifiers = [
 
 solution = cript.Material(
     name="SecBuLi solution 1.4M cHex",
-    identifiers=my_solution_material_identifiers
+    identifier=my_solution_material_identifiers
 )
 ```
 
@@ -132,10 +132,10 @@ These materials are simple, notice how we use the SMILES notation here as an ide
 Similarly, we can create more initial materials.
 
 ```python
-toluene = cript.Material(name="toluene", identifiers=[{"smiles": "Cc1ccccc1"}, {"pubchem_id": 1140}])
-styrene = cript.Material(name="styrene", identifiers=[{"smiles": "c1ccccc1C=C"}, {"inchi": "InChI=1S/C8H8/c1-2-8-6-4-3-5-7-8/h2-7H,1H2"}])
-butanol = cript.Material(name="1-butanol", identifiers=[{"smiles": "OCCCC"}, {"inchi_key": "InChIKey=LRHPLDYGYMQRHN-UHFFFAOYSA-N"}])
-methanol = cript.Material(name="methanol", identifiers=[{"smiles": "CO"}, {"names": ["Butan-1-ol", "Butyric alcohol", "Methylolpropane", "n-Butan-1-ol", "methanol"]}])
+toluene = cript.Material(name="toluene", identifier=[{"smiles": "Cc1ccccc1"}, {"pubchem_id": 1140}])
+styrene = cript.Material(name="styrene", identifier=[{"smiles": "c1ccccc1C=C"}, {"inchi": "InChI=1S/C8H8/c1-2-8-6-4-3-5-7-8/h2-7H,1H2"}])
+butanol = cript.Material(name="1-butanol", identifier=[{"smiles": "OCCCC"}, {"inchi_key": "InChIKey=LRHPLDYGYMQRHN-UHFFFAOYSA-N"}])
+methanol = cript.Material(name="methanol", identifier=[{"smiles": "CO"}, {"names": ["Butan-1-ol", "Butyric alcohol", "Methylolpropane", "n-Butan-1-ol", "methanol"]}])
 ```
 
 Now that we defined those materials, we can combine them into an inventory
@@ -250,7 +250,7 @@ that will serve as our product. We give the material a `name` attribute and add 
 [Project]((../../nodes/primary_nodes/project).
 
 ```python
-polystyrene = cript.Material(name="polystyrene", identifiers=[])
+polystyrene = cript.Material(name="polystyrene", identifier=[])
 project.material += [polystyrene]
 ```
 
@@ -258,12 +258,12 @@ Let's add some `Identifiers` to the material to make it easier to identify and s
 
 ```python
 # create a name identifier
-polystyrene.identifiers += [{"names": ["poly(styrene)", "poly(vinylbenzene)"]}]
+polystyrene.identifier += [{"names": ["poly(styrene)", "poly(vinylbenzene)"]}]
 
 # create a BigSMILES identifier
-polystyrene.identifiers += [{"bigsmiles": "[H]{[>][<]C(C[>])c1ccccc1[<]}C(C)CC"}]
+polystyrene.identifier += [{"bigsmiles": "[H]{[>][<]C(C[>])c1ccccc1[<]}C(C)CC"}]
 # create a chemical repeat unit identifier
-polystyrene.identifiers += [{"chem_repeat": ["C8H8"]}]
+polystyrene.identifier += [{"chem_repeat": ["C8H8"]}]
 ```
 
 Next, we'll add some [Property](../../nodes/subobjects/property) nodes to the

--- a/src/cript/nodes/primary_nodes/collection.py
+++ b/src/cript/nodes/primary_nodes/collection.py
@@ -171,12 +171,12 @@ class Collection(PrimaryBaseNode):
         ```python
         material_1 = cript.Material(
             name="material 1",
-            identifiers=[{"alternative_names": "material 1 alternative name"}],
+            identifier=[{"alternative_names": "material 1 alternative name"}],
         )
 
         material_2 = cript.Material(
             name="material 2",
-            identifiers=[{"alternative_names": "material 2 alternative name"}],
+            identifier=[{"alternative_names": "material 2 alternative name"}],
         )
 
         my_inventory = cript.Inventory(

--- a/src/cript/nodes/primary_nodes/computation_process.py
+++ b/src/cript/nodes/primary_nodes/computation_process.py
@@ -159,7 +159,7 @@ class ComputationProcess(PrimaryBaseNode):
         # Material node for Quantity node
         my_material = cript.Material(
             name="my material",
-            identifiers=[{"alternative_names": "my material alternative name"}]
+            identifier=[{"alternative_names": "my material alternative name"}]
             )
 
         # create quantity node

--- a/src/cript/nodes/primary_nodes/inventory.py
+++ b/src/cript/nodes/primary_nodes/inventory.py
@@ -73,12 +73,12 @@ class Inventory(PrimaryBaseNode):
         ```python
         material_1 = cript.Material(
             name="material 1",
-            identifiers=[{"alternative_names": "material 1 alternative name"}],
+            identifier=[{"alternative_names": "material 1 alternative name"}],
         )
 
         material_2 = cript.Material(
             name="material 2",
-            identifiers=[{"alternative_names": "material 2 alternative name"}],
+            identifier=[{"alternative_names": "material 2 alternative name"}],
         )
 
         # instantiate inventory node
@@ -116,7 +116,7 @@ class Inventory(PrimaryBaseNode):
         ```python
         material_3 = cript.Material(
             name="new material 3",
-            identifiers=[{"alternative_names": "new material 3 alternative name"}],
+            identifier=[{"alternative_names": "new material 3 alternative name"}],
         )
 
         my_inventory.material = [my_material_3]

--- a/src/cript/nodes/primary_nodes/material.py
+++ b/src/cript/nodes/primary_nodes/material.py
@@ -16,7 +16,7 @@ class Material(PrimaryBaseNode):
     ## Attributes
     | attribute                 | type                                                                 | example                                           | description                                         | required    | vocab |
     |---------------------------|----------------------------------------------------------------------|---------------------------------------------------|-----------------------------------------------------|-------------|-------|
-    | identifiers               | list[Identifier]                                                     |                                                   | material identifiers                                | True        |       |
+    | identifier               | list[Identifier]                                                     |                                                   | material identifiers                                | True        |       |
     | component                 | list[[Material](./)]                                                 |                                                   | list of component that make up the mixture          |             |       |
     | property                  | list[[Property](../../subobjects/property)]                          |                                                   | material properties                                 |             |       |
     | process                   | [Process](../process)                                                |                                                   | process node that made this material                |             |       |
@@ -60,9 +60,8 @@ class Material(PrimaryBaseNode):
         """
         all Material attributes
         """
-
         # identifier sub-object for the material
-        identifiers: List[Dict[str, str]] = field(default_factory=dict)  # type: ignore
+        identifier: List[Dict[str, str]] = field(default_factory=dict)  # type: ignore
         # TODO add proper typing in future, using Any for now to avoid circular import error
         component: List["Material"] = field(default_factory=list)
         process: Optional[Process] = None
@@ -77,7 +76,7 @@ class Material(PrimaryBaseNode):
     def __init__(
         self,
         name: str,
-        identifiers: List[Dict[str, str]],
+        identifier: List[Dict[str, str]],
         component: Optional[List["Material"]] = None,
         process: Optional[Process] = None,
         property: Optional[List[Any]] = None,
@@ -93,7 +92,7 @@ class Material(PrimaryBaseNode):
         Parameters
         ----------
         name: str
-        identifiers: List[Dict[str, str]]
+        identifier: List[Dict[str, str]]
         component: List["Material"], default=None
         property: Optional[Process], default=None
         process: List[Process], default=None
@@ -121,7 +120,7 @@ class Material(PrimaryBaseNode):
         self._json_attrs = replace(
             self._json_attrs,
             name=name,
-            identifiers=identifiers,
+            identifier=identifier,
             component=component,
             process=process,
             property=property,
@@ -167,7 +166,7 @@ class Material(PrimaryBaseNode):
 
     @property
     @beartype
-    def identifiers(self) -> List[Dict[str, str]]:
+    def identifier(self) -> List[Dict[str, str]]:
         """
         get the identifiers for this material
 
@@ -183,11 +182,11 @@ class Material(PrimaryBaseNode):
         List[Dict[str, str]]
             list of dictionary that has identifiers for this material
         """
-        return self._json_attrs.identifiers.copy()
+        return self._json_attrs.identifier.copy()
 
-    @identifiers.setter
+    @identifier.setter
     @beartype
-    def identifiers(self, new_identifiers_list: List[Dict[str, str]]) -> None:
+    def identifier(self, new_identifier_list: List[Dict[str, str]]) -> None:
         """
         set the list of identifiers for this material
 
@@ -196,13 +195,13 @@ class Material(PrimaryBaseNode):
 
         Parameters
         ----------
-        new_identifiers_list: List[Dict[str, str]]
+        new_identifier_list: List[Dict[str, str]]
 
         Returns
         -------
         None
         """
-        new_attrs = replace(self._json_attrs, identifiers=new_identifiers_list)
+        new_attrs = replace(self._json_attrs, identifier=new_identifier_list)
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
@@ -219,19 +218,19 @@ class Material(PrimaryBaseNode):
             # create material node
             cript.Material(
                 name="my component material 1",
-                identifiers=[{"alternative_names": "component 1 alternative name"}],
+                identifier=[{"alternative_names": "component 1 alternative name"}],
             ),
 
             # create material node
             cript.Material(
                 name="my component material 2",
-                identifiers=[{"alternative_names": "component 2 alternative name"}],
+                identifier=[{"alternative_names": "component 2 alternative name"}],
             ),
         ]
 
 
-        identifiers = [{"alternative_names": "my material alternative name"}]
-        my_material = cript.Material(name="my material", component=my_component, identifiers=identifiers)
+        identifier = [{"alternative_names": "my material alternative name"}]
+        my_material = cript.Material(name="my material", component=my_component, identifier=identifier)
         ```
 
         Returns
@@ -329,13 +328,13 @@ class Material(PrimaryBaseNode):
         [CRIPT controlled vocabulary](https://app.criptapp.org/vocab/material_keyword)
 
         ```python
-        identifiers = [{"alternative_names": "my material alternative name"}]
+        identifier = [{"alternative_names": "my material alternative name"}]
 
         # keyword
         material_keyword = ["acetylene", "acrylate", "alternating"]
 
         my_material = cript.Material(
-            name="my material", keyword=material_keyword, identifiers=identifiers
+            name="my material", keyword=material_keyword, identifier=identifier
         )
         ```
 
@@ -433,8 +432,8 @@ class Material(PrimaryBaseNode):
         * `name`: The name of the node
 
         optional fields in JSON:
-        * `identifiers`: A list of material identifiers.
-            * If the `identifiers` property is not present in the JSON dictionary,
+        * `identifier`: A list of material identifiers.
+            * If the `identifier` property is not present in the JSON dictionary,
             it will be set to an empty list.
         """
         from cript.nodes.util.material_deserialization import (

--- a/src/cript/nodes/primary_nodes/material.py
+++ b/src/cript/nodes/primary_nodes/material.py
@@ -60,6 +60,7 @@ class Material(PrimaryBaseNode):
         """
         all Material attributes
         """
+
         # identifier sub-object for the material
         identifier: List[Dict[str, str]] = field(default_factory=dict)  # type: ignore
         # TODO add proper typing in future, using Any for now to avoid circular import error

--- a/src/cript/nodes/primary_nodes/process.py
+++ b/src/cript/nodes/primary_nodes/process.py
@@ -106,7 +106,7 @@ class Process(PrimaryBaseNode):
             [ingredient](../../subobjects/ingredient) used in this process
         type: str = ""
             Process type must come from
-            [CRIPT Controlled vocabulary process type](https://app.criptapp.org/vocab/process-type/)
+            [CRIPT Controlled vocabulary process type](https://app.criptapp.org/vocab/process_type/)
         description: str = ""
             description of this process
         equipment: List[Equipment] = None
@@ -480,7 +480,7 @@ class Process(PrimaryBaseNode):
         """
         List of keyword for this process
 
-        [Process keyword](https://app.criptapp.org/vocab/process-keyword/) must come from CRIPT controlled vocabulary
+        [Process keyword](https://app.criptapp.org/vocab/process_keyword/) must come from CRIPT controlled vocabulary
 
         Returns
         -------

--- a/src/cript/nodes/primary_nodes/process.py
+++ b/src/cript/nodes/primary_nodes/process.py
@@ -121,7 +121,7 @@ class Process(PrimaryBaseNode):
             list of [properties](../../subobjects/property) for this process
         keyword: List[str] = None
             list of keywords for this process must come from
-            [CRIPT process keyword controlled keyword](https://app.criptapp.org/vocab/process-keyword/)
+            [CRIPT process keyword controlled keyword](https://app.criptapp.org/vocab/process_keyword/)
         citation: List[Citation] = None
             list of [citation](../../subobjects/citation)
 
@@ -191,7 +191,7 @@ class Process(PrimaryBaseNode):
         Returns
         -------
         str
-            Select a [Process type](https://app.criptapp.org/vocab/process-type/) from CRIPT controlled vocabulary
+            Select a [Process type](https://app.criptapp.org/vocab/process_type/) from CRIPT controlled vocabulary
         """
         return self._json_attrs.type
 

--- a/src/cript/nodes/primary_nodes/project.py
+++ b/src/cript/nodes/primary_nodes/project.py
@@ -202,8 +202,8 @@ class Project(PrimaryBaseNode):
         Examples
         --------
         ```python
-        identifiers = [{"alternative_names": "my material alternative name"}]
-        my_material = cript.Material(name="my material", identifiers=identifiers)
+        identifier = [{"alternative_names": "my material alternative name"}]
+        my_material = cript.Material(name="my material", identifier=identifier)
 
         my_project.material = [my_material]
         ```

--- a/src/cript/nodes/subobjects/ingredient.py
+++ b/src/cript/nodes/subobjects/ingredient.py
@@ -82,8 +82,8 @@ class Ingredient(UUIDBaseNode):
         import cript
 
         # create material and identifier for the ingredient sub-object
-        my_identifiers = [{"bigsmiles": "123456"}]
-        my_material = cript.Material(name="my material", identifier=my_identifiers)
+        my_identifier = [{"bigsmiles": "123456"}]
+        my_material = cript.Material(name="my material", identifier=my_identifier)
 
         # create quantity sub-object
         my_quantity = cript.Quantity(key="mass", value=11.2, unit="kg", uncertainty=0.2, uncertainty_type="stdev")
@@ -154,8 +154,8 @@ class Ingredient(UUIDBaseNode):
         Examples
         --------
         ```python
-        my_identifiers = [{"bigsmiles": "123456"}]
-        my_new_material = cript.Material(name="my material", identifier=my_identifiers)
+        my_identifier = [{"bigsmiles": "123456"}]
+        my_new_material = cript.Material(name="my material", identifier=my_identifier)
 
         my_new_quantity = cript.Quantity(
             key="mass", value=11.2, unit="kg", uncertainty=0.2, uncertainty_type="stdev"

--- a/src/cript/nodes/subobjects/property.py
+++ b/src/cript/nodes/subobjects/property.py
@@ -381,8 +381,8 @@ class Property(UUIDBaseNode):
         ---------
         ```python
 
-        my_identifiers = [{"bigsmiles": "123456"}]
-        my_material = cript.Material(name="my material", identifier=my_identifiers)
+        my_identifier = [{"bigsmiles": "123456"}]
+        my_material = cript.Material(name="my material", identifier=my_identifier)
 
         # add material node as component to Property subobject
         my_property.component = my_material

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -94,7 +94,7 @@ class File(PrimaryBaseNode):
     | Attribute       | Type | Example                                                                                               | Description                                                                 | Required |
     |-----------------|------|-------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|----------|
     | source          | str  | `"path/to/my/file"` or `"https://en.wikipedia.org/wiki/Simplified_molecular-input_line-entry_system"` | source to the file can be URL or local path                                 | True     |
-    | type            | str  | `"logs"`                                                                                              | Pick from [CRIPT File Types](https://app.criptapp.org/vocab/file-type/)          | True     |
+    | type            | str  | `"logs"`                                                                                              | Pick from [CRIPT File Types](https://app.criptapp.org/vocab/file_type/)          | True     |
     | extension       | str  | `".csv"`                                                                                              | file extension                                                              | False    |
     | data_dictionary | str  | `"my extra info in my data dictionary"`                                                               | set of information describing the contents, format, and structure of a file | False    |
 

--- a/src/cript/nodes/util/__init__.py
+++ b/src/cript/nodes/util/__init__.py
@@ -322,7 +322,7 @@ def _material_identifiers_list_to_json_fields(serialize_dict: dict) -> dict:
         {
             "node":["Material"],
             "name":"my material",
-            "identifiers":[ {"cas":"my material cas"} ],
+            "identifier":[ {"cas":"my material cas"} ],
             "uid":"_:a78203cb-82ea-4376-910e-dee74088cd37"
         }
     ```
@@ -350,13 +350,13 @@ def _material_identifiers_list_to_json_fields(serialize_dict: dict) -> dict:
     """
 
     # TODO this if statement might not be needed in future
-    if "identifiers" in serialize_dict:
-        for identifier in serialize_dict["identifiers"]:
+    if "identifier" in serialize_dict:
+        for identifier in serialize_dict["identifier"]:
             for key, value in identifier.items():
                 serialize_dict[key] = value
 
         # remove identifiers list of objects after it has been flattened
-        del serialize_dict["identifiers"]
+        del serialize_dict["identifier"]
 
     return serialize_dict
 

--- a/src/cript/nodes/util/material_deserialization.py
+++ b/src/cript/nodes/util/material_deserialization.py
@@ -32,7 +32,7 @@ def _deserialize_flattened_material_identifiers(json_dict: Dict) -> Dict:
        "node":["Material"],
        "name":"my cool material",
        "uuid":"_:my cool material",
-       "identifiers":[
+       "identifier":[
           {"smiles":"CCC"},
           {"bigsmiles":"my big smiles"}
        ]
@@ -69,6 +69,6 @@ def _deserialize_flattened_material_identifiers(json_dict: Dict) -> Dict:
             # delete identifiers from the API JSON response as they are added to the material node
             del json_dict[identifier]
 
-    json_dict["identifiers"] = identifier_argument
+    json_dict["identifier"] = identifier_argument
 
     return json_dict

--- a/tests/fixtures/primary_nodes.py
+++ b/tests/fixtures/primary_nodes.py
@@ -177,7 +177,7 @@ def complex_process_node(complex_ingredient_node, simple_equipment_node, complex
     my_process_description = "my simple material description"
 
     process_waste = [
-        cript.Material(name="my process waste material 1", identifiers=[{"bigsmiles": "process waste bigsmiles"}]),
+        cript.Material(name="my process waste material 1", identifier=[{"bigsmiles": "process waste bigsmiles"}]),
     ]
 
     my_process_keywords = [
@@ -218,9 +218,9 @@ def simple_material_node() -> cript.Material:
     """
     simple material node to use between tests
     """
-    identifiers = [{"bigsmiles": "123456"}]
+    identifier = [{"bigsmiles": "123456"}]
     # Use a unique name
-    my_material = cript.Material(name="my test material " + str(uuid.uuid4()), identifiers=identifiers)
+    my_material = cript.Material(name="my test material " + str(uuid.uuid4()), identifier=identifier)
 
     return my_material
 
@@ -265,7 +265,7 @@ def complex_material_node(simple_property_node, simple_process_node, complex_com
 
     my_complex_material = cript.Material(
         name="my complex material",
-        identifiers=my_identifier,
+        identifier=my_identifier,
         property=[simple_property_node],
         process=copy.deepcopy(simple_process_node),
         parent_material=simple_material_node,
@@ -283,7 +283,7 @@ def simple_inventory_node(simple_material_node) -> None:
     """
     # set up inventory node
 
-    material_2 = cript.Material(name="material 2 " + str(uuid.uuid4()), identifiers=[{"bigsmiles": "my big smiles"}])
+    material_2 = cript.Material(name="material 2 " + str(uuid.uuid4()), identifier=[{"bigsmiles": "my big smiles"}])
 
     my_inventory = cript.Inventory(name="my inventory name", material=[simple_material_node, material_2])
 

--- a/tests/nodes/primary_nodes/test_inventory.py
+++ b/tests/nodes/primary_nodes/test_inventory.py
@@ -18,7 +18,7 @@ def test_get_and_set_inventory(simple_inventory_node) -> None:
     4. assert that the materials list set and the one gotten are the same
     """
     # create new materials
-    material_1 = cript.Material(name="new material 1", identifiers=[{"names": ["new material 1 alternative name"]}])
+    material_1 = cript.Material(name="new material 1", identifier=[{"names": ["new material 1 alternative name"]}])
 
     # set inventory materials
     simple_inventory_node.material = [material_1]

--- a/tests/nodes/primary_nodes/test_material.py
+++ b/tests/nodes/primary_nodes/test_material.py
@@ -13,7 +13,7 @@ def test_create_complex_material(simple_material_node, simple_computational_forc
     """
 
     material_name = "my material name"
-    identifiers = [{"bigsmiles": "1234"}, {"bigsmiles": "4567"}]
+    identifier = [{"bigsmiles": "1234"}, {"bigsmiles": "4567"}]
     keyword = ["acetylene"]
 
     component = [simple_material_node]
@@ -21,11 +21,11 @@ def test_create_complex_material(simple_material_node, simple_computational_forc
 
     my_property = [cript.Property(key="modulus_shear", type="min", value=1.23, unit="gram")]
 
-    my_material = cript.Material(name=material_name, identifiers=identifiers, keyword=keyword, component=component, process=simple_process_node, property=my_property, computational_forcefield=forcefield)
+    my_material = cript.Material(name=material_name, identifier=identifier, keyword=keyword, component=component, process=simple_process_node, property=my_property, computational_forcefield=forcefield)
 
     assert isinstance(my_material, cript.Material)
     assert my_material.name == material_name
-    assert my_material.identifiers == identifiers
+    assert my_material.identifier == identifier
     assert my_material.keyword == keyword
     assert my_material.component == component
     assert my_material.process == simple_process_node
@@ -52,11 +52,11 @@ def test_all_getters_and_setters(simple_material_node, simple_property_node, sim
     # new attributes
     new_name = "new material name"
 
-    new_identifiers = [{"bigsmiles": "6789"}]
+    new_identifier = [{"bigsmiles": "6789"}]
 
     new_parent_material = cript.Material(
         name="my parent material",
-        identifiers=[
+        identifier=[
             {"bigsmiles": "9876"},
         ],
     )
@@ -66,7 +66,7 @@ def test_all_getters_and_setters(simple_material_node, simple_property_node, sim
     new_components = [
         cript.Material(
             name="my component material 1",
-            identifiers=[
+            identifier=[
                 {"bigsmiles": "654321"},
             ],
         ),
@@ -74,7 +74,7 @@ def test_all_getters_and_setters(simple_material_node, simple_property_node, sim
 
     # set all attributes for Material node
     simple_material_node.name = new_name
-    simple_material_node.identifiers = new_identifiers
+    simple_material_node.identifier = new_identifier
     simple_material_node.property = [simple_property_node]
     simple_material_node.parent_material = new_parent_material
     simple_material_node.computational_forcefield = simple_computational_forcefield_node
@@ -83,7 +83,7 @@ def test_all_getters_and_setters(simple_material_node, simple_property_node, sim
 
     # get all attributes and assert that they are equal to the setter
     assert simple_material_node.name == new_name
-    assert simple_material_node.identifiers == new_identifiers
+    assert simple_material_node.identifier == new_identifier
     assert simple_material_node.property == [simple_property_node]
     assert simple_material_node.parent_material == new_parent_material
     assert simple_material_node.computational_forcefield == simple_computational_forcefield_node
@@ -141,6 +141,6 @@ def test_integration_material(cript_api, simple_project_node, simple_material_no
 
     # ========= test update =========
     # update material attribute to trigger update
-    simple_project_node.material[0].identifiers = [{"bigsmiles": "my bigsmiles UPDATED"}]
+    simple_project_node.material[0].identifier = [{"bigsmiles": "my bigsmiles UPDATED"}]
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)

--- a/tests/nodes/primary_nodes/test_process.py
+++ b/tests/nodes/primary_nodes/test_process.py
@@ -43,7 +43,7 @@ def test_complex_process_node(complex_ingredient_node, simple_equipment_node, co
     my_process_description = "my simple material description"
 
     process_waste = [
-        cript.Material(name="my process waste material 1", identifiers=[{"bigsmiles": "process waste bigsmiles"}]),
+        cript.Material(name="my process waste material 1", identifier=[{"bigsmiles": "process waste bigsmiles"}]),
     ]
 
     my_process_keywords = [

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -124,14 +124,6 @@ def test_create_file_with_local_source(tmp_path) -> None:
     assert cript.File(name="my file node with local source", source=str(file_path), type="calibration")
 
 
-@pytest.mark.skip(reason="validating file type automatically with DB schema and test not currently needed")
-def test_file_type_invalid_vocabulary() -> None:
-    """
-    tests that setting the file type to an invalid vocabulary word gives the expected error
-    """
-    pass
-
-
 def test_file_getters_and_setters(complex_file_node) -> None:
     """
     tests that all the getters and setters are working fine

--- a/tests/test_node_util.py
+++ b/tests/test_node_util.py
@@ -29,8 +29,8 @@ def test_removing_nodes(simple_algorithm_node, complex_parameter_node, simple_al
 
 
 def test_uid_deserialization(simple_algorithm_node, complex_parameter_node, simple_algorithm_dict):
-    identifiers = [{"bigsmiles": "123456"}]
-    material = cript.Material(name="my material", identifiers=identifiers)
+    identifier = [{"bigsmiles": "123456"}]
+    material = cript.Material(name="my material", identifier=identifier)
 
     computation = cript.Computation(name="my computation name", type="analysis")
     property1 = cript.Property("modulus_shear", "value", 5.0, "GPa", computation=[computation])


### PR DESCRIPTION
# Description
One of the users made a comment that every other attribute on a node is singular except for identifiers which is plural and it would be more intuitive if it was singular

## Changes
* changed all files, tests, and documentation to use `identifier` instead of `identifiers`
  * all tests are passing
* fixed any broken links for vocabulary within documentation
* removed unneeded test for test_file.py

## Tests
* all tests are passing after heavy refactoring

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
