### PR TITLE
upgraded MKDocs build CD `action version` to fix outdated warning

### DIFF
--- a/.github/workflows/build_and_deploy_docs.yaml
+++ b/.github/workflows/build_and_deploy_docs.yaml
@@ -16,8 +16,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - run: pip install -r requirements_docs.txt


### PR DESCRIPTION
# Description

Outdated action version warning
![mkdocs build outdated error](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/6a877b5d-d40b-494c-8d02-53eb38c1bee4)

[last MKDocs build workflow warning](https://github.com/C-Accel-CRIPT/Python-SDK/actions/runs/6163330969)

Fixed by upgrading outdated actions to newest version

## Changes
* Upgraded outdated actions to newest version

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
