### PR TITLE
fixed reference docs formatting

### DIFF
--- a/src/cript/nodes/primary_nodes/reference.py
+++ b/src/cript/nodes/primary_nodes/reference.py
@@ -12,7 +12,6 @@ class Reference(UUIDBaseNode):
 
     The
     [Reference node](https://pubs.acs.org/doi/suppl/10.1021/acscentsci.3c00011/suppl_file/oc3c00011_si_001.pdf#page=15)
-
     contains the metadata for a literature publication, book, or anything external to CRIPT.
     The reference node does NOT contain the base attributes.
 
@@ -24,7 +23,7 @@ class Reference(UUIDBaseNode):
     |-----------|-----------|--------------------------------------------|-----------------------------------------------|---------------|-------|
     | type      | str       | journal_article                            | type of literature                            | True          | True  |
     | title     | str       | 'Living' Polymers                          | title of publication                          | True          |       |
-    | author   | list[str] | Michael Szwarc                             | list of authors                               |               |       |
+    | author    | list[str] | Michael Szwarc                             | list of authors                               |               |       |
     | journal   | str       | Nature                                     | journal of the publication                    |               |       |
     | publisher | str       | Springer                                   | publisher of publication                      |               |       |
     | year      | int       | 1956                                       | year of publication                           |               |       |


### PR DESCRIPTION
# Description
reference documentation had an extra space between the words, which was weird, so I changed that and it looks nice now. 
> Screenshots below

## Changes

### Screenshots

#### Before
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/2c6113f4-0f72-4f8c-a693-4a58fdd6e65c)

#### After
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/67578af8-a640-4436-92da-edc687b2410f)


## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
