### PR TITLE
Feature:  HTTP `DELETE` node

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -416,10 +416,10 @@ class API:
 
         The term "host" designates the specific CRIPT instance to which you intend to upload your data.
 
-        For most users, the host will be `criptapp.org`
+        For most users, the host will be `api.criptapp.org`
 
         ```yaml
-        host: criptapp.org
+        host: api.criptapp.org
         ```
 
         Examples

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -13,12 +13,12 @@ import requests
 from beartype import beartype
 
 from cript.api.exceptions import (
+    APIError,
     CRIPTAPIRequiredError,
     CRIPTAPISaveError,
     CRIPTConnectionError,
     InvalidHostError,
     InvalidVocabulary,
-    APIError,
 )
 from cript.api.paginator import Paginator
 from cript.api.utils.get_host_token import resolve_host_and_token

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -1098,7 +1098,7 @@ class API:
 
         delete_node_api_url: str = f"{self._host}/{node.node_type_snake_case}/{node.uuid}/"
 
-        response: Dict = requests.delete(headers=self._http_headers, url=delete_node_api_url).json()
+        response: Dict = requests.delete(headers=self._http_headers, url=delete_node_api_url, timeout=_API_TIMEOUT).json()
 
         if response["code"] != 200:
             raise APIError(api_error=str(response), http_method="DELETE", api_url=delete_node_api_url)

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -1057,7 +1057,7 @@ class API:
         None
         """
 
-        delete_node_api_url: str = f"{self._host}/{node.node_type}/{node.uuid}/"
+        delete_node_api_url: str = f"{self._host}/{node.node_type_snake_case}/{node.uuid}/"
 
         response: Dict = requests.delete(headers=self._http_headers, url=delete_node_api_url).json()
 

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -59,7 +59,7 @@ class API:
 
     # dictates whether the user wants to see terminal log statements or not
     _verbose: bool = True
-    logger: logging.Logger = None
+    logger: logging.Logger = None   # type: ignore
 
     _host: str = ""
     _api_token: str = ""

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -1030,21 +1030,33 @@ class API:
 
     def delete(self, node) -> None:
         """
-        Delete a node from the CRIPT API
+        Simply deletes the desired node from the CRIPT API and writes a log in the terminal that the node has been
+        successfully deleted.
 
-        Makes a request to the API to delete a specific node.
-        If delete was successful, it will retrieve the latest project from CRIPT API
-        and return it, and the new project node should be used from that point forward.
+        Examples
+        --------
+        ```python
+        api.delete(node=my_material_node)
+        ```
 
         Notes
         -----
         After the node has been successfully deleted, a log is written to the terminal if `cript.API.verbose = True`
 
-        Examples
-        --------
-        ```python
-        cript_api.delete(node=my_material_node)
+        ```bash
+        INFO: Deleted `Data` with UUID of `80bfc642-157e-4692-a547-97c470725397` from CRIPT API.
         ```
+
+        Warnings
+        --------
+        After successfully deleting a node from the API, keep in mind that your local Project node in your script
+        may still contain outdated data as it has not been synced with the API.
+
+        To ensure you have the latest data, follow these steps:
+
+        1. Fetch the newest Project node from the API using the [`cript.API.search()`](./#cript.api.api.API.search) provided by the SDK.
+        1. Deserialize the retrieved data into a new Project node using the [`load_nodes_from_json`](../../utility_functions/#cript.nodes.util.load_nodes_from_json) utility function.
+        1. Replace your old Project node with the new one in your script for accurate and up-to-date information.
 
         Parameters
         ----------
@@ -1054,9 +1066,10 @@ class API:
         Raises
         ------
         APIError
-            In case the API cannot delete the specified node.
+            If the API responds with anything other than HTTP status 200, then the CRIPT Python SDK raises `APIError`
+            `APIError` is raised in case the API cannot delete the specified node.
             Such cases can happen if you do not have permission to delete the node
-            or if the node is actively being used elsewhere in CRIPT and the API cannot delete it.
+            or if the node is actively being used elsewhere in CRIPT platform and the API cannot delete it.
 
         Returns
         -------
@@ -1070,4 +1083,4 @@ class API:
         if response["code"] != 200:
             raise APIError(api_error=str(response), http_method="DELETE", api_url=delete_node_api_url)
 
-        self.logger.info(f"Deleted `{node.node_type}` with UUID of {node.uuid} from CRIPT API.")
+        self.logger.info(f"Deleted `{node.node_type}` with UUID of `{node.uuid}` from CRIPT API.")

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -1062,6 +1062,4 @@ class API:
         if response["code"] != 200:
             raise APIError(api_error=str(response))
 
-        # TODO log that it has been successfully deleted from API
-        if self.verbose:
-            self.logger.info(f"Deleted `{node.node_type}` with UUID of {node.uuid} from CRIPT API.")
+        self.logger.info(f"Deleted `{node.node_type}` with UUID of {node.uuid} from CRIPT API.")

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -1036,6 +1036,16 @@ class API:
         If delete was successful, it will retrieve the latest project from CRIPT API
         and return it, and the new project node should be used from that point forward.
 
+        Notes
+        -----
+        After the node has been successfully deleted, a log is written to the terminal if `cript.API.verbose = True`
+
+        Examples
+        --------
+        ```python
+        cript_api.delete(node=my_material_node)
+        ```
+
         Parameters
         ----------
         node: UUIDBaseNode
@@ -1047,10 +1057,6 @@ class API:
             In case the API cannot delete the specified node.
             Such cases can happen if you do not have permission to delete the node
             or if the node is actively being used elsewhere in CRIPT and the API cannot delete it.
-
-        Notes
-        -----
-        After the node has been successfully deleted, a log is written to the terminal if `cript.API.verbose = True`
 
         Returns
         -------

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -287,9 +287,15 @@ class API:
         to the terminal. This can be useful for debugging and understanding the internal
         workings of the class.
 
-        When `verbose` is set to `False`, the class will only provide essential and concise
-        logging information, making the terminal output less cluttered and more user-friendly.
+        ```bash
+        INFO: Validating Project graph...
+        ```
 
+        When `verbose` is set to `False`, the class will only provide essential logging information,
+        making the terminal output less cluttered and more user-friendly.
+
+        Examples
+        --------
         ```python
         # turn off the terminal logs
         api.verbose = False

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -1057,9 +1057,11 @@ class API:
         None
         """
 
-        response: Dict = requests.delete(headers=self._http_headers, url=f"{self._host}/{node.node_type}/{node.uuid}/").json()
+        delete_node_api_url: str = f"{self._host}/{node.node_type}/{node.uuid}/"
+
+        response: Dict = requests.delete(headers=self._http_headers, url=delete_node_api_url).json()
 
         if response["code"] != 200:
-            raise APIError(api_error=str(response))
+            raise APIError(api_error=str(response), http_method="DELETE", api_url=delete_node_api_url)
 
         self.logger.info(f"Deleted `{node.node_type}` with UUID of {node.uuid} from CRIPT API.")

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -1065,30 +1065,3 @@ class API:
         # TODO log that it has been successfully deleted from API
         if self.verbose:
             self.logger.info(f"Deleted `{node.node_type}` with UUID of {node.uuid} from CRIPT API.")
-
-    # def refresh_project(self, project: cript.Project) -> cript.Project:
-    #     """
-    #     Takes a project node locally, fetches it from the API, and gives it back
-    #
-    #     Under the hood, it actually uses `cript.API.search()` with the SearchMode of `UUID`
-    #
-    #     Parameters
-    #     ----------
-    #     project: cript.Project
-    #
-    #     Raises
-    #     ------
-    #     APIError
-    #         In case the API responds with an error.
-    #
-    #     Returns
-    #     -------
-    #     Project Node: cript.Project
-    #         The latest project node as it exists on the CRIPT API
-    #     """
-    #     project_paginator: cript.Paginator = self.search(node_type=cript.Project, search_mode=SearchModes.UUID, value_to_search=project.uuid)
-    #
-    #     # deserialize project node from paginator
-    #     refreshed_project: cript.Project = cript.load_nodes_from_json(project_paginator.current_page_results[0])
-    #
-    #     return refreshed_project

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -34,7 +34,6 @@ from cript.api.valid_search_modes import SearchModes
 from cript.api.vocabulary_categories import VocabCategories
 from cript.nodes.exceptions import CRIPTNodeSchemaError
 from cript.nodes.primary_nodes.project import Project
