### PR TITLE
Refactor API config variables

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -12,7 +12,7 @@ import jsonschema
 import requests
 from beartype import beartype
 
-from cript.api.api_config import _API_TIMEOUT
+from cript.api.config.api_config import _API_TIMEOUT, _API_PREFIX, _API_VERSION
 from cript.api.exceptions import (
     APIError,
     CRIPTAPIRequiredError,
@@ -68,8 +68,6 @@ class API:
     _http_headers: dict = {}
     _vocabulary: dict = {}
     _db_schema: dict = {}
-    _api_handle: str = "api"
-    _api_version: str = "v1"
 
     # trunk-ignore-begin(cspell)
     # AWS S3 constants
@@ -331,7 +329,7 @@ class API:
     def _prepare_host(self, host: str) -> str:
         # strip ending slash to make host always uniform
         host = host.rstrip("/")
-        host = f"{host}/{self._api_handle}/{self._api_version}"
+        host = f"{host}/{_API_PREFIX}/{_API_VERSION}"
 
         # if host is using unsafe "http://" then give a warning
         if host.startswith("http://"):

--- a/src/cript/api/api_config.py
+++ b/src/cript/api/api_config.py
@@ -1,9 +1,0 @@
-"""
-# API Configuration Constants
-
-This module contains configuration constants for the API client.
-These constants are used to customize various aspects of the API requests and behavior.
-"""
-
-# Default maximum time in seconds for all API requests to wait for a response from the backend
-_API_TIMEOUT: int = 120

--- a/src/cript/api/config/api_config.py
+++ b/src/cript/api/config/api_config.py
@@ -1,0 +1,14 @@
+"""
+# API Configuration Constants
+
+This file contains configuration constants that relate to the API.
+"""
+
+# Default maximum time in seconds for all API requests to wait for a response from the backend
+_API_TIMEOUT: int = 120
+
+# Prefix used in API URLs to distinguish API routes from regular web routes
+_API_PREFIX: str = "api"
+
+# Current version of the API that the SDK works with
+_API_VERSION: str = "v1"

--- a/src/cript/api/config/aws_s3.py
+++ b/src/cript/api/config/aws_s3.py
@@ -1,0 +1,14 @@
+"""
+# AWS S3 Cognito Config Constants
+
+This file contains the configuration constants for AWS S3,
+for when `cript.API` goes to upload/download files from AWS S3 Cognito
+"""
+
+_REGION_NAME: str = "us-east-1"
+_IDENTITY_POOL_ID: str = "us-east-1:9426df38-994a-4191-86ce-3cb0ce8ac84d"
+_COGNITO_LOGIN_PROVIDER: str = "cognito-idp.us-east-1.amazonaws.com/us-east-1_SZGBXPl2j"
+_BUCKET_NAME: str = "cript-user-data"
+
+# specific directory for python sdk files
+_BUCKET_DIRECTORY_NAME: str = "python_sdk_files"

--- a/src/cript/api/paginator.py
+++ b/src/cript/api/paginator.py
@@ -5,7 +5,7 @@ from urllib.parse import quote
 import requests
 from beartype import beartype
 
-from cript.api.api_config import _API_TIMEOUT
+from cript.api.config.api_config import _API_TIMEOUT
 from cript.api.exceptions import APIError
 
 

--- a/src/cript/api/utils/web_file_downloader.py
+++ b/src/cript/api/utils/web_file_downloader.py
@@ -4,7 +4,7 @@ from typing import Union
 
 import requests
 
-from cript.api.api_config import _API_TIMEOUT
+from cript.api.config.api_config import _API_TIMEOUT
 
 
 def download_file_from_url(url: str, destination_path: Union[str, Path]) -> None:

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -20,13 +20,11 @@ def test_create_api(cript_api: cript.API) -> None:
     """
     tests that an API object can be successfully created with host and token
     """
-    # api = cript.API(host=None, api_token=None)
-    #
-    # # assertions
-    # assert api is not None
-    # assert isinstance(api, cript.API)
+    api = cript.API(host=None, api_token=None)
 
-    pass
+    # assertions
+    assert api is not None
+    assert isinstance(api, cript.API)
 
 
 def test_api_with_invalid_host() -> None:


### PR DESCRIPTION
# Description
Refactoring to clean up and simplify the API code.

## Changes
* Putting all configuration constant variables that will not change throughout the life time of the API inside of `cript/api/config/`
  * Then pulling those in through import statement
    * This poses a new challenge currently because the old way of overriding the variables (such as AWS S3) for tests will no longer work because the variables are coming via import statements and do not belong to api class, so they cannot be changed like normal attributes
* added `test_create_api` test back in after it was commented out

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
