### PR TITLE
downgraded `mkdocstrings[python]` in requirements_docs.txt

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,4 +1,4 @@
-mkdocs==1.5.2
+mkdocs==1.5.3
 mkdocs-material==9.3.1
 mkdocstrings[python]==0.22.0
 pymdown-extensions==10.3

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,5 +1,5 @@
 mkdocs==1.5.2
 mkdocs-material==9.3.1
-mkdocstrings[python]==0.23.0
+mkdocstrings[python]==0.22.0
 pymdown-extensions==10.3
 jupytext==1.15.1


### PR DESCRIPTION
# Description

* downgraded `mkdocstrings[python]` because `0.23.0` is buggy
* upgraded `mkdocs` package because new one is available and working well

## Changes

### `mkdocstrings[python]` Package
downgraded documentation package  from `mkdocstrings[python]==0.23.0` to `mkdocstrings[python]==0.22.0`

mkdocstrings[python]==0.23.0 does not support hot reload which is annoying and causing issues when updating the documentation and checking how it looks in the browser. Downgrading it now and will come back to it when it works fine.

### `mkdocs` Package
upgraded mkdocs to newest release and everything seems to be working fine

## Known Issues

## Notes
Left them an issue for them to be aware of and hopefully, they'll fix it soon.
https://github.com/mkdocstrings/mkdocstrings/issues/614

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
