### PR TITLE
Fix MKDocs Build Workflow Permissions

### DIFF
--- a/.github/workflows/build_and_deploy_docs.yaml
+++ b/.github/workflows/build_and_deploy_docs.yaml
@@ -1,5 +1,7 @@
-# build docs from master branch and push to gh-pages branch to be deployed to repository GitHub pages
+# build docs from main branch and push to gh-pages branch to be deployed to repository GitHub pages
 name: Build & Deploy Docs
+
+# trunk-ignore(checkov/CKV2_GHA_1)
 permissions: write-all
 
 on:

--- a/.github/workflows/build_and_deploy_docs.yaml
+++ b/.github/workflows/build_and_deploy_docs.yaml
@@ -1,6 +1,6 @@
 # build docs from master branch and push to gh-pages branch to be deployed to repository GitHub pages
 name: Build & Deploy Docs
-permissions: read-all
+permissions: write-all
 
 on:
   push:


### PR DESCRIPTION
# Description
* Giving GitHub workflow the permission to read from `main` and write to `gh-pages`
  * GitHub actions kept getting `permission denied errors` when trying to write to `gh-pages` branch, and the issue was that we did not specify that it has write permissions. 

## Changes

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
