### PR TITLE
changed log message for delete

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -1068,7 +1068,7 @@ class API:
         After the node has been successfully deleted, a log is written to the terminal if `cript.API.verbose = True`
 
         ```bash
-        INFO: Deleted `Data` with UUID of `80bfc642-157e-4692-a547-97c470725397` from CRIPT API.
+        INFO: Deleted 'Data' with UUID of '80bfc642-157e-4692-a547-97c470725397' from CRIPT API.
         ```
 
         Warnings
@@ -1107,4 +1107,4 @@ class API:
         if response["code"] != 200:
             raise APIError(api_error=str(response), http_method="DELETE", api_url=delete_node_api_url)
 
-        self.logger.info(f"Deleted `{node.node_type}` with UUID of `{node.uuid}` from CRIPT API.")
+        self.logger.info(f"Deleted '{node.node_type}' with UUID of '{node.uuid}' from CRIPT API.")


### PR DESCRIPTION
# Description
instead of using backticks ` I am now using single quotes. I think that is much more standard and cleaner. It was bothering me that I wrote it previously and the logs were not as standard and clean as they could be.

## Changes


### Screenshot
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/b383751d-046e-44e6-ab95-ccad7b829280)

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
