### PR TITLE
removed `get_node_by_uuid` cript.API feature

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -1143,44 +1143,6 @@ class API:
 
         return Paginator(http_headers=self._http_headers, api_endpoint=api_endpoint, query=value_to_search, current_page_number=page_number)
 
-    @beartype
-    def get_node_by_uuid(self, node_type: Any, node_uuid: str) -> Any:
-        """
-        Gets a node from API by its UUID and returns the requested node represented as a Python object.
-
-        Examples
-        ---------
-        >>> import cript
-        >>> from pathlib import Path
-        >>> my_material_node: cript.Material = api.get_node_by_uuid(
-        ...     node_type=cript.Material, node_uuid="e1b41d34-3bf2-4cd8-9a19-6412df7e7efc"
-        ... ) # doctest: +SKIP
-
-        Parameters
-        ----------
-        node_type: Any
-            The class representation of the type of node you're targeting, such as `cript.Material`.
-            This could be a representation of a `primary node`, `supporting node`, or `sub-object`.
-        node_uuid: str:
-            UUID of the target primary node, supporting node, or sub-object to retrieve from the API.
-
-        Returns
-        -------
-        UUIDBaseNode
-            The requested node represented as a Python object.
-        """
-
-        # get project node from API
-        my_paginator = self.search(node_type=node_type, search_mode=cript.SearchModes.UUID, value_to_search=node_uuid)
-
-        # get the project from paginator
-        my_node_from_api_dict = my_paginator.current_page_results[0]
-
-        # convert API JSON to CRIPT Project node
-        my_node_from_api = cript.load_nodes_from_json(json.dumps(my_node_from_api_dict))
-
-        return my_node_from_api
-
     def delete(self, node) -> None:
         """
         Simply deletes the desired node from the CRIPT API and writes a log in the terminal that the node has been

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -393,22 +393,6 @@ def test_api_search_bigsmiles(cript_api: cript.API) -> None:
     # assert bigsmiles_paginator.current_page_results[1]["name"] == "BCDB_Material_285"
 
 
-@pytest.mark.skipif(not HAS_INTEGRATION_TESTS_ENABLED, reason="requires a real cript_api_token")
-def test_api_search_get_node_by_uuid(cript_api: cript.API, dynamic_material_data) -> None:
-    """
-    tests `cript.API.get_node_by_uuid` works as intended
-
-    1. get a node from API by EXACT_NAME
-    1. from the node gotten from the API take out the UUID
-    1. use the UUID to get the desired node
-    """
-    my_material_node: cript.Material = cript_api.get_node_by_uuid(node_type=cript.Material, node_uuid=dynamic_material_data["uuid"])
-
-    assert isinstance(my_material_node, cript.Material)
-    assert my_material_node.name == dynamic_material_data["name"]
-    assert str(my_material_node.uuid) == dynamic_material_data["uuid"]
-
-
 def test_get_my_user_node_from_api(cript_api: cript.API) -> None:
     """
     tests that the Python SDK can successfully get the user node associated with the API Token


### PR DESCRIPTION
# Description
removed `get_node_by_uuid` cript.API feature. This method will be removed in later versions in favor of the single search `cript.API.get_node_by_exact_match()`

I thought it'd be a better idea to remove it from the SDK and not release it in this version because if users use it, and we remove it in the next version it will introduce a breaking change that will break their script and it will be a hassle, better to not introduce at all this version and work on it in the next version.

## Changes

## Tests

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
