### PR TITLE
Require file extension for `cript.File` node

### DIFF
--- a/docs/examples/simulation.md
+++ b/docs/examples/simulation.md
@@ -250,10 +250,33 @@ experiment.computation += [init, equilibration, bulk, ana]
 New we'd like to upload files associated with our simulation. First, we'll instantiate our File nodes under a specific project.
 
 ```python
-packing_file = cript.File(name="Initial simulation box snapshot with roughly packed molecules", type="computation_snapshot", source="path/to/local/file", extension=".csv")
-forcefield_file = cript.File(name="Forcefield definition file", type="data", source="path/to/local/file", extension=".pdf")
-snap_file = cript.File(name="Bulk measurement initial system snap shot", type="computation_snapshot", source="path/to/local/file", extension=".png")
-final_file = cript.File(name="Final snapshot of the system at the end the simulations", type="computation_snapshot", source="path/to/local/file", extension=".jpeg")
+packing_file = cript.File(
+    name="Initial simulation box snapshot with roughly packed molecules",
+    type="computation_snapshot",
+    source="path/to/local/file",
+    extension=".csv",
+)
+
+forcefield_file = cript.File(
+    name="Forcefield definition file",
+    type="data",
+    source="path/to/local/file",
+    extension=".pdf",
+)
+
+snap_file = cript.File(
+    name="Bulk measurement initial system snap shot",
+    type="computation_snapshot",
+    source="path/to/local/file",
+    extension=".png",
+)
+
+final_file = cript.File(
+    name="Final snapshot of the system at the end the simulations",
+    type="computation_snapshot",
+    source="path/to/local/file",
+    extension=".jpeg",
+)
 ```
 
 !!! note

