### PR TITLE
upgrade paginator error handling for response JSON conversion

### DIFF
--- a/src/cript/api/paginator.py
+++ b/src/cript/api/paginator.py
@@ -1,5 +1,5 @@
 from json import JSONDecodeError
-from typing import List, Optional, Union, Dict
+from typing import Dict, List, Optional, Union
 from urllib.parse import quote
 
 import requests

--- a/src/cript/api/paginator.py
+++ b/src/cript/api/paginator.py
@@ -1,3 +1,4 @@
+from json import JSONDecodeError
 from typing import List, Optional, Union
 from urllib.parse import quote
 
@@ -199,7 +200,16 @@ class Paginator:
 
         temp_api_endpoint = f"{temp_api_endpoint}&page={self.current_page_number}"
 
-        response = requests.get(url=temp_api_endpoint, headers=self._http_headers, timeout=_API_TIMEOUT).json()
+        response: requests.Response = requests.get(url=temp_api_endpoint, headers=self._http_headers, timeout=_API_TIMEOUT)
+
+        # try to convert response to JSON
+        try:
+            response = response.json()  # type: ignore
+
+        # if converting API response to JSON gives an error
+        # then there must have been an API error, so raise requests error
+        except JSONDecodeError:
+            response.raise_for_status()
 
         # handling both cases in case there is result inside of data or just data
         try:

--- a/src/cript/api/paginator.py
+++ b/src/cript/api/paginator.py
@@ -1,5 +1,5 @@
 from json import JSONDecodeError
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict
 from urllib.parse import quote
 
 import requests
@@ -202,29 +202,31 @@ class Paginator:
 
         response: requests.Response = requests.get(url=temp_api_endpoint, headers=self._http_headers, timeout=_API_TIMEOUT)
 
+        # it is expected that the response will be JSON
         # try to convert response to JSON
         try:
-            response = response.json()  # type: ignore
+            api_response: Dict = response.json()
 
         # if converting API response to JSON gives an error
-        # then there must have been an API error, so raise requests error
+        # then there must have been an API error, so raise the requests error
+        # this is to avoid bad indirect errors and make the errors more direct for users
         except JSONDecodeError:
             response.raise_for_status()
 
         # handling both cases in case there is result inside of data or just data
         try:
-            self.current_page_results = response["data"]["result"]
+            self.current_page_results = api_response["data"]["result"]
         except KeyError:
-            self.current_page_results = response["data"]
+            self.current_page_results = api_response["data"]
         except TypeError:
-            self.current_page_results = response["data"]
+            self.current_page_results = api_response["data"]
 
-        if response["code"] == 404 and response["error"] == "The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.":
+        if api_response["code"] == 404 and api_response["error"] == "The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.":
             self.current_page_results = []
             return self.current_page_results
 
         # TODO give a CRIPT error if HTTP response is anything other than 200
-        if response["code"] != 200:
-            raise Exception(f"API responded with: {response['error']}")
+        if api_response["code"] != 200:
+            raise Exception(f"API responded with: {api_response['error']}")
 
         return self.current_page_results


### PR DESCRIPTION
# Description
if there is an issue while converting the API response to JSON, then I am assuming that there has been an error and the server has returned something that was not JSON (e.g. text) where JSON was expected, so there must be an error, thus raise the error to the user.

Before this change, the user would get a `JSONDecodeError`, which made no sense for them and is not pointing out the error very well, but with this the error becomes a bit better for the user to know what happened.

## Changes
### Error Before
```
self = <Response [403]>, kwargs = {}

    def json(self, **kwargs):
        r"""Returns the json-encoded content of a response, if any.
    
        :param \*\*kwargs: Optional arguments that ``json.loads`` takes.
        :raises requests.exceptions.JSONDecodeError: If the response body does not
            contain valid json.
        """
    
        if not self.encoding and self.content and len(self.content) > 3:
            # No encoding set. JSON RFC 4627 section 3 states we should expect
            # UTF-8, -16 or -32. Detect which one to use; If the detection or
            # decoding fails, fall back to `self.text` (using charset_normalizer to make
            # a best guess).
            encoding = guess_json_utf(self.content)
            if encoding is not None:
                try:
                    return complexjson.loads(self.content.decode(encoding), **kwargs)
                except UnicodeDecodeError:
                    # Wrong UTF codec detected; usually because it's not UTF-8
                    # but some other 8-bit codec.  This is an RFC violation,
                    # and the server didn't bother to tell us what codec *was*
                    # used.
                    pass
                except JSONDecodeError as e:
                    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
    
        try:
            return complexjson.loads(self.text, **kwargs)
        except JSONDecodeError as e:
            # Catch JSON-related errors and raise as requests.JSONDecodeError
            # This aliases json.JSONDecodeError and simplejson.JSONDecodeError
>           raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
E           requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

### Error After
```

self = <Response [403]>

    def raise_for_status(self):
        """Raises :class:`HTTPError`, if one occurred."""
    
        http_error_msg = ""
        if isinstance(self.reason, bytes):
            # We attempt to decode utf-8 first because some servers
            # choose to localize their reason strings. If the string
            # isn't utf-8, we fall back to iso-8859-1 for all other
            # encodings. (See PR #3538)
            try:
                reason = self.reason.decode("utf-8")
            except UnicodeDecodeError:
                reason = self.reason.decode("iso-8859-1")
        else:
            reason = self.reason
    
        if 400 <= self.status_code < 500:
            http_error_msg = (
                f"{self.status_code} Client Error: {reason} for url: {self.url}"
            )
    
        elif 500 <= self.status_code < 600:
            http_error_msg = (
                f"{self.status_code} Server Error: {reason} for url: {self.url}"
            )
    
        if http_error_msg:
>           raise HTTPError(http_error_msg, response=self)
E           requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://api.criptapp.org/api/v1/search/exact/material/?q=Sodium%20polystyrene%20sulfonate&page=0

..\..\venv\lib\site-packages\requests\models.py:1021: HTTPError
```


## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
