### PR TITLE
Capsule requests

### DIFF
--- a/.github/workflows/docs_check.yaml
+++ b/.github/workflows/docs_check.yaml
@@ -15,6 +15,13 @@ on:
       - main
       - develop
       - "*"
+concurrency:
+  # github.workflow: name of the workflow
+  # github.event.pull_request.number || github.ref: pull request number or branch name if not a pull request
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+  # Cancel in-progress runs when a new workflow with the same group name is triggered
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/doctest.yaml
+++ b/.github/workflows/doctest.yaml
@@ -14,6 +14,14 @@ on:
       - main
       - develop
 
+concurrency:
+  # github.workflow: name of the workflow
+  # github.event.pull_request.number || github.ref: pull request number or branch name if not a pull request
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+  # Cancel in-progress runs when a new workflow with the same group name is triggered
+  cancel-in-progress: true
+
 jobs:
   doctest:
     strategy:

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -14,6 +14,14 @@ on:
       - main
       - develop
 
+concurrency:
+  # github.workflow: name of the workflow
+  # github.event.pull_request.number || github.ref: pull request number or branch name if not a pull request
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+  # Cancel in-progress runs when a new workflow with the same group name is triggered
+  cancel-in-progress: true
+
 jobs:
   mypy-test:
     strategy:

--- a/.github/workflows/test_coverage.yaml
+++ b/.github/workflows/test_coverage.yaml
@@ -15,6 +15,14 @@ on:
       - main
       - develop
 
+concurrency:
+  # github.workflow: name of the workflow
+  # github.event.pull_request.number || github.ref: pull request number or branch name if not a pull request
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+  # Cancel in-progress runs when a new workflow with the same group name is triggered
+  cancel-in-progress: true
+
 jobs:
   test-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -12,6 +12,14 @@ on:
       - main
       - develop
 
+concurrency:
+  # github.workflow: name of the workflow
+  # github.event.pull_request.number || github.ref: pull request number or branch name if not a pull request
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+  # Cancel in-progress runs when a new workflow with the same group name is triggered
+  cancel-in-progress: true
+
 jobs:
   test-examples:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,14 @@ on:
       - develop
       - "*"
 
+concurrency:
+  # github.workflow: name of the workflow
+  # github.event.pull_request.number || github.ref: pull request number or branch name if not a pull request
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+  # Cancel in-progress runs when a new workflow with the same group name is triggered
+  cancel-in-progress: true
+
 jobs:
   install:
     runs-on: ${{ matrix.os }}

--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,7 @@ and keeping all nodes in one file makes it easier/cleaner to create tests.
 
 The fixtures are all functional fixtures that stay consistent between all tests.
 """
+import logging
 import os
 
 import pytest
@@ -57,6 +58,8 @@ def cript_api():
         api._BUCKET_NAME = "cript-stage-user-data"
         # using the tests folder name within our cloud storage
         api._BUCKET_DIRECTORY_NAME = "tests"
+        api.extra_api_log_debug_info = True
+        api.logger.setLevel(logging.DEBUG)
 
         yield api
 

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -232,7 +232,7 @@ class API:
         ...     storage_token=os.getenv("CRIPT_STORAGE_TOKEN")
         ... ) as api:
         ...     print(api)
-        CRIPT API Client - Host URL: 'https://api.criptapp.org/'
+        CRIPT API Client - Host URL: 'https://api.criptapp.org'
 
         Returns
         -------
@@ -367,7 +367,7 @@ class API:
         ...     storage_token=os.getenv("CRIPT_STORAGE_TOKEN")
         ... ) as api:
         ...    print(api.host)
-        https://api.criptapp.org/
+        https://api.criptapp.org
         """
         return self._host
 

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -232,7 +232,7 @@ class API:
         ...     storage_token=os.getenv("CRIPT_STORAGE_TOKEN")
         ... ) as api:
         ...     print(api)
-        CRIPT API Client - Host URL: 'https://api.criptapp.org/api/v1'
+        CRIPT API Client - Host URL: 'https://api.criptapp.org/'
 
         Returns
         -------

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import uuid
-import warnings
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
@@ -17,9 +16,7 @@ from cript.api.exceptions import (
     APIError,
     CRIPTAPIRequiredError,
     CRIPTAPISaveError,
-    CRIPTConnectionError,
     CRIPTDuplicateNameError,
-    InvalidHostError,
 )
 from cript.api.paginator import Paginator
 from cript.api.utils.aws_s3_utils import get_s3_client
