### PR TITLE
added `name` to file node docs attributes table

### DIFF
--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -93,8 +93,9 @@ class File(PrimaryBaseNode):
 
     | Attribute       | Type | Example                                                                                               | Description                                                                 | Required |
     |-----------------|------|-------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|----------|
+    | name            | str  | `"my file name"`                                                                                      | descriptive name for the file node                                          | True     |
     | source          | str  | `"path/to/my/file"` or `"https://en.wikipedia.org/wiki/Simplified_molecular-input_line-entry_system"` | source to the file can be URL or local path                                 | True     |
-    | type            | str  | `"logs"`                                                                                              | Pick from [CRIPT File Types](https://app.criptapp.org/vocab/file_type/)          | True     |
+    | type            | str  | `"logs"`                                                                                              | Pick from [CRIPT File Types](https://app.criptapp.org/vocab/file_type/)     | True     |
     | extension       | str  | `".csv"`                                                                                              | file extension                                                              | False    |
     | data_dictionary | str  | `"my extra info in my data dictionary"`                                                               | set of information describing the contents, format, and structure of a file | False    |
 

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -103,6 +103,7 @@ class File(PrimaryBaseNode):
     ``` json
     {
         "node": ["File"],
+        "name": "my file node name",
         "source": "https://criptapp.org",
         "type": "calibration",
         "extension": ".csv",


### PR DESCRIPTION
# Description
added `name` to file node docs attributes table and JSON representation as it is a required attribute and was missing previously

## Changes

### Screenshot
#### Attributes Table Update
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/8489c33b-064f-49f6-b5ac-3a86b6684550)

#### JSON Update
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/19c6ea36-e553-428e-bbf6-9604b4ed8c91)


## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
