### PR TITLE
updated file node doc with notes

### DIFF
--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -94,7 +94,7 @@ class File(PrimaryBaseNode):
     | Attribute       | Type | Example                                                                                               | Description                                                                 | Required |
     |-----------------|------|-------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|----------|
     | source          | str  | `"path/to/my/file"` or `"https://en.wikipedia.org/wiki/Simplified_molecular-input_line-entry_system"` | source to the file can be URL or local path                                 | True     |
-    | type            | str  | `"logs"`                                                                                              | Pick from [CRIPT File Types](https://app.criptapp.org/vocab/file_type/)          | True     |
+    | type            | str  | `"logs"`                                                                                              | Pick from [CRIPT File Types](https://app.criptapp.org/vocab/file_type/)     | True     |
     | extension       | str  | `".csv"`                                                                                              | file extension                                                              | False    |
     | data_dictionary | str  | `"my extra info in my data dictionary"`                                                               | set of information describing the contents, format, and structure of a file | False    |
 

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -97,6 +97,7 @@ class File(PrimaryBaseNode):
     | type            | str  | `"logs"`                                                                                              | Pick from [CRIPT File Types](https://app.criptapp.org/vocab/file_type/)     | True     |
     | extension       | str  | `".csv"`                                                                                              | file extension                                                              | False    |
     | data_dictionary | str  | `"my extra info in my data dictionary"`                                                               | set of information describing the contents, format, and structure of a file | False    |
+    | notes           | str  |                                                                                                       | miscellaneous information, or custom data structure (e.g.; JSON)            |          |
 
     ## JSON
     ``` json


### PR DESCRIPTION
# Description
I checked through the rest of the attributes table and it seems like for the most part they are already done. 

File notes was the only thing that seems to be missing in its attributes table.

## Changes

### Screenshot
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/4bba4dfd-57e8-47b6-b752-758cd28fdbe3)

## Tests

## Known Issues

## Notes
I wonder if users would know how to use the notes attribute or know where to find the docs on it or do we need more documentation guiding them through that?

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
