### PR TITLE
removed redundant Material name getter and setter

### DIFF
--- a/src/cript/nodes/primary_nodes/material.py
+++ b/src/cript/nodes/primary_nodes/material.py
@@ -132,41 +132,6 @@ class Material(PrimaryBaseNode):
 
     @property
     @beartype
-    def name(self) -> str:
-        """
-        material name
-
-        Examples
-        ```python
-        my_material.name = "my new material"
-        ```
-
-        Returns
-        -------
-        str
-            material name
-        """
-        return self._json_attrs.name
-
-    @name.setter
-    @beartype
-    def name(self, new_name: str) -> None:
-        """
-        set the name of the material
-
-        Parameters
-        ----------
-        new_name: str
-
-        Returns
-        -------
-        None
-        """
-        new_attrs = replace(self._json_attrs, name=new_name)
-        self._update_json_attrs_if_valid(new_attrs)
-
-    @property
-    @beartype
     def identifier(self) -> List[Dict[str, str]]:
         """
         get the identifiers for this material


### PR DESCRIPTION
# Description
removed redundant material name getter and setter. Name attribute is not needed because it already exists in primary base node

## Changes

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
