### PR TITLE
Fix duplicated name error msg

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -16,6 +16,7 @@ from cript.api.exceptions import (
     CRIPTAPIRequiredError,
     CRIPTAPISaveError,
     CRIPTConnectionError,
+    CRIPTDuplicateNameError,
     InvalidHostError,
     InvalidVocabulary,
 )
@@ -690,7 +691,7 @@ class API:
                     # And (second condition) the request failed bc of the now suppressed name
                     if "duplicate item [{'name':" in response["error"] and "'name' is a required property" in exc.api_response:
                         # Raise a save error, with the nice name related error message
-                        raise CRIPTAPISaveError(api_host_domain=exc.api_host_domain, http_code=response["code"], api_response=response["error"], patch_request=exc.patch_request, pre_saved_nodes=exc.pre_saved_nodes, json_data=json_data) from exc
+                        raise CRIPTDuplicateNameError(response, json_data, exc) from exc
                     # Else just raise the exception as normal.
                     raise exc
 


### PR DESCRIPTION
# Description
We knew, and Berenger pointed it out in his testing: our error message for duplicated names was garbage.

So, this is a first attempt to fix this.
## Changes

If a node name is now duplicated you get this error now:
```
    raise CRIPTDuplicateNameError(response, json_data, exc) from exc
cript.api.exceptions.CRIPTDuplicateNameError: The name My first project. 7 for your Project node is already present in CRIPT.
 Either choose a new name, or consider namespaces like 'MyNameSpace::My first project. 7 instead.
```
Instead of 
```
cript.api.exceptions.CRIPTAPISaveError: API responded to POST with 'http:400 'name' is a required property at path: /' data: {"node": ["Material"], "uid": "_:c85c6d44-7c5d-4f32-87d9-fa8834079345", "uuid": "c85c6d44-7c5d-4f32-87d9-fa8834079345", "computational_forcefield": {"node": ["ComputationalForcefield"], "uid": "_:c9f8491b-0b0a-4f50-8c1b-0e5f490c97fc", "uuid": "c9f8491b-0b0a-4f50-8c1b-0e5f490c97fc", "key": "opls_aa", "building_block": "atom"}, "bigsmiles": "[H]{[>][<]C(C[>])c1ccccc1[<]}C(C)CC"}
```


## Tests
None added yet, we may want to consider one.

## Known Issues
We rely on the exact *undocumented* repsonse from the backend.
If that fails, you would only get the old message though.

## Notes

## Checklist

- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
