### PR TITLE
Feature: new search modes

### DIFF
--- a/.trunk/configs/.cspell.json
+++ b/.trunk/configs/.cspell.json
@@ -117,6 +117,7 @@
     "setuptools",
     "miniconda",
     "pymdown",
-    "BCDB"
+    "BCDB",
+    "chlorobenzamide"
   ]
 }

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -966,8 +966,14 @@ class API:
         elif search_mode == SearchModes.CONTAINS_NAME:
             api_endpoint = f"{self._host}/search/{node_type}/"
 
+            if value_to_search is None:
+                raise ValueError("`value_to_search` is needed for `SearchModes.CONTAINS_NAME`")
+
         elif search_mode == SearchModes.EXACT_NAME:
             api_endpoint = f"{self._host}/search/exact/{node_type}/"
+
+            if value_to_search is None:
+                raise ValueError("`value_to_search` is needed for `SearchModes.EXACT_NAME`")
 
         elif search_mode == SearchModes.UUID:
             api_endpoint = f"{self._host}/{node_type}/{value_to_search}/"
@@ -977,13 +983,26 @@ class API:
         elif search_mode == SearchModes.BIGSMILES:
             api_endpoint = f"{self._host}/search/bigsmiles/"
 
+            if value_to_search is None:
+                raise ValueError("`value_to_search` is needed for `SearchModes.BIGSMILES`")
+
+
         elif search_mode == SearchModes.CHILD_NODE_TYPE_WITHIN_PARENT:
             api_endpoint = f"{self._host}/{parent_node.node_type}/{parent_node.uuid}/{node_type}/"
             # not using `value_to_search`
             value_to_search = None
 
+            if parent_node is None:
+                raise ValueError("`parent_node` is needed for `SearchModes.CHILD_NODE_TYPE_WITHIN_PARENT`")
+
         elif search_mode == SearchModes.CHILD_WITH_EXACT_NAME_WITHIN_PARENT:
             api_endpoint = f"{self._host}/search/exact/{parent_node.node_type}/{parent_node.uuid}/{node_type}/"
