### PR TITLE
fix reference.py definition docs formatting

### DIFF
--- a/src/cript/nodes/primary_nodes/reference.py
+++ b/src/cript/nodes/primary_nodes/reference.py
@@ -12,7 +12,6 @@ class Reference(UUIDBaseNode):
 
     The
     [Reference node](https://pubs.acs.org/doi/suppl/10.1021/acscentsci.3c00011/suppl_file/oc3c00011_si_001.pdf#page=15)
-
     contains the metadata for a literature publication, book, or anything external to CRIPT.
     The reference node does NOT contain the base attributes.
 
@@ -115,13 +114,17 @@ class Reference(UUIDBaseNode):
         """
         create a reference node
 
-        reference type must come from CRIPT controlled vocabulary
+        Examples
+        --------
+        >>> import cript
+        >>> my_reference = cript.Reference(type="journal_article", title="'Living' Polymers")
 
         Parameters
         ----------
         type: str
             type of literature.
-            The reference type must come from CRIPT controlled vocabulary
+            The [reference type](https://app.criptapp.org/vocab/reference_type/)
+            must come from CRIPT controlled vocabulary
         title: str
             title of publication
         author: List[str] default=""
@@ -148,13 +151,6 @@ class Reference(UUIDBaseNode):
             PMID: PubMed ID
         website: str default=""
             website where the publication can be accessed
-
-
-        Examples
-        --------
-        ```python
-        my_reference = cript.Reference(type="journal_article", title="'Living' Polymers")
-        ```
 
         Returns
         -------
@@ -185,9 +181,9 @@ class Reference(UUIDBaseNode):
 
         Examples
         --------
-        ```python
-        my_reference.type = "journal_article"
-        ```
+        >>> import cript
+        >>> my_reference = cript.Reference(type="journal_article", title="'Living' Polymers")
+        >>> my_reference.type = "web_site"
 
         Returns
         -------
@@ -224,9 +220,9 @@ class Reference(UUIDBaseNode):
 
         Examples
         --------
-        ```python
-        my_reference.title = "my new title"
-        ```
+        >>> import cript
+        >>> my_reference = cript.Reference(type="journal_article", title="'Living' Polymers")
+        >>> my_reference.title = "my new title"
 
         Returns
         -------
@@ -260,9 +256,9 @@ class Reference(UUIDBaseNode):
 
         Examples
         --------
-        ```python
-        my_reference.author = ["Bradley D. Olsen", "Dylan Walsh"]
-        ```
+        >>> import cript
+        >>> my_reference = cript.Reference(type="journal_article", title="'Living' Polymers")
+        >>> my_reference.author += ["Navid Hariri"]
 
         Returns
         -------
@@ -296,9 +292,9 @@ class Reference(UUIDBaseNode):
 
         Examples
         --------
-        ```python
-        my_reference.journal = "my new journal"
-        ```
+        >>> import cript
+        >>> my_reference = cript.Reference(type="journal_article", title="'Living' Polymers")
+        >>> my_reference.journal = "my new journal"
 
         Returns
         -------
@@ -332,9 +328,9 @@ class Reference(UUIDBaseNode):
 
         Examples
         --------
-        ```python
-        my_reference.publisher = "my new publisher"
-        ```
+        >>> import cript
+        >>> my_reference = cript.Reference(type="journal_article", title="'Living' Polymers")
+        >>> my_reference.publisher = "my new publisher"
 
         Returns
         -------
@@ -368,9 +364,9 @@ class Reference(UUIDBaseNode):
 
         Examples
         --------
-        ```python
-        my_reference.year = 2023
-        ```
+        >>> import cript
+        >>> my_reference = cript.Reference(type="journal_article", title="'Living' Polymers")
+        >>> my_reference.year = 2023
 
         Returns
         -------
@@ -404,9 +400,9 @@ class Reference(UUIDBaseNode):
 
         Examples
         --------
-        ```python
-        my_reference.volume = 1
-        ```
+        >>> import cript
+        >>> my_reference = cript.Reference(type="journal_article", title="'Living' Polymers")
+        >>> my_reference.volume = 1
 
         Returns
         -------
@@ -440,9 +436,9 @@ class Reference(UUIDBaseNode):
 
         Examples
         --------
-        ```python
-        my_reference.issue = 2
-        ```
+        >>> import cript
+        >>> my_reference = cript.Reference(type="journal_article", title="'Living' Polymers")
+        >>> my_reference.issue = 2
 
         Returns
         -------
@@ -475,9 +471,9 @@ class Reference(UUIDBaseNode):
 
         Examples
         --------
-        ```python
-        my_reference.pages = [123, 456]
-        ```
+        >>> import cript
+        >>> my_reference = cript.Reference(type="journal_article", title="'Living' Polymers")
+        >>> my_reference.pages = [123, 456]
 
         Returns
         -------
@@ -510,9 +506,9 @@ class Reference(UUIDBaseNode):
 
         Examples
         --------
-        ```python
-        my_reference.doi = "100.1038/1781168a0"
-        ```
+        >>> import cript
+        >>> my_reference = cript.Reference(type="journal_article", title="'Living' Polymers")
+        >>> my_reference.doi = "100.1038/1781168a0"
 
         Returns
         -------
@@ -533,9 +529,9 @@ class Reference(UUIDBaseNode):
 
         Examples
         --------
-        ```python
-        my_reference.doi = "100.1038/1781168a0"
-        ```
+        >>> import cript
+        >>> my_reference = cript.Reference(type="journal_article", title="'Living' Polymers")
+        >>> my_reference.doi = "100.1038/1781168a0"
 
         Returns
         -------
@@ -551,9 +547,10 @@ class Reference(UUIDBaseNode):
         The international standard serial number (ISSN) for this reference node
 
         Examples
-        ```python
-        my_reference.issn = "1456-4687"
-        ```
+        ---------
+        >>> import cript
+        >>> my_reference = cript.Reference(type="journal_article", title="'Living' Polymers")
+        >>> my_reference.issn = "1456-4687"
 
         Returns
         -------
@@ -587,9 +584,9 @@ class Reference(UUIDBaseNode):
 
         Examples
         --------
-        ```python
-        my_reference.arxiv_id = "1501"
-        ```
+        >>> import cript
+        >>> my_reference = cript.Reference(type="journal_article", title="'Living' Polymers")
+        >>> my_reference.arxiv_id = "1501"
 
         Returns
         -------
@@ -623,9 +620,9 @@ class Reference(UUIDBaseNode):
 
         Examples
         --------
-        ```python
-        my_reference.pmid = 12345678
-        ```
+        >>> import cript
+        >>> my_reference = cript.Reference(type="journal_article", title="'Living' Polymers")
+        >>> my_reference.pmid = 12345678
 
         Returns
         -------
@@ -660,9 +657,9 @@ class Reference(UUIDBaseNode):
 
         Examples
         --------
-        ```python
-        my_reference.website = "https://criptapp.org"
-        ```
+        >>> import cript
+        >>> my_reference = cript.Reference(type="journal_article", title="'Living' Polymers")
+        >>> my_reference.website = "https://criptapp.org"
 
         Returns
         -------


### PR DESCRIPTION
# Description
reference documentation had an extra space between the words, which was weird, so I changed that and it looks nice now. 
> Screenshots below

## Changes

### Screenshots

#### Before
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/2c6113f4-0f72-4f8c-a693-4a58fdd6e65c)

#### After
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/67578af8-a640-4436-92da-edc687b2410f)


## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
