### PR TITLE
Upgrade API UUID tests to use dynamic UUID fixtures 

### DIFF
--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -356,7 +356,7 @@ def test_api_search_exact_name(cript_api: cript.API) -> None:
 
 
 @pytest.mark.skipif(not HAS_INTEGRATION_TESTS_ENABLED, reason="requires a real cript_api_token")
-def test_api_search_uuid(cript_api: cript.API) -> None:
+def test_api_search_uuid(cript_api: cript.API, dynamic_material_data) -> None:
     """
     tests search with UUID
     searches for `Sodium polystyrene sulfonate` material via UUID
@@ -366,18 +366,12 @@ def test_api_search_uuid(cript_api: cript.API) -> None:
     2. takes the UUID from the full node and puts it into the `UUID search`
     3. asserts everything is as expected
     """
-    material_name = "Sodium polystyrene sulfonate"
-
-    exact_name_paginator = cript_api.search(node_type=cript.Material, search_mode=cript.SearchModes.EXACT_NAME, value_to_search=material_name)
-
-    material_uuid = exact_name_paginator.current_page_results[0]["uuid"]
-
-    uuid_paginator = cript_api.search(node_type=cript.Material, search_mode=cript.SearchModes.UUID, value_to_search=material_uuid)
+    uuid_paginator = cript_api.search(node_type=cript.Material, search_mode=cript.SearchModes.UUID, value_to_search=dynamic_material_data["uuid"])
 
     assert isinstance(uuid_paginator, Paginator)
     assert len(uuid_paginator.current_page_results) == 1
-    assert uuid_paginator.current_page_results[0]["name"] == material_name
-    assert uuid_paginator.current_page_results[0]["uuid"] == material_uuid
+    assert uuid_paginator.current_page_results[0]["name"] == dynamic_material_data["name"]
+    assert uuid_paginator.current_page_results[0]["uuid"] == dynamic_material_data["uuid"]
 
 
 @pytest.mark.skipif(not HAS_INTEGRATION_TESTS_ENABLED, reason="requires a real cript_api_token")
@@ -400,7 +394,7 @@ def test_api_search_bigsmiles(cript_api: cript.API) -> None:
 
 
 @pytest.mark.skipif(not HAS_INTEGRATION_TESTS_ENABLED, reason="requires a real cript_api_token")
-def test_api_search_get_node_by_uuid(cript_api: cript.API, sodium_polystyrene_uuid) -> None:
+def test_api_search_get_node_by_uuid(cript_api: cript.API, dynamic_material_data) -> None:
     """
     tests `cript.API.get_node_by_uuid` works as intended
 
@@ -408,11 +402,11 @@ def test_api_search_get_node_by_uuid(cript_api: cript.API, sodium_polystyrene_uu
     1. from the node gotten from the API take out the UUID
     1. use the UUID to get the desired node
     """
-    my_material_node: cript.Material = cript_api.get_node_by_uuid(node_type=cript.Material, node_uuid=sodium_polystyrene_uuid)
+    my_material_node: cript.Material = cript_api.get_node_by_uuid(node_type=cript.Material, node_uuid=dynamic_material_data["uuid"])
 
     assert isinstance(my_material_node, cript.Material)
-    assert my_material_node.name == "Sodium polystyrene sulfonate"
-    assert str(my_material_node.uuid) == sodium_polystyrene_uuid
+    assert my_material_node.name == dynamic_material_data["name"]
+    assert str(my_material_node.uuid) == dynamic_material_data["uuid"]
 
 
 def test_get_my_user_node_from_api(cript_api: cript.API) -> None:

--- a/tests/fixtures/api_fixtures.py
+++ b/tests/fixtures/api_fixtures.py
@@ -1,22 +1,31 @@
+from typing import Dict
+
 import pytest
 
 import cript
 
 
 @pytest.fixture(scope="function")
-def sodium_polystyrene_uuid(cript_api: cript.API) -> str:
+def dynamic_material_data(cript_api: cript.API) -> Dict[str, str]:
     """
-    Get the UUID of the material, "Sodium polystyrene sulfonate" based on its EXACT_NAME from the API.
+    Get the UUID and name of the material, "Sodium polystyrene sulfonate" based on its EXACT_NAME from the API.
 
-    This fixture uses the `cript.API.search`
-    method to fetch the material and extract its UUID.
+    This fixture uses the `cript.API.search` method to fetch the material from the API.
 
     This can be particularly useful in testing scenarios where you need to perform actions based on the
     material's UUID without directly knowing it since the same material will have different UUID
     within different server environments such as production, staging, and development.
+
+    Returns
+    -------
+    Dict[str, str]
+        A dictionary containing {"uuid": uuid, "name": "Sodium polystyrene sulfonate"}.
+        This provides the test with access to both the name and UUID for verification.
     """
-    material_name = "Sodium polystyrene sulfonate"
+    material_name: str = "Sodium polystyrene sulfonate"
 
     exact_name_paginator = cript_api.search(node_type=cript.Material, search_mode=cript.SearchModes.EXACT_NAME, value_to_search=material_name)
 
-    return exact_name_paginator.current_page_results[0]["uuid"]
+    material_uuid: str = exact_name_paginator.current_page_results[0]["uuid"]
+
+    return {"name": material_name, "uuid": material_uuid}


### PR DESCRIPTION
# Description
Upgrade API UUID tests to use dynamic UUID fixtures 

## Changes
* changed material fixture to be more abstract and more flexible
  * if we want to add more data to the fixture, we can just add it to the dictionary and all current tests will run fine.
* changed past tests to work with the new dynamic UUID fixture cleanly

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