-from cript.nodes.uuid_base import UUIDBaseNode
 
 # Do not use this directly! That includes devs.
 # Use the `_get_global_cached_api for access.
@@ -59,7 +58,7 @@ class API:
 
     # dictates whether the user wants to see terminal log statements or not
     _verbose: bool = True
-    logger: logging.Logger = None   # type: ignore
+    logger: logging.Logger = None  # type: ignore
 
     _host: str = ""
     _api_token: str = ""

--- a/src/cript/api/exceptions.py
+++ b/src/cript/api/exceptions.py
@@ -1,4 +1,4 @@
-from typing import List, Set, Optional
+from typing import List, Optional, Set
 
 from cript.exceptions import CRIPTException
 

--- a/src/cript/api/exceptions.py
+++ b/src/cript/api/exceptions.py
@@ -184,11 +184,28 @@ class APIError(CRIPTException):
 
     api_error: str = ""
 
-    def __init__(self, api_error: str) -> None:
+    # having the URL that the API gave an error for helps in debugging
+    api_url: Optional[str] = None
+    http_method: Optional[str] = None
+
+    def __init__(self, api_error: str, http_method: Optional[str] = None, api_url: Optional[str] = None) -> None:
         self.api_error = api_error
 
+        self.api_url = api_url
+
+        # TODO consider having an enum for all the HTTP methods so they are easily entered and disallows anything
+        #   that would be not make sense
+        self.http_method = http_method
+
     def __str__(self) -> str:
-        error_message: str = f"The API responded with {self.api_error}"
+        # TODO refactor all of SDK using this error to be used the same to avoid this logic and optional attributes
+        # this logic currently exists to make previous SDK work
+
+        # if you have the URL then display it, otherwise just show the error message
+        if self.api_url and self.http_method:
+            error_message: str = (f"CRIPT Python SDK sent HTTP `{self.http_method.upper()}` request to URL: `{self.api_url}` and API responded with {self.api_error}")
+        else:
+            error_message: str = f"The API responded with: {self.api_error}"
 
         return error_message
 

--- a/src/cript/api/exceptions.py
+++ b/src/cript/api/exceptions.py
@@ -203,11 +203,9 @@ class APIError(CRIPTException):
 
         # if you have the URL then display it, otherwise just show the error message
         if self.api_url and self.http_method:
-            error_message: str = (f"CRIPT Python SDK sent HTTP `{self.http_method.upper()}` request to URL: `{self.api_url}` and API responded with {self.api_error}")
+            return f"CRIPT Python SDK sent HTTP `{self.http_method.upper()}` request to URL: `{self.api_url}` and API responded with {self.api_error}"
         else:
-            error_message: str = f"The API responded with: {self.api_error}"
-
-        return error_message
+            return f"The API responded with: {self.api_error}"
 
 
 class FileDownloadError(CRIPTException):

--- a/src/cript/api/exceptions.py
+++ b/src/cript/api/exceptions.py
@@ -1,5 +1,5 @@
 import json
-from typing import List, Set, Optional
+from typing import List, Optional, Set
 
 from cript.exceptions import CRIPTException
 

--- a/src/cript/api/exceptions.py
+++ b/src/cript/api/exceptions.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Set
+from typing import List, Set, Optional
 
 from cript.exceptions import CRIPTException
 
@@ -198,7 +198,7 @@ class APIError(CRIPTException):
         self.http_method = http_method
 
     def __str__(self) -> str:
-        # TODO refactor all of SDK using this error to be used the same to avoid this logic and optional attributes
+        # TODO refactor all of SDK using this error to be used the same to avoid this logic and Optional attributes
         # this logic currently exists to make previous SDK work
 
         # if you have the URL then display it, otherwise just show the error message

--- a/src/cript/api/exceptions.py
+++ b/src/cript/api/exceptions.py
@@ -1,5 +1,5 @@
 import json
-from typing import List, Set
+from typing import List, Set, Optional
 
 from cript.exceptions import CRIPTException
 

--- a/src/cript/api/paginator.py
+++ b/src/cript/api/paginator.py
@@ -4,8 +4,8 @@ from urllib.parse import quote
 import requests
 from beartype import beartype
 
-from cript.api.exceptions import APIError
 from cript.api.api_config import _API_TIMEOUT
+from cript.api.exceptions import APIError
 
 
 class Paginator:

--- a/src/cript/api/paginator.py
+++ b/src/cript/api/paginator.py
@@ -218,6 +218,6 @@ class Paginator:
 
         # TODO give a CRIPT error if HTTP response is anything other than 200
         if response["code"] != 200:
-            raise APIError(f"API responded with: {response['error']}")
+            raise APIError(api_error={response['error']}, http_method="GET", api_url=temp_api_endpoint)
 
         return self.current_page_results

