### PR TITLE
Upgrade `requirements_docs.txt`

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,5 +1,5 @@
 mkdocs==1.5.2
-mkdocs-material==9.2.6
-mkdocstrings[python]==0.22.0
-pymdown-extensions==10.2.1
+mkdocs-material==9.3.1
+mkdocstrings[python]==0.23.0
+pymdown-extensions==10.3
 jupytext==1.15.1


### PR DESCRIPTION
# Description
Upgrade requirements_docs.txt

## Changes

## Tests

## Known Issues

## Notes
requirements_dev.txt needed upgrades, but not sure if we want to change our syntax from `>=` to `==`
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/24f4d3d1-7be6-4ec2-8d7d-a6d9dad3e2f2)

---

* mkdocs 9.3 dropped support for Python 3.7
* pymdown-extensions 10.3 dropped support for Python 3.7


## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
