### PR TITLE
Support a limited number of nodes per POST/PATCH request

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -618,7 +618,8 @@ class API:
             Just sends a `POST` or `Patch` request to the API
         """
         try:
-            self._internal_save(project, max_number_of_nodes_per_save=4)
+            # TODO: replace the hard coded 100 with a request to the API end point
+            self._internal_save(project, max_number_of_nodes_per_save=100)
         except CRIPTAPISaveError as exc:
             if exc.pre_saved_nodes:
                 for node_uuid in exc.pre_saved_nodes:
@@ -661,7 +662,6 @@ class API:
 
             # If the number of nodes is larger then accepted by the backend.
             # Try to save individual nodes first.
-            print(len(assembly_data.json_node_set), max_number_of_nodes_per_save)
             if len(assembly_data.json_node_set) > max_number_of_nodes_per_save:
                 # Pick one of the nodes at random, or for simplicity 0
                 pre_save_node = assembly_data.json_node_set.pop()
@@ -669,7 +669,6 @@ class API:
                 while pre_save_node == node:
                     pre_save_node = assembly_data.json_node_set.pop()
                 # Save this node ahead of time
-                print(pre_save_node.node_type, pre_save_node.uuid, save_values)
                 self._internal_save(pre_save_node, max_number_of_nodes_per_save, save_values)
                 # Ensure the node will be just a UUID at the next try to save the whole project
                 save_values.saved_uuid.add(str(pre_save_node.uuid))
@@ -725,7 +724,6 @@ class API:
                 break
 
         if response["code"] != 200:
-            print(save_values)
             raise CRIPTAPISaveError(api_host_domain=self._host, http_code=response["code"], api_response=response["error"], patch_request=patch_request, pre_saved_nodes=save_values.saved_uuid, json_data=json_data)  # type: ignore
 
         save_values.saved_uuid.add(str(node.uuid))

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -662,6 +662,7 @@ class API:
 
             # If the number of nodes is larger then accepted by the backend.
             # Try to save individual nodes first.
+            print(len(assembly_data.json_node_set), max_number_of_nodes_per_save)
             if len(assembly_data.json_node_set) > max_number_of_nodes_per_save:
                 # Pick one of the nodes at random, or for simplicity 0
                 pre_save_node = assembly_data.json_node_set.pop()
@@ -676,6 +677,7 @@ class API:
                     raise RuntimeError("The number of nodes to be saved at the same time, cannot be further reduce, current number of nodes to save {len(assembly_data)} max number accepted by API {max_number_of_nodes_per_save}")
                 # We don't need to attempt to save, we know it would fail, so continue to the next iteration
                 continue
+            print("B", len(assembly_data.json_node_set), max_number_of_nodes_per_save)
 
             # This checks if the current node exists on the back end.
             # if it does exist we use `patch` if it doesn't `post`.

--- a/src/cript/api/utils/save_helper.py
+++ b/src/cript/api/utils/save_helper.py
@@ -53,7 +53,7 @@ class _InternalSaveValues:
         return False
 
 
-def _fix_node_save(api, node, response, save_values: _InternalSaveValues) -> _InternalSaveValues:
+def _fix_node_save(api, node, response, save_values: _InternalSaveValues, max_number_of_nodes_per_save: int) -> _InternalSaveValues:
     """
     Helper function, that attempts to fix a bad node.
     And if it is fixable, we resave the entire node.
@@ -74,7 +74,7 @@ def _fix_node_save(api, node, response, save_values: _InternalSaveValues) -> _In
         # So it will be known when we attempt to save the graph again.
         # Since we pre-saved this node, we want it to be UUID edge only the next JSON.
         # So we add it to the list of known nodes
-        returned_save_values = api._internal_save(missing_node, save_values)
+        returned_save_values = api._internal_save(missing_node, max_number_of_nodes_per_save, save_values)
         save_values += returned_save_values
         # The missing node, is now known to the API
         save_values.saved_uuid.add(missing_uuid)
@@ -101,7 +101,7 @@ def _fix_node_save(api, node, response, save_values: _InternalSaveValues) -> _In
                     save_values.suppress_attributes[str(duplicate_node.uuid)].add(set(search_dict.keys()))  # type: ignore
 
                 # Attempts to save the duplicate items element.
-                save_values += api._internal_save(duplicate_node, save_values)
+                save_values += api._internal_save(duplicate_node, max_number_of_nodes_per_save, save_values)
                 # After the save, we can reduce it to just a UUID edge in the graph (avoiding the duplicate issues).
                 save_values.saved_uuid.add(str(duplicate_node.uuid))
 

--- a/src/cript/nodes/core.py
+++ b/src/cript/nodes/core.py
@@ -274,6 +274,7 @@ class BaseNode(ABC):
         class ReturnTuple:
             json: str
             handled_ids: set
+            json_node_set: set
 
         # Do not check for circular references, since we handle them manually
         kwargs["check_circular"] = kwargs.get("check_circular", False)
@@ -295,9 +296,10 @@ class BaseNode(ABC):
         NodeEncoder.suppress_attributes = suppress_attributes
         previous_condense_to_uuid = copy.deepcopy(NodeEncoder.condense_to_uuid)
         NodeEncoder.condense_to_uuid = condense_to_uuid
+        NodeEncoder.json_node_set = set()
 
         try:
-            return ReturnTuple(json.dumps(self, cls=NodeEncoder, **kwargs), NodeEncoder.handled_ids)
+            return ReturnTuple(json.dumps(self, cls=NodeEncoder, **kwargs), NodeEncoder.handled_ids, NodeEncoder.json_node_set)
         except Exception as exc:
             # TODO this handling that doesn't tell the user what happened and how they can fix it
             #   this just tells the user that something is wrong
