### PR TITLE
added log for file uploads

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -868,6 +868,8 @@ class API:
         # upload file to AWS S3
         self._s3_client.upload_file(Filename=file_path, Bucket=self._BUCKET_NAME, Key=object_name)  # type: ignore
 
+        self.logger.info(f"Uploaded file: '{file_path}' to CRIPT storage")
+
         # return the object_name within AWS S3 for easy retrieval
         return object_name
 


### PR DESCRIPTION
# Description
The user is often unsure if the SDK uploaded their file to AWS S3 or not, so I added a log to the terminal that tells the user when their file was uploaded to S3.

## Changes
* added a log after upload to s3

### Screenshot
The output looks like this
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/1ce7bea0-62bd-467c-9a0f-cb5d2376ab5a)

## Known Issues
* the terminal output is a bit too long, but I was unsure of how else to write it

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