+
+            if value_to_search is None:
+                raise ValueError("`value_to_search` is needed for `SearchModes.CHILD_WITH_EXACT_NAME_WITHIN_PARENT`")
+
+            if parent_node is None:
+                raise ValueError("`parent_node` is needed for `SearchModes.CHILD_WITH_EXACT_NAME_WITHIN_PARENT`")
 
         assert api_endpoint != ""
 

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -908,12 +908,22 @@ class API:
             )
             ```
 
-        ??? Example "Search node type within parent"
+        ??? Example "Search child node type within parent"
             ```python
             all_materials_in_project_paginator = cript_api.search(
-                node_type=cript.Material,   # the node you want back
-                search_mode=cript.SearchModes.NODE_TYPE_WITHIN_PARENT,  # type of search
+                node_type=cript.Material,   # the node type you want back
+                search_mode=cript.SearchModes.CHILD_NODE_TYPE_WITHIN_PARENT,  # type of search
                 parent_node=my_project_node # parent node to search through
+            )
+            ```
+
+        ??? Example "Search child node type within parent"
+            ```python
+            materials_exact_name_in_project_paginator = cript_api.search(
+                node_type=cript.Material,
+                search_mode=cript.SearchModes.CHILD_WITH_EXACT_NAME_WITHIN_PARENT,
+                value_to_search="N-Butyl-2-chlorobenzamide",
+                parent_node=my_project_node
             )
             ```
 
@@ -949,24 +959,31 @@ class API:
 
         # requesting a page of some primary node
         if search_mode == SearchModes.NODE_TYPE:
-            api_endpoint = f"{self._host}/{node_type}"
+            api_endpoint = f"{self._host}/{node_type}/"
+            # not using `value_to_search`
+            value_to_search = None
 
         elif search_mode == SearchModes.CONTAINS_NAME:
-            api_endpoint = f"{self._host}/search/{node_type}"
+            api_endpoint = f"{self._host}/search/{node_type}/"
 
         elif search_mode == SearchModes.EXACT_NAME:
-            api_endpoint = f"{self._host}/search/exact/{node_type}"
+            api_endpoint = f"{self._host}/search/exact/{node_type}/"
 
         elif search_mode == SearchModes.UUID:
-            api_endpoint = f"{self._host}/{node_type}/{value_to_search}"
+            api_endpoint = f"{self._host}/{node_type}/{value_to_search}/"
             # putting the value_to_search in the URL instead of a query
             value_to_search = None
 
         elif search_mode == SearchModes.BIGSMILES:
             api_endpoint = f"{self._host}/search/bigsmiles/"
 
-        elif search_mode == SearchModes.NODE_TYPE_WITHIN_PARENT:
-            api_endpoint = f"{self._host}/{parent_node.node_type}/{parent_node.uuid}/{node_type}"
+        elif search_mode == SearchModes.CHILD_NODE_TYPE_WITHIN_PARENT:
+            api_endpoint = f"{self._host}/{parent_node.node_type}/{parent_node.uuid}/{node_type}/"
+            # not using `value_to_search`
+            value_to_search = None
+
+        elif search_mode == SearchModes.CHILD_WITH_EXACT_NAME_WITHIN_PARENT:
+            api_endpoint = f"{self._host}/search/exact/{parent_node.node_type}/{parent_node.uuid}/{node_type}/"
 
         assert api_endpoint != ""
 

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -854,13 +854,7 @@ class API:
         # the file is stored in cloud storage and must be retrieved via object_name
         self._s3_client.download_file(Bucket=self._BUCKET_NAME, Key=file_source, Filename=destination_path)  # type: ignore
 
-    def search(
-        self,
-        node_type: UUIDBaseNode,
-        search_mode: SearchModes,
-        value_to_search: Optional[str] = None,
-        parent_node: Optional[UUIDBaseNode] = None
-    ) -> Paginator:
+    def search(self, node_type: UUIDBaseNode, search_mode: SearchModes, value_to_search: Optional[str] = None, parent_node: Optional[UUIDBaseNode] = None) -> Paginator:
         """
         This method is used to perform search on the CRIPT platform.
 

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -943,6 +943,22 @@ class API:
             The parent that you are searching through.
             > Not applicable for all search modes
 
+        Raises
+        ------
+        ValueError
+            Raised when required arguments are missing for a specific search mode, preventing a silent failure.
+
+            Certain arguments are specific to different search modes. To ensure smooth API calls and avoid
+            confusion, this function performs a *pre-call* check for the necessary arguments based on the chosen
+            search mode. If a required argument is missing, a `ValueError` is raised.
+
+            Example:
+            ```python
+            cript_api.search(node_type=cript.Material, search_mode=cript.SearchModes.EXACT_NAME)
+            ```
+            > This example will raise a `ValueError` since the `value_to_search` argument is missing, which is
+            required for the `EXACT_NAME` SearchMode.
+
         Returns
         -------
         Paginator

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -964,16 +964,16 @@ class API:
             value_to_search = None
 
         elif search_mode == SearchModes.CONTAINS_NAME:
-            api_endpoint = f"{self._host}/search/{node_type}/"
-
             if value_to_search is None:
                 raise ValueError("`value_to_search` is needed for `SearchModes.CONTAINS_NAME`")
 
-        elif search_mode == SearchModes.EXACT_NAME:
-            api_endpoint = f"{self._host}/search/exact/{node_type}/"
+            api_endpoint = f"{self._host}/search/{node_type}/"
 
+        elif search_mode == SearchModes.EXACT_NAME:
             if value_to_search is None:
                 raise ValueError("`value_to_search` is needed for `SearchModes.EXACT_NAME`")
+
+            api_endpoint = f"{self._host}/search/exact/{node_type}/"
 
         elif search_mode == SearchModes.UUID:
             api_endpoint = f"{self._host}/{node_type}/{value_to_search}/"
@@ -981,28 +981,27 @@ class API:
             value_to_search = None
 
         elif search_mode == SearchModes.BIGSMILES:
-            api_endpoint = f"{self._host}/search/bigsmiles/"
-
             if value_to_search is None:
                 raise ValueError("`value_to_search` is needed for `SearchModes.BIGSMILES`")
 
+            api_endpoint = f"{self._host}/search/bigsmiles/"
 
         elif search_mode == SearchModes.CHILD_NODE_TYPE_WITHIN_PARENT:
+            if parent_node is None:
+                raise ValueError("`parent_node` is needed for `SearchModes.CHILD_NODE_TYPE_WITHIN_PARENT`")
+
             api_endpoint = f"{self._host}/{parent_node.node_type}/{parent_node.uuid}/{node_type}/"
             # not using `value_to_search`
             value_to_search = None
 
-            if parent_node is None:
-                raise ValueError("`parent_node` is needed for `SearchModes.CHILD_NODE_TYPE_WITHIN_PARENT`")
-
         elif search_mode == SearchModes.CHILD_WITH_EXACT_NAME_WITHIN_PARENT:
-            api_endpoint = f"{self._host}/search/exact/{parent_node.node_type}/{parent_node.uuid}/{node_type}/"
-
             if value_to_search is None:
                 raise ValueError("`value_to_search` is needed for `SearchModes.CHILD_WITH_EXACT_NAME_WITHIN_PARENT`")
 
             if parent_node is None:
                 raise ValueError("`parent_node` is needed for `SearchModes.CHILD_WITH_EXACT_NAME_WITHIN_PARENT`")
+
+            api_endpoint = f"{self._host}/search/exact/{parent_node.node_type}/{parent_node.uuid}/{node_type}/"
 
         assert api_endpoint != ""
 

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -868,50 +868,50 @@ class API:
 
         Examples
         --------
-        ### Search by Node Type
-        ```python
-        materials_paginator = cript_api.search(
-            node_type=cript.Material,
-            search_mode=cript.SearchModes.NODE_TYPE,
-            value_to_search=None
-        )
-        ```
+        ???+ Example "Search by Node Type"
+            ```python
+            materials_paginator = cript_api.search(
+                node_type=cript.Material,
+                search_mode=cript.SearchModes.NODE_TYPE,
+                value_to_search=None
+            )
+            ```
 
-        ### Search by Contains name
-        ```python
-        contains_name_paginator = cript_api.search(
-            node_type=cript.Process,
-            search_mode=cript.SearchModes.CONTAINS_NAME,
-            value_to_search="poly"
-        )
-        ```
+        ??? Example "Search by Contains name"
+            ```python
+            contains_name_paginator = cript_api.search(
+                node_type=cript.Process,
+                search_mode=cript.SearchModes.CONTAINS_NAME,
+                value_to_search="poly"
+            )
+            ```
 
-        ### Search by Exact Name
-        ```python
-        exact_name_paginator = cript_api.search(
-            node_type=cript.Project,
-            search_mode=cript.SearchModes.EXACT_NAME,
-            value_to_search="Sodium polystyrene sulfonate"
-        )
-        ```
+        ??? Example "Search by Exact Name"
+            ```python
+            exact_name_paginator = cript_api.search(
+                node_type=cript.Project,
+                search_mode=cript.SearchModes.EXACT_NAME,
+                value_to_search="Sodium polystyrene sulfonate"
+            )
+            ```
 
-        ### Search by UUID
-        ```python
-        uuid_paginator = cript_api.search(
-            node_type=cript.Collection,
-            search_mode=cript.SearchModes.UUID,
-            value_to_search="75fd3ee5-48c2-4fc7-8d0b-842f4fc812b7"
-        )
-        ```
+        ??? Example "Search by UUID"
+            ```python
+            uuid_paginator = cript_api.search(
+                node_type=cript.Collection,
+                search_mode=cript.SearchModes.UUID,
+                value_to_search="75fd3ee5-48c2-4fc7-8d0b-842f4fc812b7"
+            )
+            ```
 
-        ### Search by BigSmiles
-        ```python
-        paginator = cript_api.search(
-            node_type=cript.Material,
-            search_mode=cript.SearchModes.BIGSMILES,
-            value_to_search="{[][$]CC(C)(C(=O)OCCCC)[$][]}"
-        )
-        ```
+        ??? Example "Search by BigSmiles"
+            ```python
+            paginator = cript_api.search(
+                node_type=cript.Material,
+                search_mode=cript.SearchModes.BIGSMILES,
+                value_to_search="{[][$]CC(C)(C(=O)OCCCC)[$][]}"
+            )
+            ```
 
         Parameters
         ----------

--- a/src/cript/api/valid_search_modes.py
+++ b/src/cript/api/valid_search_modes.py
@@ -17,9 +17,15 @@ class SearchModes(Enum):
         Search by node UUID.
     BIGSMILES: str
         Search materials by bigsmiles identifier.
-    NODE_TYPE_WITHIN_PARENT: str
+    CHILD_NODE_TYPE_WITHIN_PARENT: str
         Search for a node type within a parent.
         > Example: Find all the materials within this specific project.
+    CHILD_CONTAINS_NAME_WITHIN_PARENT: str
+        Search for a node containing a value for an attribute within a parent
+        > Example: Search for all materials that contain a certain name for the field specified within a project.
+    CHILD_WITH_EXACT_NAME_WITHIN_PARENT: str
+        Search for an exact node name within a parent
+        > Example: Search for the materials with that exact name in the project or returns nothing.
 
     Examples
     -------
@@ -38,4 +44,6 @@ class SearchModes(Enum):
     CONTAINS_NAME: str = "contains_name"
     UUID: str = "uuid"
     BIGSMILES: str = "bigsmiles"
-    NODE_TYPE_WITHIN_PARENT: str = "node_type_within_parent"
+    CHILD_NODE_TYPE_WITHIN_PARENT: str = "child_node_type_within_parent"
+    CHILD_CONTAINS_NAME_WITHIN_PARENT: str = "child_contains_name_within_parent"
+    CHILD_WITH_EXACT_NAME_WITHIN_PARENT: str = "child_with_exact_name_within_parent"

--- a/src/cript/api/valid_search_modes.py
+++ b/src/cript/api/valid_search_modes.py
@@ -20,9 +20,6 @@ class SearchModes(Enum):
     CHILD_NODE_TYPE_WITHIN_PARENT: str
         Search for a node type within a parent.
         > Example: Find all the materials within this specific project.
-    CHILD_CONTAINS_NAME_WITHIN_PARENT: str
-        Search for a node containing a value for an attribute within a parent
-        > Example: Search for all materials that contain a certain name for the field specified within a project.
     CHILD_WITH_EXACT_NAME_WITHIN_PARENT: str
         Search for an exact node name within a parent
         > Example: Search for the materials with that exact name in the project or returns nothing.
@@ -45,5 +42,4 @@ class SearchModes(Enum):
     UUID: str = "uuid"
     BIGSMILES: str = "bigsmiles"
     CHILD_NODE_TYPE_WITHIN_PARENT: str = "child_node_type_within_parent"
-    CHILD_CONTAINS_NAME_WITHIN_PARENT: str = "child_contains_name_within_parent"
     CHILD_WITH_EXACT_NAME_WITHIN_PARENT: str = "child_with_exact_name_within_parent"

--- a/src/cript/api/valid_search_modes.py
+++ b/src/cript/api/valid_search_modes.py
@@ -34,5 +34,5 @@ class SearchModes(Enum):
     EXACT_NAME: str = "exact_name"
     CONTAINS_NAME: str = "contains_name"
     UUID: str = "uuid"
-    # UUID_CHILDREN = "uuid_children"
     BIGSMILES: str = "bigsmiles"
+    NODE_TYPE_WITHIN_PARENT: str = "node_type_within_parent"

--- a/src/cript/api/valid_search_modes.py
+++ b/src/cript/api/valid_search_modes.py
@@ -16,7 +16,10 @@ class SearchModes(Enum):
     UUID : str
         Search by node UUID.
     BIGSMILES: str
-        search materials by bigsmiles identifier.
+        Search materials by bigsmiles identifier.
+    NODE_TYPE_WITHIN_PARENT: str
+        Search for a node type within a parent.
+        > Example: Find all the materials within this specific project.
 
     Examples
     -------

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -388,22 +388,22 @@ def test_api_search_uuid(cript_api: cript.API) -> None:
 
 
 @pytest.mark.skipif(not HAS_INTEGRATION_TESTS_ENABLED, reason="requires a real cript_api_token")
-def test_api_search_bigsmiles(cript_api: cript.API) -> None:
+def test_api_search_node_type_within_parent(cript_api: cript.API, simple_project_node) -> None:
     """
-    tests search method with bigsmiles SearchMode to see if we just get at least one match
-    searches for material
-    "{[][<]C(C)C(=O)O[>][<]}{[$][$]CCC(C)C[$],[$]CC(C(C)C)[$],[$]CC(C)(CC)[$][]}"
-
-    another good example can be "{[][$]CC(C)(C(=O)OCCCC)[$][]}"
+    tests search NODE_TYPE_WITHIN_PARENT
+    searches for all materials within a project node
     """
-    bigsmiles_search_value = "{[][<]C(C)C(=O)O[>][<]}{[$][$]CCC(C)C[$],[$]CC(C(C)C)[$],[$]CC(C)(CC)[$][]}"
 
-    bigsmiles_paginator = cript_api.search(node_type=cript.Material, search_mode=cript.SearchModes.BIG_SMILES, value_to_search=bigsmiles_search_value)
+    all_materials_in_project_paginator = cript_api.search(
+        node_type=cript.Material,
+        search_mode=cript.SearchModes.NODE_TYPE_WITHIN_PARENT,
+        parent_node=simple_project_node
+    )
 
-    assert isinstance(bigsmiles_paginator, Paginator)
-    assert len(bigsmiles_paginator.current_page_results) >= 1
-    # not sure if this will always be in this position in every server environment, so commenting it out for now
-    # assert bigsmiles_paginator.current_page_results[1]["name"] == "BCDB_Material_285"
+    print(simple_project_node.uuid)
+
+    assert isinstance(all_materials_in_project_paginator, Paginator)
+    assert len(all_materials_in_project_paginator.current_page_results) >= 1
 
 
 def test_get_my_user_node_from_api(cript_api: cript.API) -> None:

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -406,15 +406,9 @@ def test_api_search_child_with_exact_name_within_parent(cript_api: cript.API, cr
     tests search NODE_TYPE_WITHIN_PARENT
     searches for all materials within a project node
     """
-
     exact_name_to_search = "N-Butyl-2-chlorobenzamide"
 
-    materials_exact_name_in_project_paginator = cript_api.search(
-        node_type=cript.Material,
-        search_mode=cript.SearchModes.CHILD_WITH_EXACT_NAME_WITHIN_PARENT,
-        value_to_search=exact_name_to_search,
-        parent_node=cript_project_node
-    )
+    materials_exact_name_in_project_paginator = cript_api.search(node_type=cript.Material, search_mode=cript.SearchModes.CHILD_WITH_EXACT_NAME_WITHIN_PARENT, value_to_search=exact_name_to_search, parent_node=cript_project_node)
 
     assert isinstance(materials_exact_name_in_project_paginator, Paginator)
     assert len(materials_exact_name_in_project_paginator.current_page_results) >= 1

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -394,11 +394,7 @@ def test_api_search_node_type_within_parent(cript_api: cript.API, simple_project
     searches for all materials within a project node
     """
 
-    all_materials_in_project_paginator = cript_api.search(
-        node_type=cript.Material,
-        search_mode=cript.SearchModes.NODE_TYPE_WITHIN_PARENT,
-        parent_node=simple_project_node
-    )
+    all_materials_in_project_paginator = cript_api.search(node_type=cript.Material, search_mode=cript.SearchModes.NODE_TYPE_WITHIN_PARENT, parent_node=simple_project_node)
 
     print(simple_project_node.uuid)
 

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -11,6 +11,7 @@ import requests
 from conftest import HAS_INTEGRATION_TESTS_ENABLED
 
 import cript
+from cript import load_nodes_from_json
 from cript.api.exceptions import InvalidVocabulary
 from cript.api.paginator import Paginator
 from cript.nodes.exceptions import CRIPTNodeSchemaError
@@ -388,18 +389,36 @@ def test_api_search_uuid(cript_api: cript.API) -> None:
 
 
 @pytest.mark.skipif(not HAS_INTEGRATION_TESTS_ENABLED, reason="requires a real cript_api_token")
-def test_api_search_node_type_within_parent(cript_api: cript.API, simple_project_node) -> None:
+def test_api_search_child_node_type_within_parent(cript_api: cript.API, cript_project_node) -> None:
+    """
+    tests search NODE_TYPE_WITHIN_PARENT
+    searches for all materials within a project node
+    """
+    materials_in_project_paginator = cript_api.search(node_type=cript.Material, search_mode=cript.SearchModes.CHILD_NODE_TYPE_WITHIN_PARENT, parent_node=cript_project_node)
+
+    assert isinstance(materials_in_project_paginator, Paginator)
+    assert len(materials_in_project_paginator.current_page_results) >= 1
+
+
+@pytest.mark.skipif(not HAS_INTEGRATION_TESTS_ENABLED, reason="requires a real cript_api_token")
+def test_api_search_child_with_exact_name_within_parent(cript_api: cript.API, cript_project_node) -> None:
     """
     tests search NODE_TYPE_WITHIN_PARENT
     searches for all materials within a project node
     """
 
-    all_materials_in_project_paginator = cript_api.search(node_type=cript.Material, search_mode=cript.SearchModes.NODE_TYPE_WITHIN_PARENT, parent_node=simple_project_node)
+    exact_name_to_search = "N-Butyl-2-chlorobenzamide"
 
-    print(simple_project_node.uuid)
+    materials_exact_name_in_project_paginator = cript_api.search(
+        node_type=cript.Material,
+        search_mode=cript.SearchModes.CHILD_WITH_EXACT_NAME_WITHIN_PARENT,
+        value_to_search=exact_name_to_search,
+        parent_node=cript_project_node
+    )
 
-    assert isinstance(all_materials_in_project_paginator, Paginator)
-    assert len(all_materials_in_project_paginator.current_page_results) >= 1
+    assert isinstance(materials_exact_name_in_project_paginator, Paginator)
+    assert len(materials_exact_name_in_project_paginator.current_page_results) >= 1
+    assert materials_exact_name_in_project_paginator.current_page_results[0]["name"] == exact_name_to_search
 
 
 def test_get_my_user_node_from_api(cript_api: cript.API) -> None:

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -11,7 +11,6 @@ import requests
 from conftest import HAS_INTEGRATION_TESTS_ENABLED
 
 import cript
-from cript import load_nodes_from_json
 from cript.api.exceptions import InvalidVocabulary
 from cript.api.paginator import Paginator
 from cript.nodes.exceptions import CRIPTNodeSchemaError

--- a/tests/fixtures/primary_nodes.py
+++ b/tests/fixtures/primary_nodes.py
@@ -1,11 +1,31 @@
 import copy
 import json
 import uuid
+from typing import Dict
 
 import pytest
 from util import strip_uid_from_dict
 
 import cript
+from cript import load_nodes_from_json
+
+
+@pytest.fixture(scope="function")
+def cript_project_node(cript_api: cript.API) -> cript.Project:
+    """
+    The CRIPT project node that exists on all server environements
+
+    Notes
+    -----
+    Good to use for when you need to test against a project but can't use any single project
+    because it might not be available on all CRIPT server environments, or any permission issues, that
+    the project is visible to you but not others running your tests so they get false errors.
+    """
+    # get CRIPT project from API and convert to node
+    exact_name_paginator = cript_api.search(node_type=cript.Project, search_mode=cript.SearchModes.EXACT_NAME, value_to_search="cript")
+    cript_project_dict: Dict = exact_name_paginator.current_page_results[0]
+    cript_project_node: cript.Project = load_nodes_from_json(json.dumps(cript_project_dict))
+    return cript_project_node
 
 
 @pytest.fixture(scope="function")

--- a/tests/fixtures/primary_nodes.py
+++ b/tests/fixtures/primary_nodes.py
@@ -13,7 +13,7 @@ from cript import load_nodes_from_json
 @pytest.fixture(scope="function")
 def cript_project_node(cript_api: cript.API) -> cript.Project:
     """
-    The CRIPT project node that exists on all server environements
+    The CRIPT project node that exists on all server environments
 
     Notes
     -----


### PR DESCRIPTION
# Description
added search mode:
* `CHILD_NODE_TYPE_WITHIN_PARENT`
  * search for all materials within a project
* `CHILD_WITH_EXACT_NAME_WITHIN_PARENT`
  * Returns the materials with that exact name in the project or nothing
* The only that remains is `CHILD_CONTAINS_NAME_WITHIN_PARENT`
  * because I am unsure of how to currently fit it into the SDK
  * trello ticket for it: https://trello.com/c/mSNPFHp8

## Changes
* wrote new search mode in `cript.API.search()`
  * wrote documentation for new search mode in `cript.API.search()`
* added new search type to `SearchMode` enum
  * wrote documentation for it there
* wrote test for it
* wrote a new fixture that will get the cript project, turn it into a node, and give it to the test to use
  * the CRIPT project will exist on all environments of CRIPT
* giving good errors in case the `value_to_search` was required and the user forgot to input it
  * this way they are not left scratching their heads figuring out what is wrong and why the search result is empty

## Screenshots
![screencapture-127-0-0-1-8000-api-api-2023-08-24-14_17_03](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/b5c1c99e-71a5-453b-a1bc-b919944412ad)

> Not loving the new documentation examples back to back, but not sure what to do either
> and the exception that it will raise is too long and could be beautified

![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/e4277214-f1f0-4a7f-b347-6d7e8cc4fcac)

## Tests
* wrote integration tests for the 2 new search methods and both are passing
 
## Known Issues
* pulling the CRIPT project from API and deserializing it takes a while
  * I think this is because we call `_is_node_schema_valid()` too many times, and when I just change that method to `pass` it speeds things up by a lot
* I don't love the way I have written the new search modes here because it is becoming big and all the error handling inside of each `if` is making it harder to read, hard to keep track of, and does not capture all error cases 
  * This can be a jumping off point for now, but after this it will need a refactor
  * However, the way the code has been written makes adding a new endpoint a breeze!
* Some of the tests for search are a bit looser because each environment will have different things in the db so I cannot test the exact thing that will be returned in the exact order
  * so many times I am just checking that paginator has at least one thing that it was able to get
* Not really loving the documentation, but I think it will be usable for now until it is beautified

## Notes
* [The full documentation I made](https://trello.com/c/mSNPFHp8) based off of the short API documentation to make understanding the new search modes clearer
* Removing `@beartype` for search for now because it causes more issues than it fixes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
