### PR TITLE
Allow users to handle invalid nodes coming from a search against the API

### DIFF
--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -988,7 +988,7 @@ class API:
         response: requests.Response = requests.request(url=url, method=method, headers=headers, timeout=timeout, **kwargs)
         post_log_message: str = f"Request return with {response.status_code}"
         if self.extra_api_log_debug_info:
-            post_log_message += f" {response.raw}"
+            post_log_message += f" {response.text}"
         self.logger.debug(post_log_message)
 
         return response

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -24,7 +24,22 @@ def test_api_search_node_type(cript_api: cript.API) -> None:
 
     # test search results
     assert isinstance(materials_paginator, Paginator)
-    materials_list = list(materials_paginator)
+    materials_list = []
+    while True:
+        try:
+            try:
+                material_node = next(materials_paginator)
+            except cript.CRIPTException as exc:
+                materials_paginator.auto_load_nodes = False
+                material_json = next(materials_paginator)
+                print(exc, material_json)
+            else:
+                materials_list += [material_node]
+            finally:
+                materials_paginator.auto_load_nodes = True
+        except StopIteration:
+            break
+
     # Assure that we paginated more then one page
     assert materials_paginator._current_page_number > 0
     assert len(materials_list) > 5

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -39,11 +39,14 @@ def test_api_search_node_type(cript_api: cript.API) -> None:
                 materials_paginator.auto_load_nodes = True
         except StopIteration:
             break
+        # We don't need to search for a million pages here.
+        if materials_paginator._number_fetched_pages > 6:
+            break
 
     # Assure that we paginated more then one page
-    assert materials_paginator._current_page_number > 0
+    assert materials_paginator._number_fetched_pages > 0
     assert len(materials_list) > 5
-    first_page_first_result = materials_list[0]["name"]
+    first_page_first_result = materials_list[0].name
     # just checking that the word has a few characters in it
     assert len(first_page_first_result) > 3
 


### PR DESCRIPTION
# Description

Before there was no path to recovery if an API search was returning nodes that were deemed incorrect by the SDK.
Now, there is a way to disable auto node conversion.

I think this should only be last resort to recover for advanced users.
But I included an FAQ to explain it to users.

## Changes

## Known Issues

## Notes

## Checklist

- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
- [x] My code changes have been verified by automated tests and pass all relevant test scenarios.
