### PR TITLE
Feature: `cript.API.get_node_by_uuid(uuid)`

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -948,7 +948,7 @@ class API:
     @beartype
     def search(
         self,
-        node_type: Union[Any, str],
+        node_type: Any,
         search_mode: SearchModes,
         value_to_search: Optional[str],
     ) -> Paginator:
@@ -1007,7 +1007,7 @@ class API:
 
         Parameters
         ----------
-        node_type : Union[UUIDBaseNode, str]
+        node_type : UUIDBaseNode
             Type of node that you are searching for.
         search_mode : SearchModes
             Type of search you want to do. You can search by name, `UUID`, `EXACT_NAME`, etc.

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -1088,7 +1088,9 @@ class API:
         Examples
         ---------
         ```python
-        my_material_node: cript.Material = cript_api.get_node_by_uuid(node_type=cript.Material, node_uuid=material_uuid)
+        my_material_node: cript.Material = cript_api.get_node_by_uuid(
+            node_type=cript.Material, node_uuid="e1b41d34-3bf2-4cd8-9a19-6412df7e7efc"
+        )
         ```
 
         Parameters

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -12,6 +12,7 @@ import jsonschema
 import requests
 from beartype import beartype
 
+import cript
 from cript.api.api_config import _API_TIMEOUT
 from cript.api.exceptions import (
     APIError,
@@ -36,6 +37,7 @@ from cript.api.valid_search_modes import SearchModes
 from cript.api.vocabulary_categories import VocabCategories
 from cript.nodes.exceptions import CRIPTNodeSchemaError
 from cript.nodes.primary_nodes.project import Project
+from cript.nodes.uuid_base import UUIDBaseNode
 
 # Do not use this directly! That includes devs.
 # Use the `_get_global_cached_api for access.
@@ -946,7 +948,7 @@ class API:
     @beartype
     def search(
         self,
-        node_type,
+        node_type: Union[Any, str],
         search_mode: SearchModes,
         value_to_search: Optional[str],
     ) -> Paginator:
@@ -1005,7 +1007,7 @@ class API:
 
         Parameters
         ----------
-        node_type : UUIDBaseNode
+        node_type : Union[UUIDBaseNode, str]
             Type of node that you are searching for.
         search_mode : SearchModes
             Type of search you want to do. You can search by name, `UUID`, `EXACT_NAME`, etc.
@@ -1077,6 +1079,46 @@ class API:
             raise RuntimeError("Internal Error: Failed to recognize any search modes. Please report this bug on https://github.com/C-Accel-CRIPT/Python-SDK/issues.")
 
         return Paginator(http_headers=self._http_headers, api_endpoint=api_endpoint, query=value_to_search, current_page_number=page_number)
+
+    @beartype
+    def get_node_by_uuid(self, node_type: Any, node_uuid: str) -> Any:
+        """
+        Gets a node from API by its UUID and returns the requested node represented as a Python object.
+
+        Examples
+        ---------
+        ```python
+        my_material_node: cript.Material = cript_api.get_node_by_uuid(node_type=cript.Material, node_uuid=material_uuid)
+        ```
+
+        Parameters
+        ----------
+        node_type: Any
+            The class representation of the type of node you're targeting, such as `cript.Material`.
+            This could be a representation of a `primary node`, `supporting node`, or `sub-object`.
+        node_uuid: str:
+            UUID of the target primary node, supporting node, or sub-object to retrieve from the API.
+
+        Returns
+        -------
+        UUIDBaseNode
+            The requested node represented as a Python object.
+        """
+
+        # get project node from API
+        my_paginator = self.search(
+            node_type=node_type,
+            search_mode=cript.SearchModes.UUID,
+            value_to_search=node_uuid
+        )
+
+        # get the project from paginator
+        my_node_from_api_dict = my_paginator.current_page_results[0]
+
+        # convert API JSON to CRIPT Project node
+        my_node_from_api = cript.load_nodes_from_json(json.dumps(my_node_from_api_dict))
+
+        return my_node_from_api
 
     def delete(self, node) -> None:
         """

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -37,7 +37,6 @@ from cript.api.valid_search_modes import SearchModes
 from cript.api.vocabulary_categories import VocabCategories
 from cript.nodes.exceptions import CRIPTNodeSchemaError
 from cript.nodes.primary_nodes.project import Project
-from cript.nodes.uuid_base import UUIDBaseNode
 
 # Do not use this directly! That includes devs.
 # Use the `_get_global_cached_api for access.

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -1106,11 +1106,7 @@ class API:
         """
 
         # get project node from API
-        my_paginator = self.search(
-            node_type=node_type,
-            search_mode=cript.SearchModes.UUID,
-            value_to_search=node_uuid
-        )
+        my_paginator = self.search(node_type=node_type, search_mode=cript.SearchModes.UUID, value_to_search=node_uuid)
 
         # get the project from paginator
         my_node_from_api_dict = my_paginator.current_page_results[0]

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -420,7 +420,7 @@ def test_api_search_get_node_by_uuid(cript_api: cript.API) -> None:
 
     assert isinstance(my_material_node, cript.Material)
     assert my_material_node.name == "Sodium polystyrene sulfonate"
-    assert my_material_node.uuid == material_uuid
+    assert str(my_material_node.uuid) == material_uuid
 
 
 def test_get_my_user_node_from_api(cript_api: cript.API) -> None:

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -399,6 +399,30 @@ def test_api_search_bigsmiles(cript_api: cript.API) -> None:
     # assert bigsmiles_paginator.current_page_results[1]["name"] == "BCDB_Material_285"
 
 
+@pytest.mark.skipif(not HAS_INTEGRATION_TESTS_ENABLED, reason="requires a real cript_api_token")
+def test_api_search_get_node_by_uuid(cript_api: cript.API) -> None:
+    """
+    tests `cript.API.get_node_by_uuid` works as intended
+
+    1. get a node from API by EXACT_NAME
+    1. from the node gotten from the API take out the UUID
+    1. use the UUID to get the desired node
+    """
+    # get node by EXACT_NAME to extract UUID from later
+    material_name = "Sodium polystyrene sulfonate"
+
+    exact_name_paginator = cript_api.search(node_type=cript.Material, search_mode=cript.SearchModes.EXACT_NAME, value_to_search=material_name)
+
+    material_uuid: str = exact_name_paginator.current_page_results[0]["uuid"]
+
+    # pass UUID for API node from the EXACT_SEARCH
+    my_material_node: cript.Material = cript_api.get_node_by_uuid(node_type=cript.Material, node_uuid=material_uuid)
+
+    assert isinstance(my_material_node, cript.Material)
+    assert my_material_node.name == "Sodium polystyrene sulfonate"
+    assert my_material_node.uuid == material_uuid
+
+
 def test_get_my_user_node_from_api(cript_api: cript.API) -> None:
     """
     tests that the Python SDK can successfully get the user node associated with the API Token

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -400,7 +400,7 @@ def test_api_search_bigsmiles(cript_api: cript.API) -> None:
 
 
 @pytest.mark.skipif(not HAS_INTEGRATION_TESTS_ENABLED, reason="requires a real cript_api_token")
-def test_api_search_get_node_by_uuid(cript_api: cript.API) -> None:
+def test_api_search_get_node_by_uuid(cript_api: cript.API, sodium_polystyrene_uuid) -> None:
     """
     tests `cript.API.get_node_by_uuid` works as intended
 
@@ -408,19 +408,11 @@ def test_api_search_get_node_by_uuid(cript_api: cript.API) -> None:
     1. from the node gotten from the API take out the UUID
     1. use the UUID to get the desired node
     """
-    # get node by EXACT_NAME to extract UUID from later
-    material_name = "Sodium polystyrene sulfonate"
-
-    exact_name_paginator = cript_api.search(node_type=cript.Material, search_mode=cript.SearchModes.EXACT_NAME, value_to_search=material_name)
-
-    material_uuid: str = exact_name_paginator.current_page_results[0]["uuid"]
-
-    # pass UUID for API node from the EXACT_SEARCH
-    my_material_node: cript.Material = cript_api.get_node_by_uuid(node_type=cript.Material, node_uuid=material_uuid)
+    my_material_node: cript.Material = cript_api.get_node_by_uuid(node_type=cript.Material, node_uuid=sodium_polystyrene_uuid)
 
     assert isinstance(my_material_node, cript.Material)
     assert my_material_node.name == "Sodium polystyrene sulfonate"
-    assert str(my_material_node.uuid) == material_uuid
+    assert str(my_material_node.uuid) == sodium_polystyrene_uuid
 
 
 def test_get_my_user_node_from_api(cript_api: cript.API) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import os
 import pytest
 
 import cript
+from tests.fixtures.api_fixtures import *
 from tests.fixtures.primary_nodes import *
 from tests.fixtures.subobjects import *
 from tests.fixtures.supporting_nodes import *

--- a/tests/fixtures/api_fixtures.py
+++ b/tests/fixtures/api_fixtures.py
@@ -3,7 +3,7 @@ import pytest
 import cript
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def sodium_polystyrene_uuid(cript_api: cript.API) -> str:
     """
     Get the UUID of the material, "Sodium polystyrene sulfonate" based on its EXACT_NAME from the API.

--- a/tests/fixtures/api_fixtures.py
+++ b/tests/fixtures/api_fixtures.py
@@ -1,0 +1,22 @@
+import pytest
+
+import cript
+
+
+@pytest.fixture
+def sodium_polystyrene_uuid(cript_api: cript.API) -> str:
+    """
+    Get the UUID of the material, "Sodium polystyrene sulfonate" based on its EXACT_NAME from the API.
+
+    This fixture uses the `cript.API.search`
+    method to fetch the material and extract its UUID.
+
+    This can be particularly useful in testing scenarios where you need to perform actions based on the
+    material's UUID without directly knowing it since the same material will have different UUID
+    within different server environments such as production, staging, and development.
+    """
+    material_name = "Sodium polystyrene sulfonate"
+
+    exact_name_paginator = cript_api.search(node_type=cript.Material, search_mode=cript.SearchModes.EXACT_NAME, value_to_search=material_name)
+
+    return exact_name_paginator.current_page_results[0]["uuid"]


### PR DESCRIPTION
# Description
Sarah asked for a method that the user can get a node via UUID like the past SDK had `api.get("uuid string")`, so I made `cript.API.get_node_by_uuid` it is not exactly the same because it requires UUID and the node you are looking for, as required by the API, but I think it will make SDK scripts easier to write and be more helpful

## Issue Link
* GtiHub: https://github.com/C-Accel-CRIPT/Python-SDK/issues/325
* Trello: https://trello.com/c/BgvWn0cQ

## Changes
* wrote test for `get_node_by_uuid`
* wrote documentation for `get_node_by_uuid`

### Tests
* `test_api_search_get_node_by_uuid` test is passing successfully
* wrote `sodium_polystyrene_uuid` api fixture
* made `test_api_search_get_node_by_uuid` DRY with uuid fixture
  * instead of repeating the same EXACT_NAME search everywhere in the tests any time we need a UUID

### Screenshots
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/646dce61-68e0-450e-8a82-39af15c4f88a)

## Known Issues

## Notes
* I don't like that this method is within the API and some ways of fetching a node from the API is called `search`, while the other is called `get..`
  * I think a better way of doing it in the future would be to have a search module within API and everything in regards to search or get conveniently and easily goes in there, so the user will easily know the methods within `cript.API.search.` without ever having to look it up
    * had we done that here, it would have been, `api.search.get_node_by_uuid(uuid)` which I think makes it much more organized
    * Brad said not to do refactoring until later, so I am leaving it for later

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
