### PR TITLE
Fixing MKDocs documentation build workflow Permissions Issue

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -958,50 +958,50 @@ class API:
 
         Examples
         --------
-        ### Search by Node Type
-        ```python
-        materials_paginator = cript_api.search(
-            node_type=cript.Material,
-            search_mode=cript.SearchModes.NODE_TYPE,
-            value_to_search=None
-        )
-        ```
+        ???+ Example "Search by Node Type"
+            ```python
+            materials_paginator = cript_api.search(
+                node_type=cript.Material,
+                search_mode=cript.SearchModes.NODE_TYPE,
+                value_to_search=None
+            )
+            ```
 
-        ### Search by Contains name
-        ```python
-        contains_name_paginator = cript_api.search(
-            node_type=cript.Process,
-            search_mode=cript.SearchModes.CONTAINS_NAME,
-            value_to_search="poly"
-        )
-        ```
+        ??? Example "Search by Contains name"
+            ```python
+            contains_name_paginator = cript_api.search(
+                node_type=cript.Process,
+                search_mode=cript.SearchModes.CONTAINS_NAME,
+                value_to_search="poly"
+            )
+            ```
 
-        ### Search by Exact Name
-        ```python
-        exact_name_paginator = cript_api.search(
-            node_type=cript.Project,
-            search_mode=cript.SearchModes.EXACT_NAME,
-            value_to_search="Sodium polystyrene sulfonate"
-        )
-        ```
+        ??? Example "Search by Exact Name"
+            ```python
+            exact_name_paginator = cript_api.search(
+                node_type=cript.Project,
+                search_mode=cript.SearchModes.EXACT_NAME,
+                value_to_search="Sodium polystyrene sulfonate"
+            )
+            ```
 
-        ### Search by UUID
-        ```python
-        uuid_paginator = cript_api.search(
-            node_type=cript.Collection,
-            search_mode=cript.SearchModes.UUID,
-            value_to_search="75fd3ee5-48c2-4fc7-8d0b-842f4fc812b7"
-        )
-        ```
+        ??? Example "Search by UUID"
+            ```python
+            uuid_paginator = cript_api.search(
+                node_type=cript.Collection,
+                search_mode=cript.SearchModes.UUID,
+                value_to_search="75fd3ee5-48c2-4fc7-8d0b-842f4fc812b7"
+            )
+            ```
 
-        ### Search by BigSmiles
-        ```python
-        paginator = cript_api.search(
-            node_type=cript.Material,
-            search_mode=cript.SearchModes.BIGSMILES,
-            value_to_search="{[][$]CC(C)(C(=O)OCCCC)[$][]}"
-        )
-        ```
+        ??? Example "Search by BigSmiles"
+            ```python
+            paginator = cript_api.search(
+                node_type=cript.Material,
+                search_mode=cript.SearchModes.BIGSMILES,
+                value_to_search="{[][$]CC(C)(C(=O)OCCCC)[$][]}"
+            )
+            ```
 
         Parameters
         ----------
@@ -1018,6 +1018,32 @@ class API:
         -------
         Paginator
             paginator object for the user to use to flip through pages of search results
+
+        Notes
+        -----
+        To learn more about working with pagination, please refer to our
+        [paginator object documentation](../paginator).
+
+        Additionally, you can utilize the utility function [`load_nodes_from_json(node_json)`](../../utility_functions/#cript.nodes.util.load_nodes_from_json)
+        to convert API JSON responses into Python SDK nodes.
+
+        ???+ Example "Convert API JSON Response to Python SDK Nodes"
+            ```python
+            # Get updated project from API
+            my_paginator = api.search(
+                node_type=cript.Project,
+                search_mode=cript.SearchModes.EXACT_NAME,
+                value_to_search="my project name",
+            )
+
+            # Take specific Project you want from paginator
+            my_project_from_api_dict: dict = my_paginator.current_page_results[0]
+
+            # Deserialize your Project dict into a Project node
+            my_project_node_from_api = cript.load_nodes_from_json(
+                nodes_json=json.dumps(my_project_from_api_dict)
+            )
+            ```
         """
 
         # get node typ from class

--- a/src/cript/api/valid_search_modes.py
+++ b/src/cript/api/valid_search_modes.py
@@ -28,6 +28,9 @@ class SearchModes(Enum):
         value_to_search=None,
     )
     ```
+
+    For more details and code examples,
+    please check the [cript.API.search( ) method](../api/#cript.api.api.API.search)
     """
 
     NODE_TYPE: str = ""

--- a/src/cript/nodes/util/__init__.py
+++ b/src/cript/nodes/util/__init__.py
@@ -406,18 +406,20 @@ def load_nodes_from_json(nodes_json: str):
     Examples
     --------
     ```python
-    # get project node from API
-    my_paginator = cript_api.search(
+    # Get updated project from API
+    my_paginator = api.search(
         node_type=cript.Project,
         search_mode=cript.SearchModes.EXACT_NAME,
-        value_to_search=project_node.name
+        value_to_search="my project name",
     )
 
-    # get the project from paginator
-    my_project_from_api_dict = my_paginator.current_page_results[0]
+    # Take specific Project you want from paginator
+    my_project_from_api_dict: dict = my_paginator.current_page_results[0]
 
-    # convert API JSON to CRIPT Project node
-    my_project_from_api = cript.load_nodes_from_json(json.dumps(my_project_from_api_dict))
+    # Deserialize your Project dict into a Project node
+    my_project_node_from_api = cript.load_nodes_from_json(
+        nodes_json=json.dumps(my_project_from_api_dict)
+    )
     ```
 
     Raises


### PR DESCRIPTION
# Description
Not a release, but mainly fixing MKDocs documentation build workflow issues.

MKDocs documentation build workflow was having issues pushing to `gh-pages` branch and was getting permissions denied because we set its permissions to `read-all` and it did not have the ability to write.

## Changes
* giving MKDocs build documentation CD ability to read from `main` and push to `gh-pages`
  * I would have liked to given it more specific permissions for each branch, but GitHub doesn't seem to support that for now, so `write-all` I think is good for now
    * trunk was complaining about `write-all` permission, and I told it to ignore it
* while we are updating the documentation, I merged in the [upgrade deserialization docs](Upgrade Deserialization Docs) to knock out 2 birds with 1 PR

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
