### PR TITLE
using MKDocs native `watch` feature and upgraded `requirements_docs.txt`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,8 +107,8 @@ plugins:
             show_bases: true
             show_source: true
             docstring_style: numpy
-      watch:
-        - src/
+watch:
+  - src/
 
 markdown_extensions:
   - toc:

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -2,4 +2,4 @@ mkdocs==1.5.3
 mkdocs-material==9.3.2
 mkdocstrings[python]==0.23.0
 pymdown-extensions==10.3
-jupytext==1.15.1
+jupytext==1.15.2

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,5 +1,5 @@
-mkdocs==1.5.2
-mkdocs-material==9.3.1
+mkdocs==1.5.3
+mkdocs-material==9.3.2
 mkdocstrings[python]==0.23.0
 pymdown-extensions==10.3
 jupytext==1.15.1


### PR DESCRIPTION
# Description
fixed hot reload issue with MKDocs and upgraded outdated packages

## Changes
* `mkdocstrings` removed `watch` feature in `0.23.0` because MKDocs does it natively now
  * changed MKDocs to reflect the change
  * this was the issue that I bumped into previously and tried to temporarily address with this PR: https://github.com/C-Accel-CRIPT/Python-SDK/pull/354
  * Found a better and more permanent solution
* upgraded some packages that recently came out

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
