### PR TITLE
fix catching the right exceptions

### DIFF
--- a/src/cript/nodes/core.py
+++ b/src/cript/nodes/core.py
@@ -82,12 +82,12 @@ class BaseNode(ABC):
                         possible_array = getattr(self._json_attrs.kwarg[: -len("_count")])
                         if not isinstance(possible_array, list):
                             raise CRIPTExtraJsonAttributes(self.node_type, kwarg)
-                    except KeyError:
+                    except AttributeError:
                         raise CRIPTExtraJsonAttributes(self.node_type, kwarg)
                 else:
                     try:
                         getattr(self._json_attrs, kwarg)
-                    except KeyError:
+                    except AttributeError:
                         raise CRIPTExtraJsonAttributes(self.node_type, kwarg)
 
         uid = get_new_uid()


### PR DESCRIPTION
# Description
catching generic python exception and raising better exception for when users specify too many arguments in their constructors.

## Changes

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