@@ -208,7 +205,7 @@ class API:
             api_token = authentication_dict["api_token"]
             storage_token = authentication_dict["storage_token"]
 
-        self._host = self._prepare_host(host=host)  # type: ignore
+        self._host: str = host.rstrip("/")
         self._api_token = api_token  # type: ignore
         self._storage_token = storage_token  # type: ignore
 
@@ -220,7 +217,7 @@ class API:
 
         # set a logger instance to use for the class logs
         self._init_logger(default_log_level)
-        self._db_schema = DataSchema(self.host, self.logger)
+        self._db_schema = DataSchema(self)
 
     def __str__(self) -> str:
         """
@@ -282,46 +279,6 @@ class API:
     @property
     def logger(self):
         return self._logger
-
-    @beartype
-    def _prepare_host(self, host: str) -> str:
-        """
-        Takes the host URL provided by the user during API object construction (e.g., `https://api.criptapp.org`)
-        and standardizes it for internal use. Performs any required string manipulation to ensure uniformity.
-
-        Parameters
-        ----------
-        host: str
-            The host URL specified during API initialization, typically in the form `https://api.criptapp.org`.
-
-        Warnings
-        --------
-        If the specified host uses the unsafe "http://" protocol, a warning will be raised to consider using HTTPS.
-
-        Raises
-        ------
-        InvalidHostError
-            If the host string does not start with either "http" or "https", an InvalidHostError will be raised.
-            Only HTTP protocol is acceptable at this time.
-
-        Returns
-        -------
-        str
-            A standardized host string formatted for internal use.
-
-        """
-        # strip ending slash to make host always uniform
-        host = host.rstrip("/")
-        host = f"{host}/{self._api_prefix}/{self._api_version}"
-
-        # if host is using unsafe "http://" then give a warning
-        if host.startswith("http://"):
-            warnings.warn("HTTP is an unsafe protocol please consider using HTTPS.")
-
-        if not host.startswith("http"):
-            raise InvalidHostError()
-
-        return host
 
     # Use a property to ensure delayed init of s3_client
     @property
@@ -414,24 +371,6 @@ class API:
         """
         return self._host
 
-    def _check_initial_host_connection(self) -> None:
-        """
-        tries to create a connection with host and if the host does not respond or is invalid it raises an error
-
-        Raises
-        -------
-        CRIPTConnectionError
-            raised when the host does not give the expected response
-
-        Returns
-        -------
-        None
-        """
-        try:
-            pass
-        except Exception as exc:
-            raise CRIPTConnectionError(self.host, self._api_token) from exc
-
     def save(self, project: Project) -> None:
         """
         This method takes a project node, serializes the class into JSON
@@ -497,7 +436,7 @@ class API:
 
             # This checks if the current node exists on the back end.
             # if it does exist we use `patch` if it doesn't `post`.
-            test_get_response: Dict = requests.get(url=f"{self._host}/{node.node_type_snake_case}/{str(node.uuid)}/", headers=self._http_headers, timeout=_API_TIMEOUT).json()
+            test_get_response: Dict = self._capsule_request(url_path=f"/{node.node_type_snake_case}/{str(node.uuid)}/", method="GET").json()
             patch_request = test_get_response["code"] == 200
 
             # TODO remove once get works properly
@@ -512,13 +451,15 @@ class API:
                 response = {"code": 200}
                 break
 
+            method = "POST"
             if patch_request:
-                response: Dict = requests.patch(url=f"{self._host}/{node.node_type_snake_case}/{str(node.uuid)}/", headers=self._http_headers, data=json_data, timeout=_API_TIMEOUT).json()  # type: ignore
-            else:
-                response: Dict = requests.post(url=f"{self._host}/{node.node_type_snake_case}/", headers=self._http_headers, data=json_data, timeout=_API_TIMEOUT).json()  # type: ignore
-                # if node.node_type != "Project":
-                #     test_success: Dict = requests.get(url=f"{self._host}/{node.node_type_snake_case}/{str(node.uuid)}/", headers=self._http_headers, timeout=_API_TIMEOUT).json()
-                #     print("XYZ", json_data, save_values, response, test_success)
+                method = "PATCH"
+
+            response: Dict = self._capsule_request(url=f"/{node.node_type_snake_case}/{str(node.uuid)}/", method=method, data=json_data).json()  # type: ignore
+
+            # if node.node_type != "Project":
+            #     test_success: Dict = requests.get(url=f"{self._host}/{node.node_type_snake_case}/{str(node.uuid)}/", headers=self._http_headers, timeout=_API_TIMEOUT).json()
+            #     print("XYZ", json_data, save_values, response, test_success)
 
             # print(json_data, patch_request, response, save_values)
             # If we get an error we may be able to fix, we to handle this extra and save the bad node first.
@@ -997,11 +938,59 @@ class API:
         -------
         None
         """
