### PR TITLE
Change Python 3.11 to 3.12 in GitHub Workflows

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -18,7 +18,7 @@ jobs:
   mypy-test:
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.12]
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_coverage.yaml
+++ b/.github/workflows/test_coverage.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.11]
+        python-version: [3.12]
 
     env:
       CRIPT_HOST: https://lb-stage.mycriptapp.org/

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.11]
+        python-version: [3.12]
 
     env:
       CRIPT_HOST: https://lb-stage.mycriptapp.org/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
 
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.11]
+        python-version: [3.8, 3.12]
 
     env:
       CRIPT_HOST: https://lb-stage.mycriptapp.org/


### PR DESCRIPTION
# Description
[Python 3.12](https://www.python.org/downloads/release/python-3120/) was released 10/2/2023 and I am adding it to our CI to use 3.12 because it has new feature, it ensures compatibility, and it is faster than 3.11


## Changes

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
