### PR TITLE
added both `PrimaryBaseNode` and `UUIDBase` to docs

### DIFF
--- a/docs/nodes/primary_nodes/base_node.md
+++ b/docs/nodes/primary_nodes/base_node.md
@@ -1,1 +1,1 @@
-# Base node
+::: cript.nodes.primary_nodes.primary_base_node

--- a/docs/nodes/uuid_base.md
+++ b/docs/nodes/uuid_base.md
@@ -1,0 +1,1 @@
+::: cript.nodes.uuid_base

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,9 @@ nav:
       - Search Modes: api/search_modes.md
       - Paginator: api/paginator.md
       - Controlled Vocabulary Categories: api/controlled_vocabulary_categories.md
+  - Base Nodes:
+      - UUIDBase: nodes/uuid_base.md
+      - PrimaryBaseNode: nodes/primary_nodes/base_node.md
   - Primary Nodes:
       - Collection: nodes/primary_nodes/collection.md
       - Computation: nodes/primary_nodes/computation.md


### PR DESCRIPTION
# Description
added both `PrimaryBaseNode` and `UUIDBase` to docs, they were missing previously and harder for users to use the SDK I think.

## Changes

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