-        delete_node_api_url: str = f"{self._host}/{node_type.lower()}/{node_uuid}/"
 
-        response: Dict = requests.delete(headers=self._http_headers, url=delete_node_api_url, timeout=_API_TIMEOUT).json()
+        response: Dict = self._capsule_request(url_path=f"/{node_type.lower()}/{node_uuid}/", method="DELETE").json()
 
         if response["code"] != 200:
-            raise APIError(api_error=str(response), http_method="DELETE", api_url=delete_node_api_url)
+            raise APIError(api_error=str(response), http_method="DELETE", api_url=f"/{node_type.lower()}/{node_uuid}/")
 
         self.logger.info(f"Deleted '{node_type.title()}' with UUID of '{node_uuid}' from CRIPT API.")
+
+    def _capsule_request(self, url_path: str, method: str, api_request: bool = True, headers: Optional[Dict] = None, timeout: int = _API_TIMEOUT, **kwargs) -> requests.Response:
+        """Helper function that capsules every request call we make against the backend.
+
+        Please *always* use this methods instead of `requests` directly.
+        We can log all request calls this way, which can help debugging immensely.
+
+        Parameters
+        ----------
+        url_path:str
+          URL path that we want to request from. So every thing that follows api.host. You can omit the api prefix and api version if you use api_request=True they are automatically added.
+
+        method: str
+          One of `GET`, `OPTIONS`, `HEAD`, `POST`, `PUT, `PATCH`, or `DELETE` as this will directly passed to `requests.request(...)`. See https://docs.python-requests.org/en/latest/api/ for details.
+
+        headers: Dict
+          HTTPS headers to use for the request.
+          If None (default) use the once associated with this API object for authentication.
+
+        timeout:int
+          Time out to be used for the request call.
+
+        kwargs
+          additional keyword arguments that are passed to `request.request`
+        """
+
+        extra_debug_info: bool = True
+
+        if headers is None:
+            headers = self._http_headers
+
+        url: str = self.host
+        if api_request:
+            url += f"/{self._api_prefix}/{self._api_version}"
+        url += url_path
+
+        pre_log_message: str = f"Requesting {method} from {url}"
+        if extra_debug_info:
+            pre_log_message += f"headers {headers} kwargs {kwargs}"
+        pre_log_message += "..."
+        self.logger.debug(pre_log_message)
+
+        response: requests.Response = requests.request(url=url, method=method, headers=headers, timeout=timeout, **kwargs)
+        post_log_message: str = f"Request return with {response.status_code}"
+        if extra_debug_info:
+            post_log_message += f" {response}"
+        self.logger.debug(post_log_message)
+
+        return response

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -367,9 +367,17 @@ class API:
         ...     storage_token=os.getenv("CRIPT_STORAGE_TOKEN")
         ... ) as api:
         ...    print(api.host)
-        https://api.criptapp.org/api/v1
+        https://api.criptapp.org/
         """
         return self._host
+
+    @property
+    def api_prefix(self):
+        return self._api_prefix
+
+    @property
+    def api_version(self):
+        return self._api_version
 
     def save(self, project: Project) -> None:
         """
@@ -978,7 +986,7 @@ class API:
 
         url: str = self.host
         if api_request:
-            url += f"/{self._api_prefix}/{self._api_version}"
+            url += f"/{self.api_prefix}/{self.api_version}"
         url += url_path
 
         pre_log_message: str = f"Requesting {method} from {url}"

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -998,7 +998,7 @@ class API:
         response: requests.Response = requests.request(url=url, method=method, headers=headers, timeout=timeout, **kwargs)
         post_log_message: str = f"Request return with {response.status_code}"
         if self.extra_api_log_debug_info:
