### PR TITLE
switch `test_config_file` to use staging for `host` instead of develop

### DIFF
--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -68,7 +68,7 @@ def test_config_file() -> None:
     test if the api can read configurations from `config.json`
     """
 
-    config_file_texts = {"host": "https://development.api.mycriptapp.org", "api_token": "I am token", "storage_token": "I am storage token"}
+    config_file_texts = {"host": "https://lb-stage.mycriptapp.org", "api_token": "I am token", "storage_token": "I am storage token"}
 
     with tempfile.NamedTemporaryFile(mode="w+t", suffix=".json", delete=False) as temp_file:
         # absolute file path


### PR DESCRIPTION
# Description
switch `test_config_file` test to use staging host instead of develop

develop server seems to not be stable, so moving every host to staging

## Changes

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
