### PR TITLE
API Tests: rename test & delete test

### DIFF
--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -20,13 +20,11 @@ def test_create_api(cript_api: cript.API) -> None:
     """
     tests that an API object can be successfully created with host and token
     """
-    # api = cript.API(host=None, api_token=None)
-    #
-    # # assertions
-    # assert api is not None
-    # assert isinstance(api, cript.API)
+    api = cript.API(host=None, api_token=None)
 
-    pass
+    # assertions
+    assert api is not None
+    assert isinstance(api, cript.API)
 
 
 def test_api_with_invalid_host() -> None:
@@ -48,10 +46,10 @@ def test_api_context(cript_api: cript.API) -> None:
     assert cript.api.api._get_global_cached_api() is not None
 
 
-def test_api_cript_env_vars() -> None:
+def test_create_api_with_none() -> None:
     """
-    tests that when the cript.API is given None for host, api_token, storage_token that it can correctly
-    retrieve things from the env variable
+    tests that when the cript.API is given `None` for `host`, `api_token`, `storage_token`
+    that it can correctly retrieve them from the environment variables
     """
     host_value = "http://development.api.mycriptapp.org/"
     api_token_value = "my cript API token value"

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -16,17 +16,6 @@ from cript.api.paginator import Paginator
 from cript.nodes.exceptions import CRIPTNodeSchemaError
 
 
-def test_create_api(cript_api: cript.API) -> None:
-    """
-    tests that an API object can be successfully created with host and token
-    """
-    api = cript.API(host=None, api_token=None)
-
-    # assertions
-    assert api is not None
-    assert isinstance(api, cript.API)
-
-
 def test_api_with_invalid_host() -> None:
     """
     this mostly tests the _prepare_host() function to be sure it is working as expected

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -37,24 +37,30 @@ def test_api_context(cript_api: cript.API) -> None:
 
 def test_create_api_with_none() -> None:
     """
-    tests that when the cript.API is given `None` for `host`, `api_token`, `storage_token`
-    that it can correctly retrieve them from the environment variables
+    tests that when the cript.API is given None for host, api_token, storage_token that it can correctly
+    retrieve things from the env variable.
+    assert that the values found from the environment are equal to what the SDK API class
+    correctly got for `_host`, `_api_token`, and `_storage_token`
+
+    Notes
+    -----
+    This test is dependent on the environment (local computer or CI), where it expects
+    `CRIPT_HOST`, `CRIPT_TOKEN` and `CRIPT_STORAGE_TOKEN` to be in the environment variables,
+    otherwise, it will not be able to find the needed environment variables and the test will fail
     """
-    host_value = "http://development.api.mycriptapp.org/"
-    api_token_value = "my cript API token value"
-    storage_token_value = "my cript storage token value"
-
     # set env vars
-    os.environ["CRIPT_HOST"] = host_value
-    os.environ["CRIPT_TOKEN"] = api_token_value
-    os.environ["CRIPT_STORAGE_TOKEN"] = storage_token_value
+    # strip end slash to make all hosts uniform for comparison
+    #   regardless of how it was entered in the env var
+    env_var_host = os.environ["CRIPT_HOST"].rstrip("/")
 
+    # create an API instance with `None`
     api = cript.API(host=None, api_token=None, storage_token=None)
 
+    # assert SDK correctly got env vars to create cript.API with
     # host/api/v1
-    assert api._host == f"{host_value}api/v1"
-    assert api._api_token == api_token_value
-    assert api._storage_token == storage_token_value
+    assert api._host == f"{env_var_host}/api/v1"
+    assert api._api_token == os.environ["CRIPT_TOKEN"]
+    assert api._storage_token == os.environ["CRIPT_STORAGE_TOKEN"]
 
 
 def test_config_file() -> None:


### PR DESCRIPTION
# Description
uncommented test and changed test name to be self documenting

## Changes
* uncommented `test_create_api` to allow it to be usable again
  * not a hugely important test, but we already have it so we can use it
    * if we need to eliminate tests later to lighten up maintenance, this can be a great place to remove because the API client is test throughout the SDK anyways
* renamed functional test from `test_api_cript_env_vars` to `test_create_api_with_none`

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