-            post_log_message += f" {response.json()}"
+            post_log_message += f" {response.text}"
         self.logger.debug(post_log_message)
 
         return response

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -998,7 +998,7 @@ class API:
         response: requests.Response = requests.request(url=url, method=method, headers=headers, timeout=timeout, **kwargs)
         post_log_message: str = f"Request return with {response.status_code}"
         if self.extra_api_log_debug_info:
-            post_log_message += f" {response.text}"
+            post_log_message += f" {response.raw}"
         self.logger.debug(post_log_message)
 
         return response

--- a/src/cript/api/data_schema.py
+++ b/src/cript/api/data_schema.py
@@ -18,7 +18,6 @@ class DataSchema:
 
     _vocabulary: dict = {}
     _db_schema: dict = {}
-    _api = None
     # Advanced User Tip: Disabling Node Validation
     # For experienced users, deactivating node validation during creation can be a time-saver.
     # Note that the complete node graph will still undergo validation before being saved to the back end.

--- a/src/cript/api/data_schema.py
+++ b/src/cript/api/data_schema.py
@@ -2,10 +2,8 @@ import json
 from typing import Union
 
 import jsonschema
-import requests
 from beartype import beartype
 
-from cript.api.api_config import _API_TIMEOUT
 from cript.api.exceptions import APIError, InvalidVocabulary
 from cript.api.utils.helper_functions import _get_node_type_from_json
 from cript.api.vocabulary_categories import VocabCategories
@@ -20,14 +18,30 @@ class DataSchema:
 
     _vocabulary: dict = {}
     _db_schema: dict = {}
-    _logger = None
+    _api = None
     # Advanced User Tip: Disabling Node Validation
     # For experienced users, deactivating node validation during creation can be a time-saver.
     # Note that the complete node graph will still undergo validation before being saved to the back end.
     # Caution: It's advisable to keep validation active while debugging scripts, as disabling it can delay error notifications and complicate the debugging process.
     skip_validation: bool = False
 
-    def _get_db_schema(self, host: str) -> dict:
+    def __init__(self, api):
+        """
+        Initialize DataSchema class with a full hostname to fetch the node validation schema.
+
+        Examples
+        --------
+        ### Create a stand alone DataSchema instance.
+        >>> import cript
+        >>> with cript.API(host="https://api.criptapp.org/") as api:
+        ...    data_schema = cript.api.DataSchema(api)
+        """
+
+        self._db_schema = self._get_db_schema()
+        self._vocabulary = self._get_vocab()
+        self._api = api
+
+    def _get_db_schema(self) -> dict:
         """
         Sends a GET request to CRIPT to get the database schema and returns it.
         The database schema can be used for validating the JSON request
@@ -45,15 +59,13 @@ class DataSchema:
             return self._db_schema
 
         # fetch db_schema from API
-        if self._logger:
-            self._logger.info(f"Loading node validation schema from {host}/schema/")
+        self._api.logger.info(f"Loading node validation schema from {self._api.host}/schema/")
         # fetch db schema from API
-        response: requests.Response = requests.get(url=f"{host}/schema/", timeout=_API_TIMEOUT)
+        response = self._api._capsule_request(url_path="/schema/", method="GET")
 
         # raise error if not HTTP 200
         response.raise_for_status()
-        if self._logger:
-            self._logger.info(f"Loading node validation schema from {host}/schema/ was successful.")
+        self._api.logger.info(f"Loading node validation schema from {self._api.host}/schema/ was successful.")
 
         # if no error, take the JSON from the API response
         response_dict: dict = response.json()
@@ -62,22 +74,6 @@ class DataSchema:
         db_schema = response_dict["data"]
 
         return db_schema
-
-    def __init__(self, host: str, logger=None):
-        """
-        Initialize DataSchema class with a full hostname to fetch the node validation schema.
-
-        Examples
-        --------
-        ### Create a stand alone DataSchema instance.
-        >>> import cript
-        >>> with cript.API(host="https://api.criptapp.org/") as api:
-        ...    data_schema = cript.api.DataSchema(api.host)
-        """
-
-        self._db_schema = self._get_db_schema(host)
-        self._vocabulary = self._get_vocab(host)
-        self._logger = logger
 
     def _get_vocab(self, host: str) -> dict:
         """
@@ -107,10 +103,10 @@ class DataSchema:
         # loop through all vocabulary categories and make a request to each vocabulary category
         # and put them all inside of self._vocab with the keys being the vocab category name
         for category in VocabCategories:
