### PR TITLE
Feature: Single search

### DIFF
--- a/docs/api/search_modes.md
+++ b/docs/api/search_modes.md
@@ -1,1 +1,1 @@
-::: cript.SearchModes
+::: cript.api.valid_search_modes

--- a/src/cript/__init__.py
+++ b/src/cript/__init__.py
@@ -8,7 +8,7 @@ from beartype.roar import BeartypeDecorHintPep585DeprecationWarning
 
 filterwarnings("ignore", category=BeartypeDecorHintPep585DeprecationWarning)
 
-from cript.api import API, SearchModes, VocabCategories
+from cript.api import API, SearchModes, ExactSearchModes, VocabCategories
 from cript.exceptions import CRIPTException
 from cript.nodes import (
     Algorithm,

--- a/src/cript/__init__.py
+++ b/src/cript/__init__.py
@@ -8,7 +8,7 @@ from beartype.roar import BeartypeDecorHintPep585DeprecationWarning
 
 filterwarnings("ignore", category=BeartypeDecorHintPep585DeprecationWarning)
 
-from cript.api import API, SearchModes, ExactSearchModes, VocabCategories
+from cript.api import API, ExactSearchModes, SearchModes, VocabCategories
 from cript.exceptions import CRIPTException
 from cript.nodes import (
     Algorithm,

--- a/src/cript/api/__init__.py
+++ b/src/cript/api/__init__.py
@@ -1,5 +1,5 @@
 # trunk-ignore-all(ruff/F401)
 
 from cript.api.api import API
-from cript.api.valid_search_modes import SearchModes
+from cript.api.valid_search_modes import SearchModes, ExactSearchModes
 from cript.api.vocabulary_categories import VocabCategories

--- a/src/cript/api/__init__.py
+++ b/src/cript/api/__init__.py
@@ -1,5 +1,5 @@
 # trunk-ignore-all(ruff/F401)
 
 from cript.api.api import API
-from cript.api.valid_search_modes import SearchModes, ExactSearchModes
+from cript.api.valid_search_modes import ExactSearchModes, SearchModes
 from cript.api.vocabulary_categories import VocabCategories

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -14,12 +14,25 @@ from beartype import beartype
 
 import cript
 from cript.api.api_config import _API_TIMEOUT
-from cript.api.exceptions import APIError, CRIPTAPIRequiredError, CRIPTAPISaveError, CRIPTConnectionError, CRIPTDuplicateNameError, InvalidHostError, InvalidVocabulary
+from cript.api.exceptions import (
+    APIError,
+    CRIPTAPIRequiredError,
+    CRIPTAPISaveError,
+    CRIPTConnectionError,
+    CRIPTDuplicateNameError,
+    InvalidHostError,
+    InvalidVocabulary,
+)
 from cript.api.paginator import Paginator
 from cript.api.utils.aws_s3_utils import get_s3_client
 from cript.api.utils.get_host_token import resolve_host_and_token
 from cript.api.utils.helper_functions import _get_node_type_from_json
-from cript.api.utils.save_helper import _fix_node_save, _get_uuid_from_error_message, _identify_suppress_attributes, _InternalSaveValues
+from cript.api.utils.save_helper import (
+    _fix_node_save,
+    _get_uuid_from_error_message,
+    _identify_suppress_attributes,
+    _InternalSaveValues,
+)
 from cript.api.utils.web_file_downloader import download_file_from_url
 from cript.api.valid_search_modes import ExactSearchModes, SearchModes
 from cript.api.vocabulary_categories import VocabCategories

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -1153,7 +1153,9 @@ class API:
         node_type: Any
             The class representation of the type of node you're targeting.
         search_mode: ExactSearchModes
-            The type of exact match criteria (UUID, EXACT_NAME, BIGSMILES, etc.)
+            The type of exact match criteria (UUID, EXACT_NAME, BIGSMILES, etc.).
+            The Exact serach mode must come
+            [cript.ExactSearchModes](../search_modes/#cript.api.valid_search_modes.ExactSearchModes)
         value_to_search: str
             The value you're searching for.
 

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -1073,7 +1073,6 @@ class API:
             Type of node that you are searching for.
         search_mode : SearchModes
             Type of search you want to do. You can search by name, `UUID`, `EXACT_NAME`, etc.
-            Refer to [valid search modes](../search_modes)
         value_to_search : Optional[str]
             What you are searching for can be either a value, and if you are only searching for
             a `NODE_TYPE`, then this value can be empty or `None`
@@ -1154,8 +1153,6 @@ class API:
             The class representation of the type of node you're targeting.
         search_mode: ExactSearchModes
             The type of exact match criteria (UUID, EXACT_NAME, BIGSMILES, etc.).
-            The Exact serach mode must come
-            [cript.ExactSearchModes](../search_modes/#cript.api.valid_search_modes.ExactSearchModes)
         value_to_search: str
             The value you're searching for.
 

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -14,27 +14,14 @@ from beartype import beartype
 
 import cript
 from cript.api.api_config import _API_TIMEOUT
-from cript.api.exceptions import (
-    APIError,
-    CRIPTAPIRequiredError,
-    CRIPTAPISaveError,
-    CRIPTConnectionError,
-    CRIPTDuplicateNameError,
-    InvalidHostError,
-    InvalidVocabulary,
-)
+from cript.api.exceptions import APIError, CRIPTAPIRequiredError, CRIPTAPISaveError, CRIPTConnectionError, CRIPTDuplicateNameError, InvalidHostError, InvalidVocabulary
 from cript.api.paginator import Paginator
 from cript.api.utils.aws_s3_utils import get_s3_client
 from cript.api.utils.get_host_token import resolve_host_and_token
 from cript.api.utils.helper_functions import _get_node_type_from_json
-from cript.api.utils.save_helper import (
-    _fix_node_save,
-    _get_uuid_from_error_message,
-    _identify_suppress_attributes,
-    _InternalSaveValues,
-)
+from cript.api.utils.save_helper import _fix_node_save, _get_uuid_from_error_message, _identify_suppress_attributes, _InternalSaveValues
 from cript.api.utils.web_file_downloader import download_file_from_url
-from cript.api.valid_search_modes import SearchModes, ExactSearchModes
+from cript.api.valid_search_modes import ExactSearchModes, SearchModes
 from cript.api.vocabulary_categories import VocabCategories
 from cript.nodes.exceptions import CRIPTNodeSchemaError
 from cript.nodes.primary_nodes.project import Project

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -12,6 +12,7 @@ import jsonschema
 import requests
 from beartype import beartype
 
+import cript
 from cript.api.api_config import _API_TIMEOUT
 from cript.api.exceptions import (
     APIError,

--- a/src/cript/api/valid_search_modes.py
+++ b/src/cript/api/valid_search_modes.py
@@ -38,3 +38,9 @@ class SearchModes(Enum):
     UUID: str = "uuid"
     # UUID_CHILDREN = "uuid_children"
     BIGSMILES: str = "bigsmiles"
+
+
+class ExactSearchModes(Enum):
+    UUID = "uuid"
+    EXACT_NAME = "exact_name"
+    BIGSMILES = "bigsmiles"

--- a/src/cript/api/valid_search_modes.py
+++ b/src/cript/api/valid_search_modes.py
@@ -5,6 +5,9 @@ class SearchModes(Enum):
     """
     Available search modes to use with the CRIPT API search
 
+    > For more details and code examples,
+    > please check the [cript.API.search( ) method](../api/#cript.api.api.API.search)
+
     Attributes
     ----------
     NODE_TYPE : str
@@ -27,9 +30,6 @@ class SearchModes(Enum):
     ...     search_mode=cript.SearchModes.NODE_TYPE,
     ...     value_to_search=None,
     ... )   # doctest: +SKIP
-
-    For more details and code examples,
-    please check the [cript.API.search( ) method](../api/#cript.api.api.API.search)
     """
 
     NODE_TYPE: str = ""

--- a/src/cript/api/valid_search_modes.py
+++ b/src/cript/api/valid_search_modes.py
@@ -41,6 +41,48 @@ class SearchModes(Enum):
 
 
 class ExactSearchModes(Enum):
-    UUID = "uuid"
-    EXACT_NAME = "exact_name"
-    BIGSMILES = "bigsmiles"
+    """
+    Available exact search modes to use with the
+    [cript.API.get_node_by_exact_match() method](../api/#cript.api.api.API.get_node_by_exact_match)
+    to retrieving single nodes.
+
+    > For more details and code examples, please review
+    > [cript.API.get_node_by_exact_match() method](../api/#cript.api.api.API.get_node_by_exact_match)
+
+    Attributes
+    ----------
+    UUID : str
+        Search by unique node UUID.
+    EXACT_NAME : str
+        Search by unique exact node name.
+    BIGSMILES: str
+        Search materials by BigSmiles identifier for an exact match.
+
+    Examples
+    -------
+    >>> import cript
+    >>> # Retrieve a node by its exact UUID
+    >>> my_material_node = api.get_node_by_exact_match(
+    ...     node_type=cript.Material,
+    ...     search_mode=cript.ExactSearchModes.UUID,
+    ...     value_to_search="e1b41d34-3bf2-4cd8-9a19-6412df7e7efc"
+    ... )   # doctest: +SKIP
+
+    >>> # Retrieve a node by its exact name
+    >>> my_project_node = api.get_node_by_exact_match(
+    ...     node_type=cript.Material,
+    ...     search_mode=cript.ExactSearchModes.EXACT_NAME,
+    ...     value_to_search="Sodium polystyrene sulfonate"
+    ... )  # doctest: +SKIP
+
+    >>> # Retrieve a material by its BigSmiles identifier
+    >>> my_material_node = api.get_node_by_exact_match(
+    ...     node_type=cript.Material,
+    ...     search_mode=cript.ExactSearchModes.BIGSMILES,
+    ...     value_to_search="{[][$]CC(C)(C(=O)OCCCC)[$][]}"
+    ... )  # doctest: +SKIP
+    """
+
+    UUID: str = "uuid"
+    EXACT_NAME: str = "exact_name"
+    BIGSMILES: str = "bigsmiles"

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -437,13 +437,16 @@ def test_api_get_node_by_exact_match_bigsmiles(cript_api: cript.API, dynamic_mat
 @pytest.mark.skipif(not HAS_INTEGRATION_TESTS_ENABLED, reason="requires a real cript_api_token")
 def test_api_get_node_by_exact_match_invalid_search_value(cript_api: cript.API) -> None:
     """
-    Tests that a `ValueError` is correctly raised when the API returns no matches for the search.
+    Verifies that `ValueError` is raised when no matches are found in the CRIPT DB.
 
-    This test function attempts to get a material from CRIPT DB with a unique name that cannot
-    possibly exist in the DB. The function expects a ValueError to be raised.
+    This test aims to validate two aspects:
+    1. When using cript.API.search with a non-existent material name, the function should return a Paginator
+     object with zero results.
+    1. Then, when using cript.API.get_node_by_exact_match with the same non-existent name,
+    the function should raise a `ValueError` letting the user know that this material does not exist.
 
-    Also, tests cript.API.search to be sure that API really returned no results and
-    correctly throws `ValueError` when no result is given by the API
+    It does so by attempting to search for a material with a name that's guaranteed to be unique
+    and cannot exist in the CRIPT DB. The name includes the current date-time to ensure uniqueness.
     """
     nonexistent_material_name = f"a unique material name that cannot exist in CRIPT DB with unique time: {str(datetime.datetime.now())}"
 

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -441,11 +441,20 @@ def test_api_get_node_by_invalid_search_mode(cript_api: cript.API) -> None:
 
     This test function attempts to get a material from CRIPT DB with a unique name that cannot
     possibly exist in the DB. The function expects a ValueError to be raised.
+
+    Also, tests cript.API.search to be sure that it correctly throws `ValueError` when no result is given by the API
     """
+    nonexistent_material_name = f"a unique material name that cannot exist in CRIPT DB with unique time: {str(datetime.datetime.now())}"
+
+    exact_name_paginator = cript_api.search(node_type=cript.Material, search_mode=cript.SearchModes.EXACT_NAME, value_to_search=nonexistent_material_name)
+
+    # check that API returned 0 results for the `nonexistent_material_name`
+    assert isinstance(exact_name_paginator, Paginator)
+    assert len(exact_name_paginator.current_page_results) == 0
+
+    # check that `get_node_by_exact_match` raises a `ValueError` since the API returned 0 results
     with pytest.raises(ValueError):
-        cript_api.get_node_by_exact_match(
-            node_type=cript.Material, search_mode=cript.ExactSearchModes.EXACT_NAME, value_to_search=f"a unique material name that does not exist in CRIPT DB with unique time: {str(datetime.datetime.now())}"  # This should raise a ValueError
-        )
+        cript_api.get_node_by_exact_match(node_type=cript.Material, search_mode=cript.ExactSearchModes.EXACT_NAME, value_to_search=nonexistent_material_name)
 
 
 def test_get_my_user_node_from_api(cript_api: cript.API) -> None:

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -428,7 +428,7 @@ def test_api_get_node_by_exact_match_uuid(cript_api: cript.API, dynamic_material
 
 
 @pytest.mark.skipif(not HAS_INTEGRATION_TESTS_ENABLED, reason="requires a real cript_api_token")
-def test_api_get_node_by_bigsmiles(cript_api: cript.API, dynamic_material_data) -> None:
+def test_api_get_node_by_exact_match_bigsmiles(cript_api: cript.API, dynamic_material_data) -> None:
     """
     Tests get_node_by_exact_match with BIGSMILES search mode.
     Searches for material "{[][<]C(C)C(=O)O[>][<]}{[$][$]CCC(C)C[$],[$]CC(C(C)C)[$],[$]CC(C)(CC)[$][]}".

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -435,14 +435,15 @@ def test_api_get_node_by_exact_match_bigsmiles(cript_api: cript.API, dynamic_mat
 
 
 @pytest.mark.skipif(not HAS_INTEGRATION_TESTS_ENABLED, reason="requires a real cript_api_token")
-def test_api_get_node_by_invalid_search_mode(cript_api: cript.API) -> None:
+def test_api_get_node_by_exact_match_invalid_search_value(cript_api: cript.API) -> None:
     """
-    Tests that a ValueError is raised when an invalid search value that does not exist.
+    Tests that a `ValueError` is correctly raised when the API returns no matches for the search.
 
     This test function attempts to get a material from CRIPT DB with a unique name that cannot
     possibly exist in the DB. The function expects a ValueError to be raised.
 
-    Also, tests cript.API.search to be sure that it correctly throws `ValueError` when no result is given by the API
+    Also, tests cript.API.search to be sure that API really returned no results and
+    correctly throws `ValueError` when no result is given by the API
     """
     nonexistent_material_name = f"a unique material name that cannot exist in CRIPT DB with unique time: {str(datetime.datetime.now())}"
 

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -399,11 +399,7 @@ def test_api_get_node_by_exact_match_exact_name(cript_api: cript.API, dynamic_ma
     Tests get_node_by_exact_match method with exact name search.
     Searches for material "Sodium polystyrene sulfonate".
     """
-    material_node = cript_api.get_node_by_exact_match(
-        node_type=cript.Material,
-        search_mode=cript.ExactSearchModes.EXACT_NAME,
-        value_to_search=dynamic_material_data["name"]
-    )
+    material_node = cript_api.get_node_by_exact_match(node_type=cript.Material, search_mode=cript.ExactSearchModes.EXACT_NAME, value_to_search=dynamic_material_data["name"])
 
     assert isinstance(material_node, cript.Material)
     assert material_node.name == dynamic_material_data["name"]
@@ -416,11 +412,7 @@ def test_api_get_node_by_exact_match_uuid(cript_api: cript.API, dynamic_material
     Tests get_node_by_exact_match with UUID.
     Searches for `Sodium polystyrene sulfonate` material via UUID.
     """
-    material_node = cript_api.get_node_by_exact_match(
-        node_type=cript.Material,
-        search_mode=cript.ExactSearchModes.UUID,
-        value_to_search=dynamic_material_data["uuid"]
-    )
+    material_node = cript_api.get_node_by_exact_match(node_type=cript.Material, search_mode=cript.ExactSearchModes.UUID, value_to_search=dynamic_material_data["uuid"])
 
     assert isinstance(material_node, cript.Material)
     assert material_node.name == dynamic_material_data["name"]
@@ -435,11 +427,7 @@ def test_api_get_node_by_exact_match_bigsmiles(cript_api: cript.API, dynamic_mat
     """
     bigsmiles_search_value = "{[][<]C(C)C(=O)O[>][<]}{[$][$]CCC(C)C[$],[$]CC(C(C)C)[$],[$]CC(C)(CC)[$][]}"
 
-    material_node = cript_api.get_node_by_exact_match(
-        node_type=cript.Material,
-        search_mode=cript.ExactSearchModes.BIGSMILES,
-        value_to_search=bigsmiles_search_value
-    )
+    material_node = cript_api.get_node_by_exact_match(node_type=cript.Material, search_mode=cript.ExactSearchModes.BIGSMILES, value_to_search=bigsmiles_search_value)
 
     assert isinstance(material_node, cript.Material)
     assert material_node.name == dynamic_material_data["name"]

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -393,22 +393,6 @@ def test_api_search_bigsmiles(cript_api: cript.API) -> None:
     # assert bigsmiles_paginator.current_page_results[1]["name"] == "BCDB_Material_285"
 
 
-@pytest.mark.skipif(not HAS_INTEGRATION_TESTS_ENABLED, reason="requires a real cript_api_token")
-def test_api_search_get_node_by_uuid(cript_api: cript.API, dynamic_material_data) -> None:
-    """
-    tests `cript.API.get_node_by_uuid` works as intended
-
-    1. get a node from API by EXACT_NAME
-    1. from the node gotten from the API take out the UUID
-    1. use the UUID to get the desired node
-    """
-    my_material_node: cript.Material = cript_api.get_node_by_uuid(node_type=cript.Material, node_uuid=dynamic_material_data["uuid"])
-
-    assert isinstance(my_material_node, cript.Material)
-    assert my_material_node.name == dynamic_material_data["name"]
-    assert str(my_material_node.uuid) == dynamic_material_data["uuid"]
-
-
 def test_get_my_user_node_from_api(cript_api: cript.API) -> None:
     """
     tests that the Python SDK can successfully get the user node associated with the API Token

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -434,6 +434,20 @@ def test_api_get_node_by_exact_match_bigsmiles(cript_api: cript.API, dynamic_mat
     assert material_node.uuid == dynamic_material_data["uuid"]
 
 
+@pytest.mark.skipif(not HAS_INTEGRATION_TESTS_ENABLED, reason="requires a real cript_api_token")
+def test_api_get_node_by_invalid_search_mode(cript_api: cript.API) -> None:
+    """
+    Tests that a ValueError is raised when an invalid search value that does not exist.
+
+    This test function attempts to get a material from CRIPT DB with a unique name that cannot
+    possibly exist in the DB. The function expects a ValueError to be raised.
+    """
+    with pytest.raises(ValueError):
+        cript_api.get_node_by_exact_match(
+            node_type=cript.Material, search_mode=cript.ExactSearchModes.EXACT_NAME, value_to_search=f"a unique material name that does not exist in CRIPT DB with unique time: {str(datetime.datetime.now())}"  # This should raise a ValueError
+        )
+
+
 def test_get_my_user_node_from_api(cript_api: cript.API) -> None:
     """
     tests that the Python SDK can successfully get the user node associated with the API Token

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -393,6 +393,59 @@ def test_api_search_bigsmiles(cript_api: cript.API) -> None:
     # assert bigsmiles_paginator.current_page_results[1]["name"] == "BCDB_Material_285"
 
 
+@pytest.mark.skipif(not HAS_INTEGRATION_TESTS_ENABLED, reason="requires a real cript_api_token")
+def test_api_get_node_by_exact_match_exact_name(cript_api: cript.API, dynamic_material_data) -> None:
+    """
+    Tests get_node_by_exact_match method with exact name search.
+    Searches for material "Sodium polystyrene sulfonate".
+    """
+    material_node = cript_api.get_node_by_exact_match(
+        node_type=cript.Material,
+        search_mode=cript.ExactSearchModes.EXACT_NAME,
+        value_to_search=dynamic_material_data["name"]
+    )
+
+    assert isinstance(material_node, cript.Material)
+    assert material_node.name == dynamic_material_data["name"]
+    assert material_node.uuid == dynamic_material_data["uuid"]
+
+
+@pytest.mark.skipif(not HAS_INTEGRATION_TESTS_ENABLED, reason="requires a real cript_api_token")
+def test_api_get_node_by_exact_match_uuid(cript_api: cript.API, dynamic_material_data) -> None:
+    """
+    Tests get_node_by_exact_match with UUID.
+    Searches for `Sodium polystyrene sulfonate` material via UUID.
+    """
+    material_node = cript_api.get_node_by_exact_match(
+        node_type=cript.Material,
+        search_mode=cript.ExactSearchModes.UUID,
+        value_to_search=dynamic_material_data["uuid"]
+    )
+
+    assert isinstance(material_node, cript.Material)
+    assert material_node.name == dynamic_material_data["name"]
+    assert material_node.uuid == dynamic_material_data["uuid"]
+
+
+@pytest.mark.skipif(not HAS_INTEGRATION_TESTS_ENABLED, reason="requires a real cript_api_token")
+def test_api_get_node_by_bigsmiles(cript_api: cript.API, dynamic_material_data) -> None:
+    """
+    Tests get_node_by_exact_match with BIGSMILES search mode.
+    Searches for material "{[][<]C(C)C(=O)O[>][<]}{[$][$]CCC(C)C[$],[$]CC(C(C)C)[$],[$]CC(C)(CC)[$][]}".
+    """
+    bigsmiles_search_value = "{[][<]C(C)C(=O)O[>][<]}{[$][$]CCC(C)C[$],[$]CC(C(C)C)[$],[$]CC(C)(CC)[$][]}"
+
+    material_node = cript_api.get_node_by_exact_match(
+        node_type=cript.Material,
+        search_mode=cript.ExactSearchModes.BIGSMILES,
+        value_to_search=bigsmiles_search_value
+    )
+
+    assert isinstance(material_node, cript.Material)
+    assert material_node.name == dynamic_material_data["name"]
+    assert material_node.uuid == dynamic_material_data["uuid"]
+
+
 def test_get_my_user_node_from_api(cript_api: cript.API) -> None:
     """
     tests that the Python SDK can successfully get the user node associated with the API Token


### PR DESCRIPTION
# Description

wrote `API.get_node_by_exact_match()` for users to easily grab a single node.

## Changes
## Removed Old
* removed `get_node_by_uuid()` method
* removed `get_node_by_uuid()` test

## Added New
### api.get_node_by_exact_match()
* created `api.get_node_by_exact_match()`
* wrote documentation for `api.get_node_by_exact_match()`
* wrote code example documentation with doctest for `api.get_node_by_exact_match()`
* wrote tests for api.get_node_by_exact_match() but none of them are passing
  * `test_api_get_node_by_exact_match_exact_name()`
  * `test_api_get_node_by_exact_match_uuid()`
  * `test_api_get_node_by_bigsmiles()`
  * wrote `test_api_get_node_by_exact_match_invalid_search_value()` to test that it correctly throws a `ValueError` when it doesn't match anything in DB


### `ExactSearchModes` enums
* added `ExactSearchModes` enums
* wrote documentation to ExactSearchModes enum
  * added code examples with doctest and relevant links to API method
* putt `ExactSearchModes` in cript root like `cript.ExactSearchModes`

### Documentation
* modified search_modes.md file to contain all valid_search_modes.py classes in it

### Screenshots
#### New Search modes
![image](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/da3e35c5-ac84-4403-a832-e5e771d2caec)

#### New `API.get_node_by_uuid()` method feature
![API get_node_by_uuid() cropped docs](https://github.com/C-Accel-CRIPT/Python-SDK/assets/26590757/08b35fc0-4dc2-49cb-b62b-cdef23a91595)

## Checklist

- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
