### PR TITLE
Performance improvement for node validation

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -713,7 +713,7 @@ class API:
         for file_node in node.find_children({"node": ["File"]}):
             file_node.ensure_uploaded(api=self)
 
-        node.validate()
+        node.validate(api=self, only_this_node_full=False)
 
         # Dummy response to have a virtual do-while loop, instead of while loop.
         response = {"code": -1}

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -713,6 +713,7 @@ class API:
         for file_node in node.find_children({"node": ["File"]}):
             file_node.ensure_uploaded(api=self)
 
+        # We request a full validation of the node just to be sure before save
         node.validate(api=self, only_this_node_full=False)
 
         # Dummy response to have a virtual do-while loop, instead of while loop.

--- a/src/cript/nodes/core.py
+++ b/src/cript/nodes/core.py
@@ -306,9 +306,18 @@ class BaseNode(ABC):
         if only_this_node_full:
             my_children = self.find_children({}, search_depth=1)
             # Create the list of UUID of the direct children (search_depth==1)
-            only_not_uuid = [str(child.uuid) for child in my_children]
+            only_not_uuid = []
+            for child in my_children:
+                try:
+                    only_not_uuid.append(str(child.uuid))  # type: ignore
+                except AttributeError:  # Technically, BaseNode does not have uuid
+                    pass
             # Add the self uuid for this node (if available)
-            only_not_uuid += [str(self.uuid)]
+            try:
+                only_not_uuid.append(str(self.uuid))  # type: ignore
+            except AttributeError:  # Technically, BaseNode does not have uuid
+                pass
+
             NodeEncoder.only_not_uuid = only_not_uuid
 
         try:

--- a/src/cript/nodes/core.py
+++ b/src/cript/nodes/core.py
@@ -300,14 +300,15 @@ class BaseNode(ABC):
         previous_condense_to_uuid = copy.deepcopy(NodeEncoder.condense_to_uuid)
         NodeEncoder.condense_to_uuid = condense_to_uuid
 
+        # For validation of just a node and its direct children, we enable a new mode in Node encoding
+        # For this node we explicitly list the nodes that are fully expressed, every other node is a UUID
         previous_only_not_uuid: Optional[list[str]] = NodeEncoder.only_not_uuid
         if only_this_node_full:
             my_children = self.find_children({}, search_depth=1)
+            # Create the list of UUID of the direct children (search_depth==1)
             only_not_uuid = [str(child.uuid) for child in my_children]
-            try:
-                only_not_uuid += [str(self.uuid)]
-            except AttributeError:  # This works only for nodes that have a uuid
-                pass
+            # Add the self uuid for this node (if available)
+            only_not_uuid += [str(self.uuid)]
             NodeEncoder.only_not_uuid = only_not_uuid
 
         try:

--- a/src/cript/nodes/util/__init__.py
+++ b/src/cript/nodes/util/__init__.py
@@ -58,7 +58,7 @@ class NodeEncoder(json.JSONEncoder):
     known_uuid: Set[str] = set()
     condense_to_uuid: Dict[str, Set[str]] = dict()
     suppress_attributes: Optional[Dict[str, Set[str]]] = None
-    only_not_uuid: Optional[list[str]] = None
+    only_not_uuid: Optional[List[str]] = None
 
     def default(self, obj):
         """

--- a/src/cript/nodes/util/__init__.py
+++ b/src/cript/nodes/util/__init__.py
@@ -58,6 +58,7 @@ class NodeEncoder(json.JSONEncoder):
     known_uuid: Set[str] = set()
     condense_to_uuid: Dict[str, Set[str]] = dict()
     suppress_attributes: Optional[Dict[str, Set[str]]] = None
+    only_not_uuid: Optional[list[str]] = None
 
     def default(self, obj):
         """
@@ -114,6 +115,8 @@ class NodeEncoder(json.JSONEncoder):
                 pass
             else:
                 if uuid_str in NodeEncoder.known_uuid:
+                    return {"uuid": uuid_str}
+                if NodeEncoder.only_not_uuid is not None and uuid_str not in NodeEncoder.only_not_uuid:
                     return {"uuid": uuid_str}
 
             default_dataclass = obj.JsonAttributes()

--- a/src/cript/nodes/util/__init__.py
+++ b/src/cript/nodes/util/__init__.py
@@ -116,6 +116,8 @@ class NodeEncoder(json.JSONEncoder):
             else:
                 if uuid_str in NodeEncoder.known_uuid:
                     return {"uuid": uuid_str}
+                # If we specified to only fully express certain nodes in `only_not_uuid`.
+                # Exit every other node with just its UUID.
                 if NodeEncoder.only_not_uuid is not None and uuid_str not in NodeEncoder.only_not_uuid:
                     return {"uuid": uuid_str}
 

--- a/tests/test_node_util.py
+++ b/tests/test_node_util.py
@@ -8,7 +8,6 @@ import cript
 from cript.nodes.core import get_new_uid
 from cript.nodes.exceptions import (
     CRIPTJsonNodeError,
-    CRIPTJsonSerializationError,
     CRIPTNodeSchemaError,
     CRIPTOrphanedComputationalProcessError,
     CRIPTOrphanedComputationError,
@@ -142,10 +141,6 @@ def test_json_error(complex_parameter_node):
     parameter._json_attrs = replace(parameter._json_attrs, value="abc")
     with pytest.raises(CRIPTNodeSchemaError):
         parameter.validate()
-    # Let's break it completely
-    parameter._json_attrs = None
-    with pytest.raises(CRIPTJsonSerializationError):
-        parameter.json
 
 
 def test_local_search(simple_algorithm_node, complex_parameter_node):


### PR DESCRIPTION
# Description
Addition or replacement of #361 
This accelerates the validation of nodes.

When we change a given node A possibly by adding node B to be its child, we already know that A that B is a valid node.

So, instead of validating the entire graph of A, it would be more efficient to only validate A and not its entire graph of children.
So the idea is to reduce the down stream graph of A to only UUID.

However, there is a flaw with this B might be a valid node, but it might be in an invalid attribute of A.
The data schema is flawed that way, that it would accept this bad graph. (The data schema has no way of validating the node type if give a UUID only.)
We should probably write a ticket for this flaw too.
It could be averted if `UID` and `UUID` also require `node` in the JSON.

As a solution, we express A and all its direct children directly, that makes sure that A is still correct and all its children are also of correct type, but still saves on evaluating the entire downstream graph.

## Changes

Added a new mode of encoding nodes to JSON, where only a fixed list of UUID are fully expressed and every other node is just a UUID.

## Tests

The existing tests should cover this.

## Known Issues

See above, flaw in the data schema that doesn't evaluate node types of UUID and UID.
Not new with the PR, but found writing this PR.

## Notes

## Checklist

- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