@@ -308,6 +310,7 @@ class BaseNode(ABC):
             NodeEncoder.known_uuid = previous_known_uuid
             NodeEncoder.suppress_attributes = previous_suppress_attributes
             NodeEncoder.condense_to_uuid = previous_condense_to_uuid
+            NodeEncoder.json_node_set = set()
 
     def find_children(self, search_attr: dict, search_depth: int = -1, handled_nodes=None) -> List:
         """

--- a/src/cript/nodes/util/__init__.py
+++ b/src/cript/nodes/util/__init__.py
@@ -2,7 +2,7 @@ import dataclasses
 import inspect
 import json
 import uuid
-from typing import Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 import cript.nodes
 from cript.nodes.core import BaseNode
@@ -58,6 +58,7 @@ class NodeEncoder(json.JSONEncoder):
     known_uuid: Set[str] = set()
     condense_to_uuid: Dict[str, Set[str]] = dict()
     suppress_attributes: Optional[Dict[str, Set[str]]] = None
+    json_node_set: Set[Any] = set()
 
     def default(self, obj):
         """
@@ -134,6 +135,9 @@ class NodeEncoder(json.JSONEncoder):
             if NodeEncoder.suppress_attributes is not None and str(obj.uuid) in NodeEncoder.suppress_attributes:
                 for attr in NodeEncoder.suppress_attributes[str(obj.uuid)]:
                     del serialize_dict[attr]
+
+            # We finished assembling the JSON for the node, so we add it into the handled nodes
+            NodeEncoder.json_node_set.add(obj)
 
             return serialize_dict
         return json.JSONEncoder.default(self, obj)

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 import uuid
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List
 
 import pytest
 import requests
@@ -404,6 +404,82 @@ def test_api_search_bigsmiles(cript_api: cript.API) -> None:
     assert len(bigsmiles_paginator.current_page_results) >= 1
     # not sure if this will always be in this position in every server environment, so commenting it out for now
     # assert bigsmiles_paginator.current_page_results[1]["name"] == "BCDB_Material_285"
+
+
+@pytest.mark.skipif(not HAS_INTEGRATION_TESTS_ENABLED, reason="requires a real cript_api_token")
+def test_api_node_limit(cript_api: cript.API) -> None:
+    """
+    The API currently does not accept more than 100 nodes at a time.
+    This test creates a project with 100+ nodes and attempts to run DB Schema on it
+    then save all of them one at a time to the API.
+
+    1. assemble a project with 100+ materials
+        * each material has a UUID in the name to avoid duplicate node errors
+    1. add 100+ collections to the project
+    1. add 100+ experiments to the collection
+    1. add 100+ process to experiments
+    """
+    big_project = cript.Project(name=f"big project {uuid.uuid4()}")
+
+    # amount of new nodes to create for each step
+    iterations_to_create = 50
+
+    # ===================== add Materials =====================
+    # create a list for Materials
+    big_materials: List[cript.Material] = []
+
+    # create Material nodes
+    for i in range(0, iterations_to_create):
+        same_identifier_for_all = [{"bigsmiles": "my bigsmiles"}]
+
+        new_material = cript.Material(name=f"Material {i} for 100+ node test {uuid.uuid4()}", identifier=same_identifier_for_all)
+
+        big_materials.append(new_material)
+
+    # add list of Materials to the Project
+    big_project.material = big_materials
+
+    # ===================== add Collections =====================
+    # create a list for Collections
+    big_collections: List[cript.Collection] = []
+
+    # create Collection nodes
+    for i in range(0, 2):
+        new_collection = cript.Collection(name=f"Collection {i} for 100+ node test {uuid.uuid4()}")
+
+        big_collections.append(new_collection)
+
+    # add list of Collections to the project
+    big_project.collection = big_collections
+
+    # ===================== add Experiments =====================
+    # create a list with Experiments
+    big_experiments: List[cript.Experiment] = []
+
+    # create Experiment nodes
+    for i in range(0, iterations_to_create):
+        new_experiment = cript.Experiment(name=f"Experiment {i} for 100+ node test {uuid.uuid4()}")
+
+        big_experiments.append(new_experiment)
+
+    # add list of Experiments to Collection[0]
+    big_project.collection[0].experiment = big_experiments
+
+    # ===================== add Process =====================
+    # create a list many Process
+    big_process: List[cript.Process] = []
+
+    # create Process nodes
+    for i in range(0, iterations_to_create):
+        new_process = cript.Process(name=f"Process {i} for 100+ node test {uuid.uuid4()}", type="mix")
+
+        big_process.append(new_process)
+
+    # add list of Process to Experiment[0]
+    big_project.collection[0].experiment[0].process = big_process
+
+    # save big Project to API
+    cript_api.save(project=big_project)
 
 
 def test_get_my_user_node_from_api(cript_api: cript.API) -> None:


### PR DESCRIPTION
# Description

The idea here is to count the number of nodes during the production of the JSON.
Unfortunately, we have to hack the `json` `NodeEncoder` class even more to do this.

We save now a set of all nodes being fully expressed in the JSON.

If that number exceeds the accepted number nodes per request, we save randomly one node from the graph first.
After this presaving, we show this node only as UUID in the graph and try again. 

## Changes
It gets more complicated and hard to read.

## Tests

We don't have a test for this yet.
https://trello.com/c/wWoz8l5l

## Known Issues

It doesn't work yet currently because of this:
https://trello.com/c/kjNVBX40

## Notes

## Checklist

- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
