### PR TITLE
Skip validation

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -615,7 +615,7 @@ class API:
             return self._db_schema
 
     @beartype
-    def _is_node_schema_valid(self, node_json: str, is_patch: bool = False, force_validation: bool = False) -> bool:
+    def _is_node_schema_valid(self, node_json: str, is_patch: bool = False, force_validation: bool = False) -> Union[bool, None]:
         """
         checks a node JSON schema against the db schema to return if it is valid or not.
 
@@ -651,7 +651,7 @@ class API:
 
         # Fast exit without validation
         if self.skip_validation and not force_validation:
-            return True
+            return None
 
         db_schema = self._get_db_schema()
 

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -81,6 +81,12 @@ class API:
     _internal_s3_client: Any = None  # type: ignore
     # trunk-ignore-end(cspell)
 
+    # Advanced User Tip: Disabling Node Validation
+    # For experienced users, deactivating node validation during creation can be a time-saver.
+    # Note that the complete node graph will still undergo validation before being saved to the back end.
+    # Caution: It's advisable to keep validation active while debugging scripts, as disabling it can delay error notifications and complicate the debugging process.
+    skip_validation: bool = False
+
     @beartype
     def __init__(self, host: Union[str, None] = None, api_token: Union[str, None] = None, storage_token: Union[str, None] = None, config_file_path: Union[str, Path] = ""):
         """
@@ -609,7 +615,7 @@ class API:
             return self._db_schema
 
     @beartype
-    def _is_node_schema_valid(self, node_json: str, is_patch: bool = False) -> bool:
+    def _is_node_schema_valid(self, node_json: str, is_patch: bool = False, force_validation: bool = False) -> bool:
         """
         checks a node JSON schema against the db schema to return if it is valid or not.
 
@@ -643,6 +649,10 @@ class API:
             whether the node JSON is valid or not
         """
 
+        # Fast exit without validation
+        if self.skip_validation and not force_validation:
+            return True
+
         db_schema = self._get_db_schema()
 
         node_type: str = _get_node_type_from_json(node_json=node_json)
@@ -651,7 +661,13 @@ class API:
 
         # logging out info to the terminal for the user feedback
         # (improve UX because the program is currently slow)
-        self.logger.info(f"Validating {node_type} graph...")
+        log_message = f"Validating {node_type} graph..."
+        if force_validation:
+            log_message = "Forced: " + log_message + " if error occur, try setting `cript.API.skip_validation = False` for debugging."
+        else:
+            log_message += " (Can be disabled by setting `cript.API.skip_validation = True`.)"
+
+        self.logger.info(log_message)
 
         # set the schema to test against http POST or PATCH of DB Schema
         schema_http_method: str

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -737,7 +737,7 @@ class API:
         for file_node in node.find_children({"node": ["File"]}):
             file_node.ensure_uploaded(api=self)
 
-        node.validate()
+        node.validate(force_validation=True)
 
         # Dummy response to have a virtual do-while loop, instead of while loop.
         response = {"code": -1}

--- a/src/cript/nodes/core.py
+++ b/src/cript/nodes/core.py
@@ -142,7 +142,7 @@ class BaseNode(ABC):
             self._json_attrs = old_json_attrs
             raise exc
 
-    def validate(self, api=None, is_patch=False) -> None:
+    def validate(self, api=None, is_patch: bool = False, force_validation: bool = False) -> None:
         """
         Validate this node (and all its children) against the schema provided by the data bank.
 
@@ -154,7 +154,7 @@ class BaseNode(ABC):
 
         if api is None:
             api = _get_global_cached_api()
-        api._is_node_schema_valid(self.get_json(is_patch=is_patch).json, is_patch=is_patch)
+        api._is_node_schema_valid(self.get_json(is_patch=is_patch).json, is_patch=is_patch, force_validation=force_validation)
 
     @classmethod
     def _from_json(cls, json_dict: dict):
@@ -239,8 +239,14 @@ class BaseNode(ABC):
         """
         # We cannot validate in `get_json` because we call it inside `validate`.
         # But most uses are probably the property, so we can validate the node here.
