### PR TITLE
moving some api vars to api_config.py

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -14,18 +14,12 @@ from beartype import beartype
 
 import cript
 from cript.api.api_config import _API_PREFIX, _API_TIMEOUT, _API_VERSION
-from cript.api.exceptions import (APIError, CRIPTAPIRequiredError,
-                                  CRIPTAPISaveError, CRIPTConnectionError,
-                                  CRIPTDuplicateNameError, InvalidHostError,
-                                  InvalidVocabulary)
+from cript.api.exceptions import APIError, CRIPTAPIRequiredError, CRIPTAPISaveError, CRIPTConnectionError, CRIPTDuplicateNameError, InvalidHostError, InvalidVocabulary
 from cript.api.paginator import Paginator
 from cript.api.utils.aws_s3_utils import get_s3_client
 from cript.api.utils.get_host_token import resolve_host_and_token
 from cript.api.utils.helper_functions import _get_node_type_from_json
-from cript.api.utils.save_helper import (_fix_node_save,
-                                         _get_uuid_from_error_message,
-                                         _identify_suppress_attributes,
-                                         _InternalSaveValues)
+from cript.api.utils.save_helper import _fix_node_save, _get_uuid_from_error_message, _identify_suppress_attributes, _InternalSaveValues
 from cript.api.utils.web_file_downloader import download_file_from_url
 from cript.api.valid_search_modes import SearchModes
 from cript.api.vocabulary_categories import VocabCategories

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -13,26 +13,19 @@ import requests
 from beartype import beartype
 
 import cript
-from cript.api.api_config import _API_TIMEOUT, _API_PREFIX, _API_VERSION
-from cript.api.exceptions import (
-    APIError,
-    CRIPTAPIRequiredError,
-    CRIPTAPISaveError,
-    CRIPTConnectionError,
-    CRIPTDuplicateNameError,
-    InvalidHostError,
-    InvalidVocabulary,
-)
+from cript.api.api_config import _API_PREFIX, _API_TIMEOUT, _API_VERSION
+from cript.api.exceptions import (APIError, CRIPTAPIRequiredError,
+                                  CRIPTAPISaveError, CRIPTConnectionError,
+                                  CRIPTDuplicateNameError, InvalidHostError,
+                                  InvalidVocabulary)
 from cript.api.paginator import Paginator
 from cript.api.utils.aws_s3_utils import get_s3_client
 from cript.api.utils.get_host_token import resolve_host_and_token
 from cript.api.utils.helper_functions import _get_node_type_from_json
-from cript.api.utils.save_helper import (
-    _fix_node_save,
-    _get_uuid_from_error_message,
-    _identify_suppress_attributes,
-    _InternalSaveValues,
-)
+from cript.api.utils.save_helper import (_fix_node_save,
+                                         _get_uuid_from_error_message,
+                                         _identify_suppress_attributes,
+                                         _InternalSaveValues)
 from cript.api.utils.web_file_downloader import download_file_from_url
 from cript.api.valid_search_modes import SearchModes
 from cript.api.vocabulary_categories import VocabCategories

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -13,7 +13,7 @@ import requests
 from beartype import beartype
 
 import cript
-from cript.api.api_config import _API_TIMEOUT
+from cript.api.api_config import _API_TIMEOUT, _API_PREFIX, _API_VERSION
 from cript.api.exceptions import (
     APIError,
     CRIPTAPIRequiredError,
@@ -70,8 +70,6 @@ class API:
     _http_headers: dict = {}
     _vocabulary: dict = {}
     _db_schema: dict = {}
-    _api_prefix: str = "api"
-    _api_version: str = "v1"
 
     # trunk-ignore-begin(cspell)
     # AWS S3 constants
@@ -333,7 +331,7 @@ class API:
     def _prepare_host(self, host: str) -> str:
         # strip ending slash to make host always uniform
         host = host.rstrip("/")
-        host = f"{host}/{self._api_prefix}/{self._api_version}"
+        host = f"{host}/{_API_PREFIX}/{_API_VERSION}"
 
         # if host is using unsafe "http://" then give a warning
         if host.startswith("http://"):

--- a/src/cript/api/api_config.py
+++ b/src/cript/api/api_config.py
@@ -6,6 +6,6 @@ These constants are used to customize various aspects of the API requests and be
 """
 
 # Default maximum time in seconds for all API requests to wait for a response from the backend
-_API_TIMEOUT: int = 120     # 2 minutes
+_API_TIMEOUT: int = 120  # 2 minutes
 _API_PREFIX: str = "api"
 _API_VERSION: str = "v1"

--- a/src/cript/api/api_config.py
+++ b/src/cript/api/api_config.py
@@ -6,4 +6,6 @@ These constants are used to customize various aspects of the API requests and be
 """
 
 # Default maximum time in seconds for all API requests to wait for a response from the backend
-_API_TIMEOUT: int = 120
+_API_TIMEOUT: int = 120     # 2 minutes
+_API_PREFIX: str = "api"
+_API_VERSION: str = "v1"


### PR DESCRIPTION
# Description
moving some api vars to api_config.py that will make the API class a bit cleaner, simpler, and easier to work with I think

## Changes

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
