### PR TITLE
Enforce correct python version for testing.

### DIFF
--- a/.github/workflows/build_and_deploy_docs.yaml
+++ b/.github/workflows/build_and_deploy_docs.yaml
@@ -1,6 +1,7 @@
 # build docs from master branch and push to gh-pages branch to be deployed to repository GitHub pages
-
 name: Build & Deploy Docs
+permissions: read-all
+
 on:
   push:
     branches:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,7 @@
 # supported CodeQL languages.
 #
 name: CodeQL
+permissions: read-all
 
 on:
   push:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,6 +5,7 @@
 # Source repository: https://github.com/actions/dependency-review-action
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
 name: Dependency Review
+
 on:
   push:
     branches:

--- a/.github/workflows/docs_check.yaml
+++ b/.github/workflows/docs_check.yaml
@@ -1,6 +1,7 @@
 # this CI workflow checks the documentation for any broken links or errors within documentation files/configuration
 # and reports errors to catch errors and never deploy broken documentation
 name: MkDocs CI Check
+permissions: read-all
 
 on:
   push:

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -1,6 +1,7 @@
 # check code types with mypy to be sure the static types are correct and make sense
 
 name: MyPy Check
+permissions: read-all
 
 on:
   push:

--- a/.github/workflows/test_coverage.yaml
+++ b/.github/workflows/test_coverage.yaml
@@ -2,6 +2,7 @@
 # WARNING: this workflow will fail if any of the tests within it fail
 
 name: Test Coverage
+permissions: read-all
 
 on:
   push:

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -29,6 +29,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: install test dependency
         run: python3 -m pip install -r requirements_docs.txt

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -1,4 +1,5 @@
 name: Test Jupyter Notebook
+permissions: read-all
 
 on:
   push:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 # Runs all the Python SDK tests within the `tests/` directory to check our code
 
 name: CI Tests
+permissions: read-all
 
 on:
   # trunk-ignore(yamllint/empty-values)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: temp
         run: |
           python3 --version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,11 +42,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: temp
-        run: |
-          python3 --version
-          echo python${{ matrix.python-version }}
-          python${{ matrix.python-version }} --version
 
       - name: pip install CRIPT Python SDK local package
         run: python${{ matrix.python-version }} -m pip install .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 # Runs all the Python SDK tests within the `tests/` directory to check our code
 
-name: Tests
+name: CI Tests
 
 on:
   # trunk-ignore(yamllint/empty-values)
@@ -38,11 +38,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: temp
+        run: |
+          python3 --version
+          echo python${{ matrix.python-version }}
+          python${{ matrix.python-version }} --version
+
       - name: pip install CRIPT Python SDK local package
-        run: python3 -m pip install .
+        run: python${{ matrix.python-version }} -m pip install .
 
       - name: pip install requirements_dev.txt
-        run: python3 -m pip install -r requirements_dev.txt
+        run: python${{ matrix.python-version }} -m pip install -r requirements_dev.txt
 
       - name: Run pytest on tests/
-        run: pytest ./tests/
+        run: python${{ matrix.python-version }} -m pytest ./tests/

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Trunk.io
 
 on:
   push:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -11,6 +11,7 @@ on:
       - main
       - develop
       - "*"
+permissions: read-all
 
 jobs:
   trunk:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests==2.31.0
-jsonschema==4.17.3
+jsonschema>=4.17.3
 boto3==1.28.39
 beartype==0.14.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,4 @@
 -r requirements.txt
-black==23.7.0
 mypy==1.5.1
 pytest==7.4.0
 pytest-cov==4.1.0
@@ -8,3 +7,4 @@ types-jsonschema==4.17.0.9
 types-requests==2.31.0.1
 types-boto3==1.0.2
 deepdiff==6.3.1
+#lint-tools like black are managed by trunk, see .trunk/trunk.yaml

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,10 +1,8 @@
 -r requirements.txt
-mypy==1.5.1
-pytest==7.4.0
-pytest-cov==4.1.0
-coverage==7.3.0
-types-jsonschema==4.17.0.9
-types-requests==2.31.0.1
-types-boto3==1.0.2
-deepdiff==6.3.1
+mypy>=1.4.1
+pytest>=7.4.0
+pytest-cov>=4.1.0
+types-requests>=2.31.0.1
+types-boto3>=1.0.2
+deepdiff>=6.3.1
 #lint-tools like black are managed by trunk, see .trunk/trunk.yaml

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,6 +2,7 @@
 mypy>=1.4.1
 pytest>=7.4.0
 pytest-cov>=4.1.0
+types-jsonschema>=4.17.0.9
 types-requests>=2.31.0.1
 types-boto3>=1.0.2
 deepdiff>=6.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ python_requires = >=3.7
 include_package_data = True
 install_requires =
         requests==2.31.0
-        jsonschema==4.17.3
+        jsonschema>=4.17.3
         beartype==0.14.1
         boto3==1.28.39
 


### PR DESCRIPTION
# Description
Previously, we forgot to setup the python version for our CI tests.
I resolved this, which made python 3.7 build to correctly fail.

## Changes

1. Fixed the tests to correctly setup python.
2. Added permissions to workflows
3. Changed the confusing name of the trunk test.

## Notes
I had to change the version of packages to ranges instead of fixed values.
Otherwise it is impossible to get 3.7 and 3.11 builds to pass at the same time.

## Checklist

- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