-            vocabulary_category_url: str = f"{host}/cv/{category.value}/"
+            vocabulary_category_url: str = f"/cv/{category.value}/"
 
             # if vocabulary category is not in cache, then get it from API and cache it
-            response: dict = requests.get(url=vocabulary_category_url, timeout=_API_TIMEOUT).json()
+            response: dict = self._api._capsule_request(url_path=vocabulary_category_url, method="GET").json()
 
             if response["code"] != 200:
                 raise APIError(api_error=str(response), http_method="GET", api_url=vocabulary_category_url)
@@ -247,8 +243,7 @@ class DataSchema:
         else:
             log_message += " (Can be disabled by setting `cript.API.skip_validation = True`.)"
 
-        if self._logger:
-            self._logger.info(log_message)
+        self._api.logger.info(log_message)
 
         # set the schema to test against http POST or PATCH of DB Schema
         schema_http_method: str

--- a/src/cript/api/data_schema.py
+++ b/src/cript/api/data_schema.py
@@ -36,10 +36,9 @@ class DataSchema:
         >>> with cript.API(host="https://api.criptapp.org/") as api:
         ...    data_schema = cript.api.DataSchema(api)
         """
-
+        self._api = api
         self._db_schema = self._get_db_schema()
         self._vocabulary = self._get_vocab()
-        self._api = api
 
     def _get_db_schema(self) -> dict:
         """
@@ -75,7 +74,7 @@ class DataSchema:
 
         return db_schema
 
-    def _get_vocab(self, host: str) -> dict:
+    def _get_vocab(self) -> dict:
         """
         gets the entire CRIPT controlled vocabulary and stores it in _vocabulary
 

--- a/src/cript/nodes/uuid_base.py
+++ b/src/cript/nodes/uuid_base.py
@@ -52,7 +52,7 @@ class UUIDBaseNode(BaseNode, ABC):
         from cript.api.api import _get_global_cached_api
 
         api = _get_global_cached_api()
-        return f"{api.host}/{self.uuid}"
+        return f"{api.host}/{api.api_prefix}/{api.api_version}/{self.uuid}"
 
     def __deepcopy__(self, memo):
         node = super().__deepcopy__(memo)

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -56,7 +56,7 @@ def test_create_api_with_none() -> None:
 
     # assert SDK correctly got env vars to create cript.API with
     # host/api/v1
-    assert api._host == f"{env_var_host}/api/v1"
+    assert api._host == f"{env_var_host}"
     assert api._api_token == os.environ["CRIPT_TOKEN"]
     assert api._storage_token == os.environ["CRIPT_STORAGE_TOKEN"]
 
@@ -80,7 +80,7 @@ def test_config_file() -> None:
 
         api = cript.API(config_file_path=config_file_path)
 
-        assert api._host == config_file_texts["host"] + "/api/v1"
+        assert api._host == config_file_texts["host"]
         assert api._api_token == config_file_texts["api_token"]
 
 

--- a/tests/api/test_db_schema.py
+++ b/tests/api/test_db_schema.py
@@ -127,7 +127,7 @@ def test_get_controlled_vocabulary_from_api(cript_api: cript.API) -> None:
     checks if it can successfully get the controlled vocabulary list from CRIPT API
     """
     number_of_vocab_categories = 26
-    vocab = cript_api.schema._get_vocab(cript_api.host)
+    vocab = cript_api.schema._get_vocab()
 
     # assertions
     # check vocabulary list is not empty


### PR DESCRIPTION
# Description

The idea is to never call `requests.XXX` directly, but to use `cript.API._capsule_request` instead.
This has the advantage that we only make direct calls to the CRIPT API from a single point. And only through the API object.
This ensure we only hit the right host.

But the biggest advantage is, that we can consistently log all calls and responses to the API.
This should help debugging, and make communicating with the API team much easier, since we always have the exact API call, and the response we are working with logged.
No more extra digging to find the repsonse.

## Changes

api.host only returns the basename URL now.
api.api_prefix = "api/" and `api.api_version=v1` are not automatically attached anymore. 

## Known Issues

This is implemented for the paginator or the file uploader yet.
(So those API calls go unlogged.)
I will merge this into #425 and address the paginator there.

The file upload needs a refactor of the design too, and we will address logging there.

## Notes

Happy to receive feedback for this idea.
@duboyal it would be great if we can have the new save work with this too at some point.

## Checklist

- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
- [x] My code changes have been verified by automated tests and pass all relevant test scenarios.
