### PR TITLE
clean up `APIError` so it is uniform everywhere and clean

### DIFF
--- a/src/cript/api/exceptions.py
+++ b/src/cript/api/exceptions.py
@@ -1,5 +1,7 @@
 import json
-from typing import List, Optional, Set
+from typing import List, Set
+
+from beartype import beartype
 
 from cript.exceptions import CRIPTException
 
@@ -215,10 +217,11 @@ class APIError(CRIPTException):
     api_error: str = ""
 
     # having the URL that the API gave an error for helps in debugging
-    api_url: Optional[str] = None
-    http_method: Optional[str] = None
+    api_url: str = ""
+    http_method: str = ""
 
-    def __init__(self, api_error: str, http_method: Optional[str] = None, api_url: Optional[str] = None) -> None:
+    @beartype
+    def __init__(self, api_error: str, http_method: str, api_url: str) -> None:
         self.api_error = api_error
 
         self.api_url = api_url
@@ -228,14 +231,7 @@ class APIError(CRIPTException):
         self.http_method = http_method
 
     def __str__(self) -> str:
-        # TODO refactor all of SDK using this error to be used the same to avoid this logic and Optional attributes
-        # this logic currently exists to make previous SDK work
-
-        # if you have the URL then display it, otherwise just show the error message
-        if self.api_url and self.http_method:
-            return f"CRIPT Python SDK sent HTTP `{self.http_method.upper()}` request to URL: `{self.api_url}` and API responded with {self.api_error}"
-        else:
-            return f"The API responded with: {self.api_error}"
+        return f"CRIPT Python SDK sent HTTP `{self.http_method.upper()}` request to URL: `{self.api_url}` and API responded with {self.api_error}"
 
 
 class FileDownloadError(CRIPTException):


### PR DESCRIPTION
# Description
clean up `APIError` so it is uniform everywhere and clean
removed unnecessary code since it is being used uniformly everywhere

## Changes

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