--- a/src/cript/api/paginator.py
+++ b/src/cript/api/paginator.py
@@ -218,6 +218,6 @@ class Paginator:
 
         # TODO give a CRIPT error if HTTP response is anything other than 200
         if response["code"] != 200:
-            raise APIError(api_error={response['error']}, http_method="GET", api_url=temp_api_endpoint)
+            raise APIError(api_error=str(response), http_method="GET", api_url=temp_api_endpoint)
 
         return self.current_page_results

--- a/src/cript/api/paginator.py
+++ b/src/cript/api/paginator.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict
 from urllib.parse import quote
 
 import requests
@@ -199,7 +199,7 @@ class Paginator:
 
         temp_api_endpoint = f"{temp_api_endpoint}&page={self.current_page_number}"
 
-        response = requests.get(
+        response: Dict = requests.get(
             url=temp_api_endpoint,
             headers=self._http_headers,
         ).json()

--- a/src/cript/api/paginator.py
+++ b/src/cript/api/paginator.py
@@ -1,5 +1,4 @@
 from json import JSONDecodeError
-
 from typing import Dict, List, Optional, Union
 from urllib.parse import quote
 

--- a/src/cript/api/paginator.py
+++ b/src/cript/api/paginator.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union, Dict
+from typing import Dict, List, Optional, Union
 from urllib.parse import quote
 
 import requests

--- a/src/cript/api/paginator.py
+++ b/src/cript/api/paginator.py
@@ -4,6 +4,8 @@ from urllib.parse import quote
 import requests
 from beartype import beartype
 
+from cript.api.exceptions import APIError
+
 
 class Paginator:
     """
@@ -216,6 +218,6 @@ class Paginator:
 
         # TODO give a CRIPT error if HTTP response is anything other than 200
         if response["code"] != 200:
-            raise Exception(f"API responded with: {response['error']}")
+            raise APIError(f"API responded with: {response['error']}")
 
         return self.current_page_results

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -398,7 +398,7 @@ def test_api_search_bigsmiles(cript_api: cript.API) -> None:
     """
     bigsmiles_search_value = "{[][<]C(C)C(=O)O[>][<]}{[$][$]CCC(C)C[$],[$]CC(C(C)C)[$],[$]CC(C)(CC)[$][]}"
 
-    bigsmiles_paginator = cript_api.search(node_type=cript.Material, search_mode=cript.SearchModes.BIG_SMILES, value_to_search=bigsmiles_search_value)
+    bigsmiles_paginator = cript_api.search(node_type=cript.Material, search_mode=cript.SearchModes.BIGSMILES, value_to_search=bigsmiles_search_value)
 
     assert isinstance(bigsmiles_paginator, Paginator)
     assert len(bigsmiles_paginator.current_page_results) >= 1

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -406,14 +406,6 @@ def test_api_search_bigsmiles(cript_api: cript.API) -> None:
     # assert bigsmiles_paginator.current_page_results[1]["name"] == "BCDB_Material_285"
 
 
-@pytest.mark.skipif(not HAS_INTEGRATION_TESTS_ENABLED, reason="requires a real cript_api_token")
-def test_api_refresh_project(cript_api: cript.API):
-    """
-    take the CRIPT Project, since it is available on all environments, and refresh it successfully
-    """
-    pass
-
-
 def test_get_my_user_node_from_api(cript_api: cript.API) -> None:
     """
     tests that the Python SDK can successfully get the user node associated with the API Token

--- a/tests/integration_test_helper.py
+++ b/tests/integration_test_helper.py
@@ -144,10 +144,13 @@ def delete_integration_node_helper(cript_api: cript.API, node_to_delete: UUIDBas
     cript_api.delete(node=node_to_delete)
 
     # should not be able to get node by UUID anymore because it is deleted and API should return an  error
-    with pytest.raises(APIError):
-        cript_api.search(
-            node_type=node_to_delete,
-            search_mode=cript.SearchModes.UUID,
-            value_to_search=str(node_to_delete.uuid)
-        )
 
+    # with pytest.raises(APIError):
+    deleted_node_paginator = cript_api.search(
+        node_type=node_to_delete,
+        search_mode=cript.SearchModes.UUID,
+        value_to_search=str(node_to_delete.uuid)
+    )
+
+    # be sure API responded with empty results
+    assert len(deleted_node_paginator.current_page_results) == 0

--- a/tests/integration_test_helper.py
+++ b/tests/integration_test_helper.py
@@ -1,10 +1,10 @@
 import json
 
 import pytest
+from conftest import HAS_INTEGRATION_TESTS_ENABLED
 from deepdiff import DeepDiff
 
 import cript
-from conftest import HAS_INTEGRATION_TESTS_ENABLED
 from cript.nodes.uuid_base import UUIDBaseNode
 
 

--- a/tests/integration_test_helper.py
+++ b/tests/integration_test_helper.py
@@ -137,7 +137,7 @@ def delete_integration_node_helper(cript_api: cript.API, node_to_delete: UUIDBas
         # passing in the full node to get the node type from
         node_type=node_to_delete,
         search_mode=cript.SearchModes.UUID,
-        value_to_search=str(node_to_delete.uuid)
+        value_to_search=str(node_to_delete.uuid),
     )
 
     assert len(my_node_paginator.current_page_results) == 1
@@ -148,11 +148,7 @@ def delete_integration_node_helper(cript_api: cript.API, node_to_delete: UUIDBas
     # should not be able to get node by UUID anymore because it is deleted and API should return an  error
 
     # with pytest.raises(APIError):
-    deleted_node_paginator = cript_api.search(
-        node_type=node_to_delete,
-        search_mode=cript.SearchModes.UUID,
-        value_to_search=str(node_to_delete.uuid)
-    )
+    deleted_node_paginator = cript_api.search(node_type=node_to_delete, search_mode=cript.SearchModes.UUID, value_to_search=str(node_to_delete.uuid))
 
     # be sure API responded with empty results
     assert len(deleted_node_paginator.current_page_results) == 0

--- a/tests/integration_test_helper.py
+++ b/tests/integration_test_helper.py
@@ -118,6 +118,8 @@ def delete_integration_node_helper(cript_api: cript.API, node_to_delete: UUIDBas
     1. checks that it first exists on the API before deleting
     1. sends an HTTP DELETE to API
     1. asserts that the API response is 200
+        > This is done under the hood in the `cript.API.delete()`
+        method where at the end it checks that the response is 2000, else raises an error
     1. tries to get the same node via UUID from the API and expects that it should fail
 
     Notes

--- a/tests/integration_test_helper.py
+++ b/tests/integration_test_helper.py
@@ -1,11 +1,10 @@
 import json
 
 import pytest
-from conftest import HAS_INTEGRATION_TESTS_ENABLED
 from deepdiff import DeepDiff
 
 import cript
-from cript.api.exceptions import APIError
+from conftest import HAS_INTEGRATION_TESTS_ENABLED
 from cript.nodes.uuid_base import UUIDBaseNode
 
 

--- a/tests/integration_test_helper.py
+++ b/tests/integration_test_helper.py
@@ -44,18 +44,12 @@ def integrate_nodes_helper(cript_api: cript.API, project_node: cript.Project):
     * ignoring the UID field through all the JSON because those the API changes when responding
     """
 
-    # TODO this is temporary and must be removed
-    developer_name = "Navid"
-
     if not HAS_INTEGRATION_TESTS_ENABLED:
         pytest.skip("Integration tests with API requires real API and Storage token")
         return
 
     print("\n\n=================== Project Node ============================")
-    if developer_name == "Navid":
-        print(project_node.get_json(sort_keys=False).json)
-    else:
-        print(project_node.get_json(sort_keys=False, condense_to_uuid={}, indent=2).json)
+    print(project_node.get_json(sort_keys=False, condense_to_uuid={}, indent=2).json)
     print("==============================================================")
 
     cript_api.save(project_node)
@@ -67,10 +61,7 @@ def integrate_nodes_helper(cript_api: cript.API, project_node: cript.Project):
     my_project_from_api_dict = my_paginator.current_page_results[0]
 
     print("\n\n================= API Response Node ============================")
-    if developer_name == "Navid":
-        print(json.dumps(my_project_from_api_dict, sort_keys=False))
-    else:
-        print(json.dumps(my_project_from_api_dict, sort_keys=False, indent=2))
+    print(json.dumps(my_project_from_api_dict, sort_keys=False, indent=2))
     print("==============================================================")
 
     # Configure keys and blocks to be ignored by deepdiff using exclude_regex_path
@@ -103,10 +94,7 @@ def integrate_nodes_helper(cript_api: cript.API, project_node: cript.Project):
     # try to convert api JSON project to node
     my_project_from_api = cript.load_nodes_from_json(json.dumps(my_project_from_api_dict))
     print("\n\n=================== Project Node Deserialized =========================")
-    if developer_name == "Navid":
-        print(my_project_from_api.get_json(sort_keys=False).json)
-    else:
-        print(my_project_from_api.get_json(sort_keys=False, condense_to_uuid={}, indent=2).json)
+    print(my_project_from_api.get_json(sort_keys=False, condense_to_uuid={}, indent=2).json)
     print("==============================================================")
     print("\n\n\n######################################## TEST Passed ########################################\n\n\n")
 
@@ -118,13 +106,16 @@ def delete_integration_node_helper(cript_api: cript.API, node_to_delete: UUIDBas
     1. sends an HTTP DELETE to API
     1. asserts that the API response is 200
         > This is done under the hood in the `cript.API.delete()`
-        method where at the end it checks that the response is 2000, else raises an error
+        method where at the end it checks that the response is 200, else raises an error
     1. tries to get the same node via UUID from the API and expects that it should fail
 
     Notes
     ------
-    > for future it should also take the project that the node was in, and get the project again
-    > then compare that the node was successfully deleted/missing from the project
+    > for future this test should also take the project that the node was in, get the project again,
+    > and compare that the node was successfully deleted/missing from the project
+
+    > within search we can also add assert statements to be sure that the API gave the same node
+    > that we searched for. Not needed at the time of writing this test
     """
 
     if not HAS_INTEGRATION_TESTS_ENABLED:
@@ -139,14 +130,13 @@ def delete_integration_node_helper(cript_api: cript.API, node_to_delete: UUIDBas
         value_to_search=str(node_to_delete.uuid),
     )
 
+    # be sure API returned at least one result for the node that we searched for
     assert len(my_node_paginator.current_page_results) == 1
 
     # DELETE the node from the API
     cript_api.delete(node=node_to_delete)
 
-    # should not be able to get node by UUID anymore because it is deleted and API should return an  error
-
-    # with pytest.raises(APIError):
+    # should not be able to get node by UUID anymore because it is deleted
     deleted_node_paginator = cript_api.search(node_type=node_to_delete, search_mode=cript.SearchModes.UUID, value_to_search=str(node_to_delete.uuid))
 
     # be sure API responded with empty results

--- a/tests/integration_test_helper.py
+++ b/tests/integration_test_helper.py
@@ -96,3 +96,19 @@ def integrate_nodes_helper(cript_api: cript.API, project_node: cript.Project):
     print(my_project_from_api.get_json(sort_keys=False, condense_to_uuid={}, indent=2).json)
     print("==============================================================")
     print("\n\n\n######################################## TEST Passed ########################################\n\n\n")
+
+
+def integrate_delete_node_helper(cript_api: cript.API, node_to_delete) -> None:
+    """
+    1. takes the node/sub-object that needs to be deleted
+    1. checks that it first exists on the API before deleting
+    1. sends an HTTP DELETE to API
+    1. asserts that the API response is 200
+    1. tries to get the same node via UUID from the API and expects that it should fail
+
+    Notes
+    ------
+    > for future it should also take the project that the node was in, and get the project again
+    > then compare that the node was successfully deleted/missing from the project
+    """
+    pass

--- a/tests/integration_test_helper.py
+++ b/tests/integration_test_helper.py
@@ -140,10 +140,10 @@ def delete_integration_node_helper(cript_api: cript.API, node_to_delete: UUIDBas
 
     assert len(my_node_paginator.current_page_results) == 1
 
-    # DELETE the project from API
+    # DELETE the node from the API
     cript_api.delete(node=node_to_delete)
 
-    # should not be able to get node by UUID anymore because it is deleted and should get an error
+    # should not be able to get node by UUID anymore because it is deleted and API should return an  error
     with pytest.raises(APIError):
         cript_api.search(
             node_type=node_to_delete,

--- a/tests/nodes/primary_nodes/test_collection.py
+++ b/tests/nodes/primary_nodes/test_collection.py
@@ -6,6 +6,7 @@ from integration_test_helper import integrate_nodes_helper
 from util import strip_uid_from_dict
 
 import cript
+from tests.integration_test_helper import delete_integration_node_helper
 
 
 def test_create_simple_collection(simple_experiment_node) -> None:
@@ -182,3 +183,6 @@ def test_integration_collection(cript_api, simple_project_node, simple_collectio
     # simple_project_node.collection[0].notes = "my collection notes UPDATED"
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    delete_integration_node_helper(cript_api=cript_api, node_to_delete=simple_collection_node)

--- a/tests/nodes/primary_nodes/test_collection.py
+++ b/tests/nodes/primary_nodes/test_collection.py
@@ -2,7 +2,10 @@ import copy
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/primary_nodes/test_collection.py
+++ b/tests/nodes/primary_nodes/test_collection.py
@@ -2,11 +2,10 @@ import copy
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
-from tests.integration_test_helper import delete_integration_node_helper
 
 
 def test_create_simple_collection(simple_experiment_node) -> None:

--- a/tests/nodes/primary_nodes/test_computation.py
+++ b/tests/nodes/primary_nodes/test_computation.py
@@ -2,7 +2,7 @@ import copy
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
@@ -143,3 +143,6 @@ def test_integration_computation(cript_api, simple_project_node, simple_computat
     simple_project_node.collection[0].experiment[0].computation[0].type = "data_fit"
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    delete_integration_node_helper(cript_api=cript_api, node_to_delete=simple_computation_node)

--- a/tests/nodes/primary_nodes/test_computation.py
+++ b/tests/nodes/primary_nodes/test_computation.py
@@ -2,7 +2,10 @@ import copy
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/primary_nodes/test_computational_process.py
+++ b/tests/nodes/primary_nodes/test_computational_process.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
@@ -145,7 +145,7 @@ def test_serialize_computational_process_to_json(simple_computational_process_no
     assert ref_dict == expected_dict
 
 
-def test_integration_computational_process(cript_api, simple_project_node, simple_collection_node, simple_experiment_node, simplest_computational_process_node, simple_material_node, simple_data_node):
+def test_integration_computational_process(cript_api, simple_project_node, simple_collection_node, simple_experiment_node, simplest_computational_process_node, simple_material_node, simple_data_node) -> None:
     """
     integration test between Python SDK and API Client
 
@@ -177,3 +177,6 @@ def test_integration_computational_process(cript_api, simple_project_node, simpl
     simple_project_node.collection[0].experiment[0].computation_process[0].type = "DPD"
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    delete_integration_node_helper(cript_api=cript_api, node_to_delete=simplest_computational_process_node)

--- a/tests/nodes/primary_nodes/test_computational_process.py
+++ b/tests/nodes/primary_nodes/test_computational_process.py
@@ -1,7 +1,10 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/primary_nodes/test_data.py
+++ b/tests/nodes/primary_nodes/test_data.py
@@ -2,7 +2,10 @@ import copy
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/primary_nodes/test_data.py
+++ b/tests/nodes/primary_nodes/test_data.py
@@ -2,7 +2,7 @@ import copy
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
@@ -182,3 +182,6 @@ def test_integration_data(cript_api, simple_project_node, simple_data_node):
     simple_project_node.collection[0].experiment[0].data[0].type = "afm_height"
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    delete_integration_node_helper(cript_api=cript_api, node_to_delete=simple_data_node)

--- a/tests/nodes/primary_nodes/test_experiment.py
+++ b/tests/nodes/primary_nodes/test_experiment.py
@@ -6,6 +6,7 @@ from integration_test_helper import integrate_nodes_helper
 from util import strip_uid_from_dict
 
 import cript
+from tests.integration_test_helper import delete_integration_node_helper
 
 
 def test_create_simple_experiment() -> None:
@@ -227,3 +228,6 @@ def test_integration_experiment(cript_api, simple_project_node, simple_collectio
     # update simple attribute to trigger update
     simple_project_node.collection[0].experiment[0].funding = ["update1", "update2", "update3"]
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    delete_integration_node_helper(cript_api=cript_api, node_to_delete=simple_experiment_node)

--- a/tests/nodes/primary_nodes/test_experiment.py
+++ b/tests/nodes/primary_nodes/test_experiment.py
@@ -2,7 +2,10 @@ import copy
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/primary_nodes/test_experiment.py
+++ b/tests/nodes/primary_nodes/test_experiment.py
@@ -2,11 +2,10 @@ import copy
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
-from tests.integration_test_helper import delete_integration_node_helper
 
 
 def test_create_simple_experiment() -> None:

--- a/tests/nodes/primary_nodes/test_inventory.py
+++ b/tests/nodes/primary_nodes/test_inventory.py
@@ -1,7 +1,10 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/primary_nodes/test_inventory.py
+++ b/tests/nodes/primary_nodes/test_inventory.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
@@ -76,3 +76,6 @@ def test_integration_inventory(cript_api, simple_project_node, simple_inventory_
     simple_project_node.collection[0].inventory[0].notes = "inventory notes UPDATED"
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    delete_integration_node_helper(cript_api=cript_api, node_to_delete=simple_inventory_node)

--- a/tests/nodes/primary_nodes/test_material.py
+++ b/tests/nodes/primary_nodes/test_material.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
@@ -144,3 +144,6 @@ def test_integration_material(cript_api, simple_project_node, simple_material_no
     simple_project_node.material[0].identifier = [{"bigsmiles": "my bigsmiles UPDATED"}]
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    delete_integration_node_helper(cript_api=cript_api, node_to_delete=simple_material_node)

--- a/tests/nodes/primary_nodes/test_material.py
+++ b/tests/nodes/primary_nodes/test_material.py
@@ -1,7 +1,10 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/primary_nodes/test_process.py
+++ b/tests/nodes/primary_nodes/test_process.py
@@ -6,7 +6,7 @@ from integration_test_helper import integrate_nodes_helper
 from util import strip_uid_from_dict
 
 import cript
-from tests.integration_test_helper import delete_integration_node_helper
+from integration_test_helper import delete_integration_node_helper
 
 
 def test_simple_process() -> None:

--- a/tests/nodes/primary_nodes/test_process.py
+++ b/tests/nodes/primary_nodes/test_process.py
@@ -6,6 +6,7 @@ from integration_test_helper import integrate_nodes_helper
 from util import strip_uid_from_dict
 
 import cript
+from tests.integration_test_helper import delete_integration_node_helper
 
 
 def test_simple_process() -> None:
@@ -214,3 +215,6 @@ def test_integration_complex_process(cript_api, simple_project_node, simple_proc
     simple_project_node.collection[0].experiment[0].process[0].description = "process description UPDATED"
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    delete_integration_node_helper(cript_api=cript_api, node_to_delete=simple_process_node)

--- a/tests/nodes/primary_nodes/test_process.py
+++ b/tests/nodes/primary_nodes/test_process.py
@@ -2,11 +2,13 @@ import copy
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript
-from integration_test_helper import delete_integration_node_helper
 
 
 def test_simple_process() -> None:

--- a/tests/nodes/primary_nodes/test_project.py
+++ b/tests/nodes/primary_nodes/test_project.py
@@ -2,12 +2,11 @@ import json
 import uuid
 
 import pytest
-from integration_test_helper import integrate_nodes_helper
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
 from cript.api.exceptions import APIError
-from tests.integration_test_helper import delete_integration_node_helper
 
 
 def test_create_simple_project(simple_collection_node) -> None:

--- a/tests/nodes/primary_nodes/test_project.py
+++ b/tests/nodes/primary_nodes/test_project.py
@@ -1,7 +1,10 @@
 import json
 import uuid
 
-from integration_test_helper import delete_integration_node_helper, integrate_nodes_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/primary_nodes/test_project.py
+++ b/tests/nodes/primary_nodes/test_project.py
@@ -1,12 +1,10 @@
 import json
 import uuid
 
-import pytest
 from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
-from cript.api.exceptions import APIError
 
 
 def test_create_simple_project(simple_collection_node) -> None:

--- a/tests/nodes/primary_nodes/test_project.py
+++ b/tests/nodes/primary_nodes/test_project.py
@@ -88,4 +88,3 @@ def test_integration_project(cript_api, simple_project_node):
 
     # ========= test delete =========
     delete_integration_node_helper(cript_api=cript_api, node_to_delete=simple_project_node)
-

--- a/tests/nodes/primary_nodes/test_project.py
+++ b/tests/nodes/primary_nodes/test_project.py
@@ -1,7 +1,8 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (delete_integration_node_helper,
+                                     integrate_nodes_helper)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/primary_nodes/test_project.py
+++ b/tests/nodes/primary_nodes/test_project.py
@@ -7,6 +7,7 @@ from util import strip_uid_from_dict
 
 import cript
 from cript.api.exceptions import APIError
+from tests.integration_test_helper import delete_integration_node_helper
 
 
 def test_create_simple_project(simple_collection_node) -> None:
@@ -89,13 +90,5 @@ def test_integration_project(cript_api, simple_project_node):
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
 
     # ========= test delete =========
-    cript_api.delete(node=simple_project_node)
-
-    # should not be able to get node by UUID anymore because it is deleted and should get an error
-    with pytest.raises(APIError):
-        cript_api.search(
-            node_type=cript.Project,
-            search_mode=cript.SearchModes.UUID,
-            value_to_search=str(simple_project_node.uuid)
-        )
+    delete_integration_node_helper(cript_api=cript_api, node_to_delete=simple_project_node)
 

--- a/tests/nodes/primary_nodes/test_project.py
+++ b/tests/nodes/primary_nodes/test_project.py
@@ -1,8 +1,7 @@
 import json
 import uuid
 
-from integration_test_helper import (delete_integration_node_helper,
-                                     integrate_nodes_helper)
+from integration_test_helper import delete_integration_node_helper, integrate_nodes_helper
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/primary_nodes/test_project.py
+++ b/tests/nodes/primary_nodes/test_project.py
@@ -1,10 +1,12 @@
 import json
 import uuid
 
+import pytest
 from integration_test_helper import integrate_nodes_helper
 from util import strip_uid_from_dict
 
 import cript
+from cript.api.exceptions import APIError
 
 
 def test_create_simple_project(simple_collection_node) -> None:
@@ -85,3 +87,15 @@ def test_integration_project(cript_api, simple_project_node):
     simple_project_node.notes = "project notes UPDATED"
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test update =========
+    cript_api.delete(node=simple_project_node)
+
+    # should not be able to get node by UUID anymore because it is deleted and should get an error
+    with pytest.raises(APIError):
+        cript_api.search(
+            node_type=cript.Project,
+            search_mode=cript.SearchModes.UUID,
+            value_to_search=str(simple_project_node.uuid)
+        )
+

--- a/tests/nodes/primary_nodes/test_project.py
+++ b/tests/nodes/primary_nodes/test_project.py
@@ -88,7 +88,7 @@ def test_integration_project(cript_api, simple_project_node):
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
 
-    # ========= test update =========
+    # ========= test delete =========
     cript_api.delete(node=simple_project_node)
 
     # should not be able to get node by UUID anymore because it is deleted and should get an error

--- a/tests/nodes/primary_nodes/test_reference.py
+++ b/tests/nodes/primary_nodes/test_reference.py
@@ -3,7 +3,10 @@ import uuid
 import warnings
 
 import pytest
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/primary_nodes/test_reference.py
+++ b/tests/nodes/primary_nodes/test_reference.py
@@ -2,10 +2,12 @@ import json
 import uuid
 import warnings
 
-from integration_test_helper import integrate_nodes_helper
+import pytest
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
+from cript.api.exceptions import APIError
 
 
 def test_create_simple_reference() -> None:
@@ -220,3 +222,15 @@ def test_integration_reference(cript_api, simple_project_node, complex_citation_
     simple_project_node.collection[0].citation[0].reference.title = "reference title UPDATED"
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    # isolate reference from citation
+    reference_node_from_citation: cript.Reference = complex_citation_node.reference
+
+    # cannot delete a reference node because it is a frozen node
+    # so API gives errors when trying to delete it
+    with pytest.raises(APIError) as error:
+        delete_integration_node_helper(cript_api=cript_api, node_to_delete=reference_node_from_citation)
+
+        # current API error when trying to delete reference
+        assert "The browser (or proxy) sent a request that this server could not understand." in str(error)

--- a/tests/nodes/subobjects/test_algorithm.py
+++ b/tests/nodes/subobjects/test_algorithm.py
@@ -1,7 +1,10 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/subobjects/test_algorithm.py
+++ b/tests/nodes/subobjects/test_algorithm.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
@@ -66,3 +66,6 @@ def test_integration_algorithm(cript_api, simple_project_node, simple_collection
     simple_project_node.collection[0].experiment[0].computation[0].software_configuration[0].algorithm[0].type = "integration"
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    delete_integration_node_helper(cript_api=cript_api, node_to_delete=simple_algorithm_node)

--- a/tests/nodes/subobjects/test_citation.py
+++ b/tests/nodes/subobjects/test_citation.py
@@ -1,7 +1,10 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/subobjects/test_citation.py
+++ b/tests/nodes/subobjects/test_citation.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
@@ -51,3 +51,6 @@ def test_integration_citation(cript_api, simple_project_node, simple_collection_
     simple_project_node.collection[0].citation[0].type = "extracted_by_human"
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    delete_integration_node_helper(cript_api=cript_api, node_to_delete=complex_citation_node)

--- a/tests/nodes/subobjects/test_computational_forcefiled.py
+++ b/tests/nodes/subobjects/test_computational_forcefiled.py
@@ -2,7 +2,10 @@ import copy
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/subobjects/test_computational_forcefiled.py
+++ b/tests/nodes/subobjects/test_computational_forcefiled.py
@@ -2,7 +2,7 @@ import copy
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
@@ -84,3 +84,6 @@ def test_integration_computational_forcefield(cript_api, simple_project_node, si
     # change simple attribute to trigger update
     simple_project_node.material[0].computational_forcefield.description = "material computational_forcefield description UPDATED"
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    delete_integration_node_helper(cript_api=cript_api, node_to_delete=simple_computational_forcefield_node)

--- a/tests/nodes/subobjects/test_condition.py
+++ b/tests/nodes/subobjects/test_condition.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 
@@ -85,3 +85,6 @@ def test_integration_process_condition(cript_api, simple_project_node, simple_co
     simple_project_node.collection[0].experiment[0].computation[0].condition[0].descriptor = "condition descriptor UPDATED"
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    delete_integration_node_helper(cript_api=cript_api, node_to_delete=simple_condition_node)

--- a/tests/nodes/subobjects/test_condition.py
+++ b/tests/nodes/subobjects/test_condition.py
@@ -1,7 +1,10 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 

--- a/tests/nodes/subobjects/test_equipment.py
+++ b/tests/nodes/subobjects/test_equipment.py
@@ -2,7 +2,7 @@ import copy
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 
@@ -73,3 +73,6 @@ def test_integration_equipment(cript_api, simple_project_node, simple_collection
     simple_project_node.collection[0].experiment[0].process[0].equipment[0].description = "equipment description UPDATED"
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    delete_integration_node_helper(cript_api=cript_api, node_to_delete=simple_equipment_node)

--- a/tests/nodes/subobjects/test_equipment.py
+++ b/tests/nodes/subobjects/test_equipment.py
@@ -2,7 +2,10 @@ import copy
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 

--- a/tests/nodes/subobjects/test_ingredient.py
+++ b/tests/nodes/subobjects/test_ingredient.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
@@ -70,3 +70,6 @@ def test_integration_ingredient(cript_api, simple_project_node, simple_collectio
     simple_project_node.collection[0].experiment[0].process[0].ingredient[0].keyword = ["polymer"]
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    delete_integration_node_helper(cript_api=cript_api, node_to_delete=simple_ingredient_node)

--- a/tests/nodes/subobjects/test_ingredient.py
+++ b/tests/nodes/subobjects/test_ingredient.py
@@ -1,7 +1,10 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/subobjects/test_parameter.py
+++ b/tests/nodes/subobjects/test_parameter.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
@@ -57,3 +57,6 @@ def test_integration_parameter(cript_api, simple_project_node, simple_collection
     simple_project_node.collection[0].experiment[0].computation[0].software_configuration[0].algorithm[0].parameter[0].value = 123456789
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    delete_integration_node_helper(cript_api=cript_api, node_to_delete=complex_parameter_node)

--- a/tests/nodes/subobjects/test_parameter.py
+++ b/tests/nodes/subobjects/test_parameter.py
@@ -1,7 +1,10 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/subobjects/test_property.py
+++ b/tests/nodes/subobjects/test_property.py
@@ -2,8 +2,7 @@ import copy
 import json
 import uuid
 
-from integration_test_helper import (delete_integration_node_helper,
-                                     integrate_nodes_helper)
+from integration_test_helper import delete_integration_node_helper, integrate_nodes_helper
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/subobjects/test_property.py
+++ b/tests/nodes/subobjects/test_property.py
@@ -2,7 +2,10 @@ import copy
 import json
 import uuid
 
-from integration_test_helper import delete_integration_node_helper, integrate_nodes_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/subobjects/test_property.py
+++ b/tests/nodes/subobjects/test_property.py
@@ -2,7 +2,7 @@ import copy
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
@@ -115,3 +115,6 @@ def test_integration_material_property(cript_api, simple_project_node, simple_ma
     # change simple attribute to trigger update
     simple_project_node.material[0].property[0].notes = "property sub-object notes UPDATED"
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    delete_integration_node_helper(cript_api=cript_api, node_to_delete=simple_property_node)

--- a/tests/nodes/subobjects/test_property.py
+++ b/tests/nodes/subobjects/test_property.py
@@ -2,7 +2,8 @@ import copy
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (delete_integration_node_helper,
+                                     integrate_nodes_helper)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/subobjects/test_quantity.py
+++ b/tests/nodes/subobjects/test_quantity.py
@@ -1,7 +1,10 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/subobjects/test_quantity.py
+++ b/tests/nodes/subobjects/test_quantity.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
@@ -63,3 +63,11 @@ def test_integration_quantity(cript_api, simple_project_node, simple_collection_
     # change simple attribute to trigger update
     simple_project_node.collection[0].experiment[0].process[0].ingredient[0].quantity[0].value = 123456789
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    # isolate quantity from ingredient
+    quantity_subobject: cript.Quantity = simple_ingredient_node.quantity[0]
+
+    # each ingredient is required to have a quantity,
+    # so deleting the only quantity that it has is illegal because then it would make it invalid
+    delete_integration_node_helper(cript_api=cript_api, node_to_delete=quantity_subobject)

--- a/tests/nodes/subobjects/test_software.py
+++ b/tests/nodes/subobjects/test_software.py
@@ -79,5 +79,8 @@ def test_integration_software(cript_api, simple_project_node, simple_computation
     # ========= test delete =========
     # software nodes are frozen nodes and cannot be deleted
     # we expect the API to give an error when trying to delete a frozen node
-    with pytest.raises(APIError):
+    with pytest.raises(APIError) as error:
         delete_integration_node_helper(cript_api=cript_api, node_to_delete=complex_software_node)
+
+        # the current error that the API gives
+        assert "'error': 'The browser (or proxy) sent a request that this server could not understand.'" in str(error)

--- a/tests/nodes/subobjects/test_software.py
+++ b/tests/nodes/subobjects/test_software.py
@@ -83,4 +83,4 @@ def test_integration_software(cript_api, simple_project_node, simple_computation
         delete_integration_node_helper(cript_api=cript_api, node_to_delete=complex_software_node)
 
         # the current error that the API gives
-        assert "'error': 'The browser (or proxy) sent a request that this server could not understand.'" in str(error)
+        assert "The browser (or proxy) sent a request that this server could not understand." in str(error)

--- a/tests/nodes/subobjects/test_software.py
+++ b/tests/nodes/subobjects/test_software.py
@@ -2,10 +2,12 @@ import copy
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper
+import pytest
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
+from cript.api.exceptions import APIError
 
 
 def test_json(complex_software_node, complex_software_dict):
@@ -73,3 +75,9 @@ def test_integration_software(cript_api, simple_project_node, simple_computation
     # change simple attribute to trigger update
     simple_project_node.collection[0].experiment[0].computation[0].software_configuration[0].software.version = "software version UPDATED"
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    # software nodes are frozen nodes and cannot be deleted
+    # we expect the API to give an error when trying to delete a frozen node
+    with pytest.raises(APIError):
+        delete_integration_node_helper(cript_api=cript_api, node_to_delete=complex_software_node)

--- a/tests/nodes/subobjects/test_software.py
+++ b/tests/nodes/subobjects/test_software.py
@@ -3,7 +3,10 @@ import json
 import uuid
 
 import pytest
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/subobjects/test_software_configuration.py
+++ b/tests/nodes/subobjects/test_software_configuration.py
@@ -1,10 +1,12 @@
 import json
 import uuid
 
-from integration_test_helper import integrate_nodes_helper
+import pytest
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
+from cript.api.exceptions import APIError
 
 
 def test_json(complex_software_configuration_node, complex_software_configuration_dict):
@@ -61,3 +63,11 @@ def test_integration_software_configuration(cript_api, simple_project_node, simp
     simple_project_node.collection[0].experiment[0].computation[0].software_configuration[0].notes = "software configuration integration test UPDATED"
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    # cannot delete `Software_Configuration` from a frozen node `Software`
+    with pytest.raises(APIError) as error:
+        delete_integration_node_helper(cript_api=cript_api, node_to_delete=simple_software_configuration)
+
+        # the current error that the API gives
+        assert "The browser (or proxy) sent a request that this server could not understand." in str(error)

--- a/tests/nodes/subobjects/test_software_configuration.py
+++ b/tests/nodes/subobjects/test_software_configuration.py
@@ -2,7 +2,10 @@ import json
 import uuid
 
 import pytest
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -4,10 +4,8 @@ import os
 import uuid
 
 import pytest
-from integration_test_helper import (
-    delete_integration_node_helper,
-    integrate_nodes_helper,
-)
+from integration_test_helper import (delete_integration_node_helper,
+                                     integrate_nodes_helper)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -4,8 +4,7 @@ import os
 import uuid
 
 import pytest
-from integration_test_helper import (delete_integration_node_helper,
-                                     integrate_nodes_helper)
+from integration_test_helper import delete_integration_node_helper, integrate_nodes_helper
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -4,7 +4,10 @@ import os
 import uuid
 
 import pytest
-from integration_test_helper import delete_integration_node_helper, integrate_nodes_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -4,7 +4,7 @@ import os
 import uuid
 
 import pytest
-from integration_test_helper import integrate_nodes_helper
+from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
 from util import strip_uid_from_dict
 
 import cript
@@ -218,3 +218,9 @@ def test_integration_file(cript_api, simple_project_node, simple_data_node):
     # simple_project_node.collection[0].experiment[0].data[0].file[0].data_dictionary = "file data_dictionary UPDATED"
 
     integrate_nodes_helper(cript_api=cript_api, project_node=simple_project_node)
+
+    # ========= test delete =========
+    # isolated file node from data node
+    file_node: cript.File = simple_project_node.collection[0].experiment[0].data[0].file[0]
+
+    delete_integration_node_helper(cript_api=cript_api, node_to_delete=file_node)

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -4,7 +4,10 @@ import os
 import uuid
 
 import pytest
-from integration_test_helper import integrate_nodes_helper, delete_integration_node_helper
+from integration_test_helper import (
+    delete_integration_node_helper,
+    integrate_nodes_helper,
+)
 from util import strip_uid_from_dict
 
 import cript


### PR DESCRIPTION
# Description
giving users a way to delete a nodes from the API

## Changes

### Wrote Delete
* wrote `cript.API.delete()` method
* wrote integration tests for delete
* wrote full documentation for delete

---

### Updated Logger
* created a `set_log()` method
  * it essentially sets the logger for the whole `cript.API` class
    * was considering making it into a getter that would create a new logger and return it, but since each class should only have one logger that might encourage bad programming and create bugs
  * made `verbose` into a property that changes the class logger after the user sets it.
    * The user simply sets it casually and we rearrange the logger behind the scenes for them to work correctly so they can turn verbose `ON` and `OFF` easily throughout their script 
    * The logger has good simple logic so we don't have to keep putting `if self.verbose then log`
  * I am not sure if the way I am doing logger is perfect right now, but I think it is good for our use cases for now and we can upgrade it as we go
* wrote/updated documentation for `cript.API.verbose` and the logging in general for that class
---

### Updated Paginator Errors
* changed paginator exception from `Exception` to `APIError`
* upgraded/refactored `APIError`
  * `APIError` did not have as much information and was unhelpful in debugging
  * gave it more information and made it much more helpful for users to read and for us to debug

---

### Updated Documentation
* updated documentation: noticed that documentation for `cript.API` tells users to use host as `criptapp.org` and since that was outdated, I changed it to `api.criptapp.org`

## Tests
* wrote out `integrate_delete_node_helper`

## Screenshots
### Terminal Log: `cript.API.delete()` Successfully Deleted a Node
This is logged to the terminal after the SDK successfully deletes a node from the API
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/ee72d329-fe26-470d-874d-fabdb4120b6f)

### New APIError Exception Terminal Output:
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/070b6b84-fdce-4afe-9149-51d841d1d28b)

### Documentation: `cript.API.delete()`
![screencapture-127-0-0-1-8000-api-api-2023-08-29-18_40_401](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/c2b76e11-1adb-457f-80fc-191aee76651d)

### Documentation: `cript.API logging`
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/b473f52a-083a-4022-b78d-cda57731aa4b)


## Known Issues
* We are only using logger in the `cript.API` but if we start putting it in more places then we'll need a refactor for it to make it cleaner and consider putting it within `cript/logger.py`

## Notes
### Integration Tests
**Recommendation:** I recommend running the all SDK tests locally to confirm everything I did works correctly

<details>
    <summary> click to see screenshots of all tests ran locally </summary>
        <img src="https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/d7892081-9733-4f92-a6c7-a6dea009845c">
</details>

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
