### PR TITLE
fixed `BIGSMILES` search test

### DIFF
--- a/src/cript/api/api_config.py
+++ b/src/cript/api/api_config.py
@@ -6,4 +6,4 @@ These constants are used to customize various aspects of the API requests and be
 """
 
 # Default maximum time in seconds for all API requests to wait for a response from the backend
-_API_TIMEOUT: int = 25
+_API_TIMEOUT: int = 120

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -398,7 +398,7 @@ def test_api_search_bigsmiles(cript_api: cript.API) -> None:
     """
     bigsmiles_search_value = "{[][<]C(C)C(=O)O[>][<]}{[$][$]CCC(C)C[$],[$]CC(C(C)C)[$],[$]CC(C)(CC)[$][]}"
 
-    bigsmiles_paginator = cript_api.search(node_type=cript.Material, search_mode=cript.SearchModes.BIG_SMILES, value_to_search=bigsmiles_search_value)
+    bigsmiles_paginator = cript_api.search(node_type=cript.Material, search_mode=cript.SearchModes.BIGSMILES, value_to_search=bigsmiles_search_value)
 
     assert isinstance(bigsmiles_paginator, Paginator)
     assert len(bigsmiles_paginator.current_page_results) >= 1


### PR DESCRIPTION
# Description
fixed bigsmiles search test

## Changes
* fixed SearchMode from `BIG_SMILES` to `BIGSMILES`
  * after refactoring the SearchMode from `BIG_SMILES` to `BIGSMILES` this was left out, but it is now tested and working
* changed timeout from `25` to `120`
  * the API takes a really long time to send response for bigsmiles search and waiting 2 minutes before quitting could be a good boundary for now
    * if we realize that it is too small we can raise it again

## Tests
tests are working!

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
