### PR TITLE
updated SDK version from `2.0.0` to `2.1.0`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cript
-version = 2.0.0
+version = 2.1.0
 description = CRIPT Python SDK
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
# Description
updated SDK version from `2.0.0` to `2.1.0`

## Changes
* updated SDK version from `2.0.0` to `2.1.0` 

## Tests

## Known Issues
* Before each release we have to increment the package version manually
  * This workflow is very problematic because there has ben Many times where I have forgotten to change the version number before a release
  * This needs to be automated to reduce chances of errors
  * @InnocentBug if you have any ideas please feel free to let me know

## Notes
Python SDK 2.1.0 will be the last version that will support Python 3.7. All next versions of Python SDK will support Python 3.8 or higher as [Python 3.7 has reached end of life](https://devguide.python.org/versions/)

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
