### PR TITLE
renaming CI names to be more self documenting

### DIFF
--- a/.github/workflows/build_and_deploy_docs.yaml
+++ b/.github/workflows/build_and_deploy_docs.yaml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  deploy_docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docs_check.yaml
+++ b/.github/workflows/docs_check.yaml
@@ -17,7 +17,7 @@ on:
       - "*"
 
 jobs:
-  build:
+  documentation_ci_check:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -15,7 +15,7 @@ on:
       - develop
 
 jobs:
-  mypy-test:
+  mypy_check:
     strategy:
       matrix:
         python-version: [3.11]

--- a/.github/workflows/test_coverage.yaml
+++ b/.github/workflows/test_coverage.yaml
@@ -16,7 +16,7 @@ on:
       - develop
 
 jobs:
-  test-coverage:
+  test_coverage:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -13,7 +13,7 @@ on:
       - develop
 
 jobs:
-  test-examples:
+  test_docs_example_scripts:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ on:
       - "*"
 
 jobs:
-  install:
+  tests:
     runs-on: ${{ matrix.os }}
 
     strategy:


### PR DESCRIPTION
# Description
was setting up status check repository requirements and saw that some of our names were not very self documenting, so changing that here quickly.

I debated if we should use dashes or underscores for job names, and ultimately I came up with underscores because if we need to chain jobs together calling the job would be easier I think and we are using underscore convention everywhere in our repository so it just makes sense to keep the consistency. Feel free to let me know if I am wrong

## Changes

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
