### PR TITLE
Self-Contained JSON file format

### DIFF
--- a/.trunk/configs/.cspell.json
+++ b/.trunk/configs/.cspell.json
@@ -120,6 +120,7 @@
     "BCDB",
     "doctest",
     "Doctest",
-    "Doctests"
+    "Doctests",
+    "linenums"
   ]
 }

--- a/src/cript/nodes/core.py
+++ b/src/cript/nodes/core.py
@@ -242,6 +242,17 @@ class BaseNode(ABC):
         self.validate()
         return self.get_json().json
 
+    def get_self_contained_json(self):
+        """
+        This generates a JSON representation of the current node at root that is self-contained.
+        Self-contained means in this context that we do not have references via UUID to external node (i.e. present only the CRIPT back end).
+        Such a self-contained JSON can be helpful to temporarily store CRIPT nodes in a file to be uploaded to CRIPT at a later time.
+        A self-contained JSON is also guaranteed to be loadable via `cript.load_nodes_from_json()` into the SDK.
+
+        A self-contained JSON may not be directly compatible with the JSON schema requirements for POST or PATCH uploads.
+        """
+        return self.get_json(handled_ids=None, known_uuid=None, suppress_attributes=None, is_patch=False, condense_to_uuid={}).json
+
     def get_json(
         self,
         handled_ids: Optional[Set[str]] = None,

--- a/src/cript/nodes/core.py
+++ b/src/cript/nodes/core.py
@@ -299,7 +299,7 @@ class BaseNode(ABC):
         >>> my_project.collection = [my_collection]
         >>> my_project.collection[0].inventory = [my_inventory]
         >>> #  ============= Get long form JSON =============
-        >>> long_form_json = my_project.get_expanded_json()(indent=4)
+        >>> long_form_json = my_project.get_expanded_json(indent=4)
 
         ???+ info "Short JSON VS Long JSON"
             # Default Short JSON

--- a/src/cript/nodes/core.py
+++ b/src/cript/nodes/core.py
@@ -242,7 +242,7 @@ class BaseNode(ABC):
         self.validate()
         return self.get_json().json
 
-    def get_self_contained_json(self):
+    def get_self_contained_json(self, **kwargs):
         """
         This generates a JSON representation of the current node at root that is self-contained.
         Self-contained means in this context that we do not have references via UUID to external node (i.e. present only the CRIPT back end).
@@ -250,8 +250,9 @@ class BaseNode(ABC):
         A self-contained JSON is also guaranteed to be loadable via `cript.load_nodes_from_json()` into the SDK.
 
         A self-contained JSON may not be directly compatible with the JSON schema requirements for POST or PATCH uploads.
+        Similar to `get_json` we also accept kwargs, that are passed on to the JSON decoding via `json.dumps()`  this can be used for example to prettify the output.
         """
-        return self.get_json(handled_ids=None, known_uuid=None, suppress_attributes=None, is_patch=False, condense_to_uuid={}).json
+        return self.get_json(handled_ids=None, known_uuid=None, suppress_attributes=None, is_patch=False, condense_to_uuid={}, **kwargs).json
 
     def get_json(
         self,
@@ -277,6 +278,8 @@ class BaseNode(ABC):
         User facing access to get the JSON of a node.
         Opposed to the also available property json this functions allows further control.
         Additionally, this function does not call `self.validate()` but the property `json` does.
+        We also accept `kwargs`, that are passed on to the JSON decoding via `json.dumps()` this can be used for example to prettify the output.
+
 
         Returns named tuple with json and handled ids as result.
         """

--- a/tests/test_node_util.py
+++ b/tests/test_node_util.py
@@ -325,12 +325,23 @@ def test_invalid_project_graphs(simple_project_node, simple_material_node, simpl
     project.validate()
 
 
-def test_self_contained_json(complex_project_node):
-    json_string: str = complex_project_node.get_self_contained_json()
+def test_expanded_json(complex_project_node):
+    """
+    Tests the generation and deserialization of expanded JSON for a complex project node.
 
-    loaded_json = cript.load_nodes_from_json(json_string)
-    assert loaded_json == complex_project_node
+    This test verifies 2 key aspects:
+        1. A complex project node can be serialized into an expanded JSON string, without UUID placeholders.
+        2. The expanded JSON can be deserialized into a node  that is equivalent to the original node.
+    """
+    expanded_project_json: str = complex_project_node.get_expanded_json()
+    deserialized_project_node: cript.Project = cript.load_nodes_from_json(expanded_project_json)
+
+    # assert the expanded JSON was correctly deserialized to project node
+    assert deserialized_project_node == complex_project_node
 
     short_json: str = complex_project_node.json
+
+    # since short JSON has UUID it will not be able to deserialize correctly and will
+    # raise CRIPTJsonDeserializationError
     with pytest.raises(cript.nodes.exceptions.CRIPTJsonDeserializationError):
         cript.load_nodes_from_json(short_json)

--- a/tests/test_node_util.py
+++ b/tests/test_node_util.py
@@ -323,3 +323,14 @@ def test_invalid_project_graphs(simple_project_node, simple_material_node, simpl
 
     cript.add_orphaned_nodes_to_project(project, project.collection[0].experiment[0], 10)
     project.validate()
+
+
+def test_self_contained_json(complex_project_node):
+    json_string: str = complex_project_node.get_self_contained_json()
+
+    loaded_json = cript.load_nodes_from_json(json_string)
+    assert loaded_json == complex_project_node
+
+    short_json: str = complex_project_node.json
+    with pytest.raises(cript.nodes.exceptions.CRIPTJsonDeserializationError):
+        cript.load_nodes_from_json(short_json)


### PR DESCRIPTION
# Description

The SDK can produce fully self-contained JSON string for node graphs.
Such a node graph does not contain any UUID reference (self-contained) and can be super helpful for users if they want to store their work in a JSON file  before uploading it to CRIPT.

@bearmit expressed that he would like this feature.

## Changes

Also added a hint about using `kwargs` to beautify JSON strings into the documentation.

## Tests

A test is included to ensures that self-containing JSON can be parsed by `cript.load_nodes_from_json`.

## Known Issues

## Notes

## Checklist

- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
