### PR TITLE
Docs: putting `Data` node example code above

### DIFF
--- a/src/cript/nodes/primary_nodes/data.py
+++ b/src/cript/nodes/primary_nodes/data.py
@@ -104,6 +104,23 @@ class Data(PrimaryBaseNode):
         **kwargs
     ) -> None:
         """
+        Examples
+        --------
+        ```python
+        # create file nodes for the data node
+        my_file = cript.File(
+            source="https://pubs.acs.org/doi/suppl/10.1021/acscentsci.3c00011/suppl_file/oc3c00011_si_001.pdf",
+            type="calibration",
+            extension=".pdf",
+        )
+
+        # create data node and add the file node to it
+        my_data = cript.Data(
+            name="my data node name",
+            type="afm_amp",
+            file=my_file,
+        )
+        ```
 
         Parameters
         ----------
@@ -129,24 +146,6 @@ class Data(PrimaryBaseNode):
             miscellaneous information, or custom data structure
         kwargs
             used for deserializing JSON into Python SDK nodes
-
-        Examples
-        --------
-        ```python
-        # create file nodes for the data node
-        my_file = cript.File(
-            source="https://pubs.acs.org/doi/suppl/10.1021/acscentsci.3c00011/suppl_file/oc3c00011_si_001.pdf",
-            type="calibration",
-            extension=".pdf",
-        )
-
-        # create data node and add the file node to it
-        my_data = cript.Data(
-            name="my data node name",
-            type="afm_amp",
-            file=my_file,
-        )
-        ```
 
         Returns
         -------


### PR DESCRIPTION
# Description
Moving the example code for creating `Data` node above the `Parameter` and `Returns` section in under the constructor

## Changes

### Screenshot
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/13faf4e8-141b-4921-852a-226e796c33cb)

## Tests

## Known Issues
* the ordering between all the nodes I think is inconsistent because each one is in a different order
  * this would not change the overall documentation, its usefulness, but lessens its perfection
* the ordering goes against [Numpy style guide ideal order](https://github.com/C-Accel-CRIPT/Python-SDK/wiki/Documentation#numpy-style-docstring-ideal-order), but I think it is okay because
  1. we are not currently following the ideal order anywhere else
  2. it looks nicer and has better UI/UX for the user 

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