-        self.validate()
-        return self.get_json().json
+        json_string: str = self.get_json().json
+
+        from cript.api.api import _get_global_cached_api
+
+        api = _get_global_cached_api()
+        api._is_node_schema_valid(json_string, force_validation=True)
+
+        return json_string
 
     def get_json(
         self,

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -168,15 +168,16 @@ def test_is_node_schema_valid_skipped(cript_api: cript.API) -> None:
 
     """
 
-    cript_api.skip_validation = True
-    # ------ invalid node schema------
-    invalid_schema = {"invalid key": "invalid value", "node": ["Material"]}
+    with cript.API(host=cript_api.host, api_token=cript_api._api_token, storage_token=cript_api._storage_token) as local_cript_api:
+        local_cript_api.skip_validation = True
+        # ------ invalid node schema------
+        invalid_schema = {"invalid key": "invalid value", "node": ["Material"]}
 
-    # Test should be skipped
-    assert cript_api._is_node_schema_valid(node_json=json.dumps(invalid_schema), is_patch=False) is True
+        # Test should be skipped
+        assert local_cript_api._is_node_schema_valid(node_json=json.dumps(invalid_schema), is_patch=False) is True
 
-    with pytest.raises(CRIPTNodeSchemaError):
-        cript_api._is_node_schema_valid(node_json=json.dumps(invalid_schema), is_patch=False, force_validation=True)
+        with pytest.raises(CRIPTNodeSchemaError):
+            local_cript_api._is_node_schema_valid(node_json=json.dumps(invalid_schema), is_patch=False, force_validation=True)
 
 
 def test_get_vocabulary_by_category(cript_api: cript.API) -> None:

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -183,7 +183,7 @@ def test_is_node_schema_valid_skipped(cript_api: cript.API) -> None:
         invalid_schema = {"invalid key": "invalid value", "node": ["Material"]}
 
         # Test should be skipped
-        assert local_cript_api._is_node_schema_valid(node_json=json.dumps(invalid_schema), is_patch=False) is True
+        assert local_cript_api._is_node_schema_valid(node_json=json.dumps(invalid_schema), is_patch=False) is None
 
         with pytest.raises(CRIPTNodeSchemaError):
             local_cript_api._is_node_schema_valid(node_json=json.dumps(invalid_schema), is_patch=False, force_validation=True)

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -168,7 +168,16 @@ def test_is_node_schema_valid_skipped(cript_api: cript.API) -> None:
 
     """
 
-    with cript.API(host=cript_api.host, api_token=cript_api._api_token, storage_token=cript_api._storage_token) as local_cript_api:
+    def extract_base_url(url):
+        # Split the URL by "//" first to separate the scheme (like http, https)
+        parts = url.split("//", 1)
+        scheme, rest = parts if len(parts) > 1 else ("", parts[0])
+
+        # Split the rest by the first "/" to separate the domain
+        domain = rest.split("/", 1)[0]
+        return f"{scheme}//{domain}" if scheme else domain
+
+    with cript.API(host=extract_base_url(cript_api.host), api_token=cript_api._api_token, storage_token=cript_api._storage_token) as local_cript_api:
         local_cript_api.skip_validation = True
         # ------ invalid node schema------
         invalid_schema = {"invalid key": "invalid value", "node": ["Material"]}

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -155,6 +155,30 @@ def test_is_node_schema_valid(cript_api: cript.API) -> None:
     assert cript_api._is_node_schema_valid(node_json=json.dumps(valid_file_dict), is_patch=False) is True
 
 
+def test_is_node_schema_valid_skipped(cript_api: cript.API) -> None:
+    """
+    test that a CRIPT node can be correctly validated and invalidated with the db schema, when skipping tests is active
+
+    * test db schema validation with an invalid node, and it should be invalid, but only detected if forced
+
+    Notes
+    -----
+    * does not test if serialization/deserialization works correctly,
+    just tests if the node schema can work correctly if serialization was correct
+
+    """
+
+    cript_api.skip_validation = True
+    # ------ invalid node schema------
+    invalid_schema = {"invalid key": "invalid value", "node": ["Material"]}
+
+    # Test should be skipped
+    assert cript_api._is_node_schema_valid(node_json=json.dumps(invalid_schema), is_patch=False) is True
+
+    with pytest.raises(CRIPTNodeSchemaError):
+        cript_api._is_node_schema_valid(node_json=json.dumps(invalid_schema), is_patch=False, force_validation=True)
+
+
 def test_get_vocabulary_by_category(cript_api: cript.API) -> None:
     """
     tests if a vocabulary can be retrieved by category


### PR DESCRIPTION
# Description
As discussed with @bearmit 
A flag that disables partially the tests is being implemented.

At the moment we do not disable tests by default.

There is a text output that let's users know that they can disable the validation if needed.
Some checks are forced even as tests are disabled.
 - upon `save`
 - and upon `node.json`

## Changes

I changed the logging  text to let users know that they can disable the validation.
And marked forced checks as such, letting the user know that they can't be disabled and that if they have issues, they should enable the tests.

## Tests
I added a test that checks, that a wrong node is accepted if tests are disabled, but detected if forced.

## Known Issues
None.
## Notes

If we decide to disable tests by default, we just have to change the default value for `cript.API.skip_validation` to `True`.

## Checklist

- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