--- a/docs/examples/simulation.md
+++ b/docs/examples/simulation.md
@@ -55,8 +55,11 @@ with cript.API(host="https://api.criptapp.org/", api_token="123456", storage_tok
     Here in a jupyter notebook, we need to connect manually. We just have to remember to disconnect at the end.
 
 ```python
-api = cript.API(host="https://api.criptapp.org/", api_token=None, storage_token="123456")
+api = cript.API(
+    host="https://api.criptapp.org/", api_token=None, storage_token="123456"
+)
 api = api.connect()
+
 ```
 
 ## Create a Project
@@ -121,9 +124,17 @@ If They are not, you can create them as follows:
 
 ```python
 python = cript.Software(name="python", version="3.9")
+
 rdkit = cript.Software(name="rdkit", version="2020.9")
-stage = cript.Software(name="stage", source="https://doi.org/10.1021/jp505332p", version="N/A")
-packmol = cript.Software(name="Packmol", source="http://m3g.iqm.unicamp.br/packmol", version="N/A")
+
+stage = cript.Software(
+    name="stage", source="https://doi.org/10.1021/jp505332p", version="N/A"
+)
+
+packmol = cript.Software(
+    name="Packmol", source="http://m3g.iqm.unicamp.br/packmol", version="N/A"
+)
+
 openmm = cript.Software(name="openmm", version="7.5")
 ```
 
@@ -195,8 +206,11 @@ init = cript.Computation(
 )
 
 # Initiate the simulation equilibration using a separate node.
-# The equilibration process is governed by specific conditions and a set equilibration time.
-# Given this is an NPT (Number of particles, Pressure, Temperature) simulation, conditions such as the number of chains, temperature, and pressure are specified.
+# The equilibration process is governed by specific conditions and a 
+# set equilibration time.
+# Given this is an NPT (Number of particles, Pressure, Temperature) 
+# simulation, conditions such as the number of chains, temperature, 
+# and pressure are specified.
 equilibration = cript.Computation(
     name="Equilibrate data prior to measurement",
     type="MD",
@@ -211,7 +225,8 @@ equilibration = cript.Computation(
 )
 
 # This section involves the actual data measurement.
-# Note that we use the previously computed data as a prerequisite. Additionally, we incorporate the input data at a later stage.
+# Note that we use the previously computed data as a prerequisite. 
+# Additionally, we incorporate the input data at a later stage.
 bulk = cript.Computation(
     name="Bulk simulation for measurement",
     type="MD",
@@ -225,7 +240,8 @@ bulk = cript.Computation(
     prerequisite_computation=equilibration,
 )
 
-# The following step involves analyzing the data from the measurement run to ascertain a specific property.
+# The following step involves analyzing the data 
+# from the measurement run to ascertain a specific property.
 ana = cript.Computation(
     name="Density analysis",
     type="analysis",
@@ -332,8 +348,10 @@ Next, we'll link these [`Data`](../../nodes/primary_nodes/data) nodes to the app
 
 ```python
 
-# Observe how this step also forms a continuous graph, enabling data to flow from one computation to the next.
-# The sequence initiates with the computation process and culminates with the determination of the material property.
+# Observe how this step also forms a continuous graph, 
+# enabling data to flow from one computation to the next.
+# The sequence initiates with the computation process 
+# and culminates with the determination of the material property.
 init.output_data = [packing_data, forcefield_data]
 equilibration.input_data = [packing_data, forcefield_data]
 equilibration.output_data = [equilibration_snap]
@@ -396,7 +414,8 @@ Now we can save the project to CRIPT (and upload the files) or inspect the JSON 
 ## Validate CRIPT Project Node
 ```python
 # Before we can save it, we should add all the orphaned nodes to the experiments.
-# It is important to do this for every experiment separately, but here we only have one.
+# It is important to do this for every experiment separately, 
+# but here we only have one.
 cript.add_orphaned_nodes_to_project(project, active_experiment=experiment)
 project.validate()
 

--- a/docs/examples/simulation.md
+++ b/docs/examples/simulation.md
@@ -250,10 +250,10 @@ experiment.computation += [init, equilibration, bulk, ana]
 New we'd like to upload files associated with our simulation. First, we'll instantiate our File nodes under a specific project.
 
 ```python
-packing_file = cript.File(name="Initial simulation box snapshot with roughly packed molecules", type="computation_snapshot", source="path/to/local/file")
-forcefield_file = cript.File(name="Forcefield definition file", type="data", source="path/to/local/file")
-snap_file = cript.File(name="Bulk measurement initial system snap shot", type="computation_snapshot", source="path/to/local/file")
-final_file = cript.File(name="Final snapshot of the system at the end the simulations", type="computation_snapshot", source="path/to/local/file")
+packing_file = cript.File(name="Initial simulation box snapshot with roughly packed molecules", type="computation_snapshot", source="path/to/local/file", extension=".csv")
+forcefield_file = cript.File(name="Forcefield definition file", type="data", source="path/to/local/file", extension=".pdf")
+snap_file = cript.File(name="Bulk measurement initial system snap shot", type="computation_snapshot", source="path/to/local/file", extension=".png")
+final_file = cript.File(name="Final snapshot of the system at the end the simulations", type="computation_snapshot", source="path/to/local/file", extension=".jpeg")
 ```
 
 !!! note

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -341,6 +341,9 @@ class File(PrimaryBaseNode):
         my_file_node.extension = ".csv"`
         ```
 
+        !!! Note "file extensions must start with a dot"
+            File extensions must start with a dot, for example `.csv` or `.pdf`
+
         Returns
         -------
         extension: str

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -201,9 +201,8 @@ class File(PrimaryBaseNode):
         It is not necessary to call this function manually.
         A saved project automatically ensures uploaded files, it is recommend to rely on the automatic upload.
 
-        Parameters:
+        Parameters
         -----------
-
         api: cript.API, optional
            API object that performs the upload.
            If None, the globally cached object is being used.
@@ -214,7 +213,7 @@ class File(PrimaryBaseNode):
         ```python
         my_file = cript.File(source="/local/path/to/file", type="calibration")
         my_file.ensure_uploaded()
-        my_file.source # Starts with http now
+        my_file.source # changed to cloud storage object name
         ```
 
         """

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -128,7 +128,7 @@ class File(PrimaryBaseNode):
     _json_attrs: JsonAttributes = JsonAttributes()
 
     @beartype
-    def __init__(self, name: str, source: str, type: str, extension: str = "", data_dictionary: str = "", notes: str = "", **kwargs):
+    def __init__(self, name: str, source: str, type: str, extension: str, data_dictionary: str = "", notes: str = "", **kwargs):
         """
         create a File node
 

--- a/src/cript/nodes/supporting_nodes/file.py
+++ b/src/cript/nodes/supporting_nodes/file.py
@@ -152,24 +152,27 @@ class File(PrimaryBaseNode):
 
         Examples
         --------
-        ### Minimal File Node
+        ### Web URL File Node
         ```python
         my_file = cript.File(
             name="my file name",
-            source="https://criptapp.org",
+            source="https://pubs.acs.org/doi/suppl/10.1021/acscentsci.3c00011/suppl_file/oc3c00011_si_001.pdf",
             type="calibration",
+            extension=".pdf",
+            data_dictionary="my file's data dictionary",
+            notes="my notes for this file",
         )
         ```
 
-        ### Maximal File Node
+        ### Local Source File Node
         ```python
         my_file = cript.File(
             name="my file name",
-            source="https://criptapp.org",
+            source="/home/user/MIT/project/my_file.csv",
             type="calibration",
             extension=".csv",
             data_dictionary="my file's data dictionary",
-            notes="my notes for this file"
+            notes="my notes for this file",
         )
         ```
         """

--- a/tests/nodes/supporting_nodes/test_file.py
+++ b/tests/nodes/supporting_nodes/test_file.py
@@ -17,7 +17,7 @@ def test_create_file() -> None:
     """
     tests that a simple file with only required attributes can be created
     """
-    file_node = cript.File(name="my file name", source="https://google.com", type="calibration")
+    file_node = cript.File(name="my file name", source="https://google.com", type="calibration", extension=".csv")
 
     assert isinstance(file_node, cript.File)
 
@@ -90,7 +90,7 @@ def test_local_file_source_upload_and_download(tmp_path_factory) -> None:
     local_file_path.write_text(file_text)
 
     # create a file node with a local file path
-    my_file = cript.File(name="my local file source node", source=str(local_file_path), type="data")
+    my_file = cript.File(name="my local file source node", source=str(local_file_path), type="data", extension=".txt")
 
     # check that the file source has been uploaded to cloud storage and source has changed to reflect that
     assert my_file.source.startswith("tests/")
@@ -124,7 +124,7 @@ def test_create_file_with_local_source(tmp_path) -> None:
     with open(file_path, "w") as temporary_file:
         temporary_file.write("hello world!")
 
-    assert cript.File(name="my file node with local source", source=str(file_path), type="calibration")
+    assert cript.File(name="my file node with local source", source=str(file_path), type="calibration", extension=".txt")
 
 
 def test_file_getters_and_setters(complex_file_node) -> None:


### PR DESCRIPTION
# Description



## Changes
* requiring file extension for all nodes when created
* updated documentation
  * updated File node creation example code
    * changed the code examples from minimal and maximal to 2 maximal file nodes with local path source and web url source
  * fixed `ensure_uploaded` documentation
    * the syntax was wrong
  * fixed example code documentation after the error popped up
    > **really happy that there is automated tests that check the validity of the code** 
    * formatted entire example code walkthrough and comments

### Screenshots

<details>

<summary> click to see updated file documentation </summary>

![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/aa17d6a3-32cf-44bd-a261-448870fcf59d)

</details>

<details>

<summary> click to see formatted code example documentation </summary>

![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/e5a06574-00d8-45af-a61a-19aa8fd4d56c)

</details>

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
