### PR TITLE
SDK Requires Python 3.8+

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
 
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.11]
+        python-version: [3.8, 3.11]
 
     env:
       CRIPT_HOST: https://lb-stage.mycriptapp.org/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](./CRIPT_full_logo_colored_transparent.png)](https://github.com/C-Accel-CRIPT/Python-SDK/blob/develop/LICENSE.md)
 
 [![License](https://img.shields.io/github/license/C-Accel-CRIPT/cript?style=flat-square)](https://github.com/C-Accel-CRIPT/Python-SDK/blob/develop/LICENSE.md)
-[![Python](https://img.shields.io/badge/Language-Python%203.7+-blue?style=flat-square&logo=python)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/Language-Python%203.8+-blue?style=flat-square&logo=python)](https://www.python.org/)
 [![Code style is black](https://img.shields.io/badge/Code%20Style-black-000000.svg?style=flat-square&logo=python)](https://github.com/psf/black)
 [![Link to CRIPT website](https://img.shields.io/badge/platform-criptapp.org-blueviolet?style=flat-square)](https://criptapp.org/)
 [![Using Pytest](https://img.shields.io/badge/Dependencies-pytest-green?style=flat-square&logo=Pytest)](https://docs.pytest.org/en/7.2.x/)
@@ -36,7 +36,7 @@ The CRIPT Python SDK allows programmatic access to the [CRIPT platform](https://
 
 ## Installation
 
-CRIPT Python SDK requires Python 3.7+
+CRIPT Python SDK requires Python 3.8+
 
 The latest released of CRIPT Python SDK is available on [Python Package Index (PyPI)](https://pypi.org/project/cript/)
 

--- a/docs/tutorial/cript_installation_guide.md
+++ b/docs/tutorial/cript_installation_guide.md
@@ -7,7 +7,7 @@
 
 ## Steps
 
-1.  Install [Python 3.7+](https://www.python.org/downloads/)
+1.  Install [Python 3.8+](https://www.python.org/downloads/)
 2.  Create a virtual environment
 
     > It is best practice to create a dedicated [python virtual environment](https://docs.python.org/3/library/venv.html) for each python project

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,13 +14,13 @@ classifiers =
     Topic :: Scientific/Engineering
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 
 [options]
 package_dir =
     =src
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 include_package_data = True
 install_requires =
         requests==2.31.0


### PR DESCRIPTION
# Description
updated SDK to require Python 3.8+ because [Python 3.7 is deprecated](https://devguide.python.org/versions/). Dropping support for SDK 3.7

## Changes
* changed README Python badge to be `3.8+`
* changed README installation guide to be `3.8+`
* changed `tests.yaml` to run from `[3.8, 3.11]`

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
