### PR TITLE
DO NOT MERGE disable UID generation

### DIFF
--- a/src/cript/nodes/core.py
+++ b/src/cript/nodes/core.py
@@ -424,6 +424,7 @@ class BaseNode(ABC):
             "Project": {"member", "admin"},
             "Collection": {"member", "admin"},
         },
+        suppress_uid_usage: bool = False,
         **kwargs
     ):
         """
@@ -461,6 +462,8 @@ class BaseNode(ABC):
         NodeEncoder.suppress_attributes = suppress_attributes
         previous_condense_to_uuid = copy.deepcopy(NodeEncoder.condense_to_uuid)
         NodeEncoder.condense_to_uuid = condense_to_uuid
+        previous_suppress_uid_usage = copy.deepcopy(NodeEncoder.suppress_uid_usage)
+        NodeEncoder.suppress_uid_usage = suppress_uid_usage
 
         try:
             return ReturnTuple(json.dumps(self, cls=NodeEncoder, **kwargs), NodeEncoder.handled_ids)
@@ -474,6 +477,7 @@ class BaseNode(ABC):
             NodeEncoder.known_uuid = previous_known_uuid
             NodeEncoder.suppress_attributes = previous_suppress_attributes
             NodeEncoder.condense_to_uuid = previous_condense_to_uuid
+            NodeEncoder.suppress_uid_usage = previous_suppress_uid_usage
 
     def find_children(self, search_attr: dict, search_depth: int = -1, handled_nodes: Optional[List] = None) -> List:
         """

--- a/src/cript/nodes/util/__init__.py
+++ b/src/cript/nodes/util/__init__.py
@@ -103,8 +103,9 @@ class NodeEncoder(json.JSONEncoder):
             except AttributeError:
                 pass
             else:
-                if uid in NodeEncoder.handled_ids:
-                    return {"uid": uid}
+                pass
+                # if uid in NodeEncoder.handled_ids:
+                #     return {"uid": uid}
 
             # When saving graphs, some nodes can be pre-saved.
             # If that happens, we want to represent them as a UUID edge only

--- a/src/cript/nodes/util/__init__.py
+++ b/src/cript/nodes/util/__init__.py
@@ -38,6 +38,8 @@ class NodeEncoder(json.JSONEncoder):
         A set to store the node types that should be condensed to UUID edges in the JSON.
     suppress_attributes : Optional[Dict[str, Set[str]]]
         A dictionary that allows suppressing specific attributes for nodes with the corresponding UUIDs.
+    suppress_uid_usage : bool
+        Can suppress the usage of UID abbreviations. Warning, this can lead to infinite recursion with graphs that contain cycles.
 
     Methods
     -------
@@ -58,6 +60,7 @@ class NodeEncoder(json.JSONEncoder):
     known_uuid: Set[str] = set()
     condense_to_uuid: Dict[str, Set[str]] = dict()
     suppress_attributes: Optional[Dict[str, Set[str]]] = None
+    suppress_uid_usage: bool = False
 
     def default(self, obj):
         """
@@ -103,9 +106,8 @@ class NodeEncoder(json.JSONEncoder):
             except AttributeError:
                 pass
             else:
-                pass
-                # if uid in NodeEncoder.handled_ids:
-                #     return {"uid": uid}
+                if not NodeEncoder.suppress_uid_usage and uid in NodeEncoder.handled_ids:
+                    return {"uid": uid}
 
             # When saving graphs, some nodes can be pre-saved.
             # If that happens, we want to represent them as a UUID edge only


### PR DESCRIPTION
# Description

Give an option to disbale the UID use for JSON.

@bearmit 

## Changes

## Known Issues

Disabling the use of UIDs, make JSON generation for graphs that contain cycles crash.
This is not gracefully handled at the moment.

I am not sure it is a good idea to offer users on option that leads to ungracefully handled errors.

It would be nice to offer this option for @bearmit work.
But I am scared to include it, what do you think @Ardi028 ?

## Notes

## Checklist

- [y] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [half] I have updated the documentation to reflect my changes.
- [n] My code changes have been verified by automated tests and pass all relevant test scenarios.
