### PR TITLE
Fix uid cycle deserialization

### DIFF
--- a/src/cript/nodes/core.py
+++ b/src/cript/nodes/core.py
@@ -468,7 +468,7 @@ class BaseNode(ABC):
             if is_patch:
                 del tmp_dict["uuid"]  # patches do not allow UUID is the parent most node
 
-            return ReturnTuple(json.dumps(tmp_dict), tmp_dict, NodeEncoder.handled_ids)
+            return ReturnTuple(json.dumps(tmp_dict, **kwargs), tmp_dict, NodeEncoder.handled_ids)
         except Exception as exc:
             # TODO this handling that doesn't tell the user what happened and how they can fix it
             #   this just tells the user that something is wrong

--- a/src/cript/nodes/primary_nodes/collection.py
+++ b/src/cript/nodes/primary_nodes/collection.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass, field, replace
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 from beartype import beartype
 
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
 from cript.nodes.supporting_nodes import User
-from cript.nodes.util.json import NodeUID
+from cript.nodes.util.json import UIDProxy
 
 
 class Collection(PrimaryBaseNode):
@@ -57,17 +57,19 @@ class Collection(PrimaryBaseNode):
         """
 
         # TODO add proper typing in future, using Any for now to avoid circular import error
-        member: List[NodeUID[User]] = field(default_factory=list)
-        admin: List[NodeUID[User]] = field(default_factory=list)
-        experiment: List[NodeUID[Any]] = field(default_factory=list)
-        inventory: List[NodeUID[Any]] = field(default_factory=list)
+        member: List[Union[User, UIDProxy]] = field(default_factory=list)
+        admin: List[Union[User, UIDProxy]] = field(default_factory=list)
+        experiment: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        inventory: List[Union[Any, UIDProxy]] = field(default_factory=list)
         doi: str = ""
-        citation: List[NodeUID[Any]] = field(default_factory=list)
+        citation: List[Union[Any, UIDProxy]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
     @beartype
-    def __init__(self, name: str, experiment: Optional[List[NodeUID[Any]]] = None, inventory: Optional[List[NodeUID[Any]]] = None, doi: str = "", citation: Optional[List[NodeUID[Any]]] = None, notes: str = "", **kwargs) -> None:
+    def __init__(
+        self, name: str, experiment: Optional[List[Union[Any, UIDProxy]]] = None, inventory: Optional[List[Union[Any, UIDProxy]]] = None, doi: str = "", citation: Optional[List[Union[Any, UIDProxy]]] = None, notes: str = "", **kwargs
+    ) -> None:
         """
         create a Collection with a name
         add list of experiment, inventory, citation, doi, and notes if available.
@@ -118,12 +120,12 @@ class Collection(PrimaryBaseNode):
 
     @property
     @beartype
-    def member(self) -> List[User]:
+    def member(self) -> List[Union[User, UIDProxy]]:
         return self._json_attrs.member.copy()
 
     @property
     @beartype
-    def admin(self) -> List[User]:
+    def admin(self) -> List[Union[User, UIDProxy]]:
         return self._json_attrs.admin
 
     @property

--- a/src/cript/nodes/primary_nodes/collection.py
+++ b/src/cript/nodes/primary_nodes/collection.py
@@ -5,6 +5,7 @@ from beartype import beartype
 
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
 from cript.nodes.supporting_nodes import User
+from cript.nodes.util.json import NodeUID
 
 
 class Collection(PrimaryBaseNode):
@@ -56,17 +57,17 @@ class Collection(PrimaryBaseNode):
         """
 
         # TODO add proper typing in future, using Any for now to avoid circular import error
-        member: List[User] = field(default_factory=list)
-        admin: List[User] = field(default_factory=list)
-        experiment: List[Any] = field(default_factory=list)
-        inventory: List[Any] = field(default_factory=list)
+        member: List[NodeUID[User]] = field(default_factory=list)
+        admin: List[NodeUID[User]] = field(default_factory=list)
+        experiment: List[NodeUID[Any]] = field(default_factory=list)
+        inventory: List[NodeUID[Any]] = field(default_factory=list)
         doi: str = ""
-        citation: List[Any] = field(default_factory=list)
+        citation: List[NodeUID[Any]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
     @beartype
-    def __init__(self, name: str, experiment: Optional[List[Any]] = None, inventory: Optional[List[Any]] = None, doi: str = "", citation: Optional[List[Any]] = None, notes: str = "", **kwargs) -> None:
+    def __init__(self, name: str, experiment: Optional[List[NodeUID[Any]]] = None, inventory: Optional[List[NodeUID[Any]]] = None, doi: str = "", citation: Optional[List[NodeUID[Any]]] = None, notes: str = "", **kwargs) -> None:
         """
         create a Collection with a name
         add list of experiment, inventory, citation, doi, and notes if available.

--- a/src/cript/nodes/primary_nodes/computation.py
+++ b/src/cript/nodes/primary_nodes/computation.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass, field, replace
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 from beartype import beartype
 
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
-from cript.nodes.util.json import NodeUID
+from cript.nodes.util.json import UIDProxy
 
 
 class Computation(PrimaryBaseNode):
@@ -65,12 +65,12 @@ class Computation(PrimaryBaseNode):
 
         type: str = ""
         # TODO add proper typing in future, using Any for now to avoid circular import error
-        input_data: List[NodeUID[Any]] = field(default_factory=list)
-        output_data: List[NodeUID[Any]] = field(default_factory=list)
-        software_configuration: List[NodeUID[Any]] = field(default_factory=list)
-        condition: List[NodeUID[Any]] = field(default_factory=list)
-        prerequisite_computation: Optional[NodeUID["Computation"]] = None
-        citation: List[NodeUID[Any]] = field(default_factory=list)
+        input_data: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        output_data: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        software_configuration: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        condition: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        prerequisite_computation: Optional[Union["Computation", UIDProxy]] = None
+        citation: List[Union[Any, UIDProxy]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
@@ -79,12 +79,12 @@ class Computation(PrimaryBaseNode):
         self,
         name: str,
         type: str,
-        input_data: Optional[List[NodeUID[Any]]] = None,
-        output_data: Optional[List[NodeUID[Any]]] = None,
-        software_configuration: Optional[List[NodeUID[Any]]] = None,
-        condition: Optional[List[NodeUID[Any]]] = None,
-        prerequisite_computation: Optional[NodeUID["Computation"]] = None,
-        citation: Optional[List[NodeUID[Any]]] = None,
+        input_data: Optional[List[Union[Any, UIDProxy]]] = None,
+        output_data: Optional[List[Union[Any, UIDProxy]]] = None,
+        software_configuration: Optional[List[Union[Any, UIDProxy]]] = None,
+        condition: Optional[List[Union[Any, UIDProxy]]] = None,
+        prerequisite_computation: Optional[Union["Computation", UIDProxy]] = None,
+        citation: Optional[List[Union[Any, UIDProxy]]] = None,
         notes: str = "",
         **kwargs
     ) -> None:
@@ -365,7 +365,7 @@ class Computation(PrimaryBaseNode):
 
     @property
     @beartype
-    def prerequisite_computation(self) -> Optional["Computation"]:
+    def prerequisite_computation(self) -> Optional[Union["Computation", UIDProxy]]:
         """
         prerequisite computation
 
@@ -387,7 +387,7 @@ class Computation(PrimaryBaseNode):
 
     @prerequisite_computation.setter
     @beartype
-    def prerequisite_computation(self, new_prerequisite_computation: Optional["Computation"]) -> None:
+    def prerequisite_computation(self, new_prerequisite_computation: Optional[Union["Computation", UIDProxy]]) -> None:
         """
         set new prerequisite_computation
 

--- a/src/cript/nodes/primary_nodes/computation.py
+++ b/src/cript/nodes/primary_nodes/computation.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional
 from beartype import beartype
 
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
+from cript.nodes.util.json import NodeUID
 
 
 class Computation(PrimaryBaseNode):
@@ -64,12 +65,12 @@ class Computation(PrimaryBaseNode):
 
         type: str = ""
         # TODO add proper typing in future, using Any for now to avoid circular import error
-        input_data: List[Any] = field(default_factory=list)
-        output_data: List[Any] = field(default_factory=list)
-        software_configuration: List[Any] = field(default_factory=list)
-        condition: List[Any] = field(default_factory=list)
-        prerequisite_computation: Optional["Computation"] = None
-        citation: List[Any] = field(default_factory=list)
+        input_data: List[NodeUID[Any]] = field(default_factory=list)
+        output_data: List[NodeUID[Any]] = field(default_factory=list)
+        software_configuration: List[NodeUID[Any]] = field(default_factory=list)
+        condition: List[NodeUID[Any]] = field(default_factory=list)
+        prerequisite_computation: Optional[NodeUID["Computation"]] = None
+        citation: List[NodeUID[Any]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
@@ -78,12 +79,12 @@ class Computation(PrimaryBaseNode):
         self,
         name: str,
         type: str,
-        input_data: Optional[List[Any]] = None,
-        output_data: Optional[List[Any]] = None,
-        software_configuration: Optional[List[Any]] = None,
-        condition: Optional[List[Any]] = None,
-        prerequisite_computation: Optional["Computation"] = None,
-        citation: Optional[List[Any]] = None,
+        input_data: Optional[List[NodeUID[Any]]] = None,
+        output_data: Optional[List[NodeUID[Any]]] = None,
+        software_configuration: Optional[List[NodeUID[Any]]] = None,
+        condition: Optional[List[NodeUID[Any]]] = None,
+        prerequisite_computation: Optional[NodeUID["Computation"]] = None,
+        citation: Optional[List[NodeUID[Any]]] = None,
         notes: str = "",
         **kwargs
     ) -> None:

--- a/src/cript/nodes/primary_nodes/computation_process.py
+++ b/src/cript/nodes/primary_nodes/computation_process.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional
 from beartype import beartype
 
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
+from cript.nodes.util.json import NodeUID
 
 
 class ComputationProcess(PrimaryBaseNode):
@@ -113,13 +114,13 @@ class ComputationProcess(PrimaryBaseNode):
 
         type: str = ""
         # TODO add proper typing in future, using Any for now to avoid circular import error
-        input_data: List[Any] = field(default_factory=list)
-        output_data: List[Any] = field(default_factory=list)
-        ingredient: List[Any] = field(default_factory=list)
-        software_configuration: List[Any] = field(default_factory=list)
-        condition: List[Any] = field(default_factory=list)
-        property: List[Any] = field(default_factory=list)
-        citation: List[Any] = field(default_factory=list)
+        input_data: List[NodeUID[Any]] = field(default_factory=list)
+        output_data: List[NodeUID[Any]] = field(default_factory=list)
+        ingredient: List[NodeUID[Any]] = field(default_factory=list)
+        software_configuration: List[NodeUID[Any]] = field(default_factory=list)
+        condition: List[NodeUID[Any]] = field(default_factory=list)
+        property: List[NodeUID[Any]] = field(default_factory=list)
+        citation: List[NodeUID[Any]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
@@ -128,13 +129,13 @@ class ComputationProcess(PrimaryBaseNode):
         self,
         name: str,
         type: str,
-        input_data: List[Any],
-        ingredient: List[Any],
-        output_data: Optional[List[Any]] = None,
-        software_configuration: Optional[List[Any]] = None,
-        condition: Optional[List[Any]] = None,
-        property: Optional[List[Any]] = None,
-        citation: Optional[List[Any]] = None,
+        input_data: List[NodeUID[Any]],
+        ingredient: List[NodeUID[Any]],
+        output_data: Optional[List[NodeUID[Any]]] = None,
+        software_configuration: Optional[List[NodeUID[Any]]] = None,
+        condition: Optional[List[NodeUID[Any]]] = None,
+        property: Optional[List[NodeUID[Any]]] = None,
+        citation: Optional[List[NodeUID[Any]]] = None,
         notes: str = "",
         **kwargs
     ):

--- a/src/cript/nodes/primary_nodes/computation_process.py
+++ b/src/cript/nodes/primary_nodes/computation_process.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass, field, replace
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 from beartype import beartype
 
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
-from cript.nodes.util.json import NodeUID
+from cript.nodes.util.json import UIDProxy
 
 
 class ComputationProcess(PrimaryBaseNode):
@@ -114,13 +114,13 @@ class ComputationProcess(PrimaryBaseNode):
 
         type: str = ""
         # TODO add proper typing in future, using Any for now to avoid circular import error
-        input_data: List[NodeUID[Any]] = field(default_factory=list)
-        output_data: List[NodeUID[Any]] = field(default_factory=list)
-        ingredient: List[NodeUID[Any]] = field(default_factory=list)
-        software_configuration: List[NodeUID[Any]] = field(default_factory=list)
-        condition: List[NodeUID[Any]] = field(default_factory=list)
-        property: List[NodeUID[Any]] = field(default_factory=list)
-        citation: List[NodeUID[Any]] = field(default_factory=list)
+        input_data: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        output_data: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        ingredient: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        software_configuration: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        condition: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        property: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        citation: List[Union[Any, UIDProxy]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
@@ -129,13 +129,13 @@ class ComputationProcess(PrimaryBaseNode):
         self,
         name: str,
         type: str,
-        input_data: List[NodeUID[Any]],
-        ingredient: List[NodeUID[Any]],
-        output_data: Optional[List[NodeUID[Any]]] = None,
-        software_configuration: Optional[List[NodeUID[Any]]] = None,
-        condition: Optional[List[NodeUID[Any]]] = None,
-        property: Optional[List[NodeUID[Any]]] = None,
-        citation: Optional[List[NodeUID[Any]]] = None,
+        input_data: List[Union[Any, UIDProxy]],
+        ingredient: List[Union[Any, UIDProxy]],
+        output_data: Optional[List[Union[Any, UIDProxy]]] = None,
+        software_configuration: Optional[List[Union[Any, UIDProxy]]] = None,
+        condition: Optional[List[Union[Any, UIDProxy]]] = None,
+        property: Optional[List[Union[Any, UIDProxy]]] = None,
+        citation: Optional[List[Union[Any, UIDProxy]]] = None,
         notes: str = "",
         **kwargs
     ):

--- a/src/cript/nodes/primary_nodes/data.py
+++ b/src/cript/nodes/primary_nodes/data.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional, Union
 from beartype import beartype
 
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
-from cript.nodes.util.json import NodeUID
+from cript.nodes.util.json import UIDProxy
 
 
 class Data(PrimaryBaseNode):
@@ -75,13 +75,13 @@ class Data(PrimaryBaseNode):
 
         type: str = ""
         # TODO add proper typing in future, using Any for now to avoid circular import error
-        file: List[NodeUID[Any]] = field(default_factory=list)
-        sample_preparation: NodeUID[Any] = field(default_factory=list)
-        computation: List[NodeUID[Any]] = field(default_factory=list)
-        computation_process: NodeUID[Any] = field(default_factory=list)
-        material: List[NodeUID[Any]] = field(default_factory=list)
-        process: List[NodeUID[Any]] = field(default_factory=list)
-        citation: List[NodeUID[Any]] = field(default_factory=list)
+        file: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        sample_preparation: Union[Any, UIDProxy] = field(default_factory=list)
+        computation: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        computation_process: Union[Any, UIDProxy] = field(default_factory=list)
+        material: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        process: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        citation: List[Union[Any, UIDProxy]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
@@ -90,13 +90,13 @@ class Data(PrimaryBaseNode):
         self,
         name: str,
         type: str,
-        file: List[NodeUID[Any]],
-        sample_preparation: NodeUID[Any] = None,
-        computation: Optional[List[NodeUID[Any]]] = None,
-        computation_process: Optional[NodeUID[Any]] = None,
-        material: Optional[List[NodeUID[Any]]] = None,
-        process: Optional[List[NodeUID[Any]]] = None,
-        citation: Optional[List[NodeUID[Any]]] = None,
+        file: List[Union[Any, UIDProxy]],
+        sample_preparation: Union[Any, UIDProxy] = None,
+        computation: Optional[List[Union[Any, UIDProxy]]] = None,
+        computation_process: Optional[Union[Any, UIDProxy]] = None,
+        material: Optional[List[Union[Any, UIDProxy]]] = None,
+        process: Optional[List[Union[Any, UIDProxy]]] = None,
+        citation: Optional[List[Union[Any, UIDProxy]]] = None,
         notes: str = "",
         **kwargs
     ) -> None:

--- a/src/cript/nodes/primary_nodes/data.py
+++ b/src/cript/nodes/primary_nodes/data.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional, Union
 from beartype import beartype
 
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
+from cript.nodes.util.json import NodeUID
 
 
 class Data(PrimaryBaseNode):
@@ -74,13 +75,13 @@ class Data(PrimaryBaseNode):
 
         type: str = ""
         # TODO add proper typing in future, using Any for now to avoid circular import error
-        file: List[Any] = field(default_factory=list)
-        sample_preparation: Any = field(default_factory=list)
-        computation: List[Any] = field(default_factory=list)
-        computation_process: Any = field(default_factory=list)
-        material: List[Any] = field(default_factory=list)
-        process: List[Any] = field(default_factory=list)
-        citation: List[Any] = field(default_factory=list)
+        file: List[NodeUID[Any]] = field(default_factory=list)
+        sample_preparation: NodeUID[Any] = field(default_factory=list)
+        computation: List[NodeUID[Any]] = field(default_factory=list)
+        computation_process: NodeUID[Any] = field(default_factory=list)
+        material: List[NodeUID[Any]] = field(default_factory=list)
+        process: List[NodeUID[Any]] = field(default_factory=list)
+        citation: List[NodeUID[Any]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
@@ -89,13 +90,13 @@ class Data(PrimaryBaseNode):
         self,
         name: str,
         type: str,
-        file: List[Any],
-        sample_preparation: Any = None,
-        computation: Optional[List[Any]] = None,
-        computation_process: Optional[Any] = None,
-        material: Optional[List[Any]] = None,
-        process: Optional[List[Any]] = None,
-        citation: Optional[List[Any]] = None,
+        file: List[NodeUID[Any]],
+        sample_preparation: NodeUID[Any] = None,
+        computation: Optional[List[NodeUID[Any]]] = None,
+        computation_process: Optional[NodeUID[Any]] = None,
+        material: Optional[List[NodeUID[Any]]] = None,
+        process: Optional[List[NodeUID[Any]]] = None,
+        citation: Optional[List[NodeUID[Any]]] = None,
         notes: str = "",
         **kwargs
     ) -> None:

--- a/src/cript/nodes/primary_nodes/experiment.py
+++ b/src/cript/nodes/primary_nodes/experiment.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass, field, replace
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 from beartype import beartype
 
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
-from cript.nodes.util.json import NodeUID
+from cript.nodes.util.json import UIDProxy
 
 
 class Experiment(PrimaryBaseNode):
@@ -66,12 +66,12 @@ class Experiment(PrimaryBaseNode):
         all Collection attributes
         """
 
-        process: List[NodeUID[Any]] = field(default_factory=list)
-        computation: List[NodeUID[Any]] = field(default_factory=list)
-        computation_process: List[NodeUID[Any]] = field(default_factory=list)
-        data: List[NodeUID[Any]] = field(default_factory=list)
+        process: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        computation: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        computation_process: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        data: List[Union[Any, UIDProxy]] = field(default_factory=list)
         funding: List[str] = field(default_factory=list)
-        citation: List[NodeUID[Any]] = field(default_factory=list)
+        citation: List[Union[Any, UIDProxy]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
@@ -79,12 +79,12 @@ class Experiment(PrimaryBaseNode):
     def __init__(
         self,
         name: str,
-        process: Optional[List[NodeUID[Any]]] = None,
-        computation: Optional[List[NodeUID[Any]]] = None,
-        computation_process: Optional[List[NodeUID[Any]]] = None,
-        data: Optional[List[NodeUID[Any]]] = None,
+        process: Optional[List[Union[Any, UIDProxy]]] = None,
+        computation: Optional[List[Union[Any, UIDProxy]]] = None,
+        computation_process: Optional[List[Union[Any, UIDProxy]]] = None,
+        data: Optional[List[Union[Any, UIDProxy]]] = None,
         funding: Optional[List[str]] = None,
-        citation: Optional[List[NodeUID[Any]]] = None,
+        citation: Optional[List[Union[Any, UIDProxy]]] = None,
         notes: str = "",
         **kwargs
     ):

--- a/src/cript/nodes/primary_nodes/experiment.py
+++ b/src/cript/nodes/primary_nodes/experiment.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional
 from beartype import beartype
 
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
+from cript.nodes.util.json import NodeUID
 
 
 class Experiment(PrimaryBaseNode):
@@ -65,12 +66,12 @@ class Experiment(PrimaryBaseNode):
         all Collection attributes
         """
 
-        process: List[Any] = field(default_factory=list)
-        computation: List[Any] = field(default_factory=list)
-        computation_process: List[Any] = field(default_factory=list)
-        data: List[Any] = field(default_factory=list)
+        process: List[NodeUID[Any]] = field(default_factory=list)
+        computation: List[NodeUID[Any]] = field(default_factory=list)
+        computation_process: List[NodeUID[Any]] = field(default_factory=list)
+        data: List[NodeUID[Any]] = field(default_factory=list)
         funding: List[str] = field(default_factory=list)
-        citation: List[Any] = field(default_factory=list)
+        citation: List[NodeUID[Any]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
@@ -78,12 +79,12 @@ class Experiment(PrimaryBaseNode):
     def __init__(
         self,
         name: str,
-        process: Optional[List[Any]] = None,
-        computation: Optional[List[Any]] = None,
-        computation_process: Optional[List[Any]] = None,
-        data: Optional[List[Any]] = None,
+        process: Optional[List[NodeUID[Any]]] = None,
+        computation: Optional[List[NodeUID[Any]]] = None,
+        computation_process: Optional[List[NodeUID[Any]]] = None,
+        data: Optional[List[NodeUID[Any]]] = None,
         funding: Optional[List[str]] = None,
-        citation: Optional[List[Any]] = None,
+        citation: Optional[List[NodeUID[Any]]] = None,
         notes: str = "",
         **kwargs
     ):

--- a/src/cript/nodes/primary_nodes/inventory.py
+++ b/src/cript/nodes/primary_nodes/inventory.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass, field, replace
-from typing import List
+from typing import List, Union
 
 from beartype import beartype
 
 from cript.nodes.primary_nodes.material import Material
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
-from cript.nodes.util.json import NodeUID
+from cript.nodes.util.json import UIDProxy
 
 
 class Inventory(PrimaryBaseNode):
@@ -60,12 +60,12 @@ class Inventory(PrimaryBaseNode):
         all Inventory attributes
         """
 
-        material: List[NodeUID[Material]] = field(default_factory=list)
+        material: List[Union[Material, UIDProxy]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
     @beartype
-    def __init__(self, name: str, material: List[NodeUID[Material]], notes: str = "", **kwargs) -> None:
+    def __init__(self, name: str, material: List[Union[Material, UIDProxy]], notes: str = "", **kwargs) -> None:
         """
         Instantiate an inventory node
 
@@ -105,7 +105,7 @@ class Inventory(PrimaryBaseNode):
 
     @property
     @beartype
-    def material(self) -> List[Material]:
+    def material(self) -> List[Union[Material, UIDProxy]]:
         """
         List of [material](../material) in this inventory
 
@@ -132,7 +132,7 @@ class Inventory(PrimaryBaseNode):
 
     @material.setter
     @beartype
-    def material(self, new_material_list: List[Material]):
+    def material(self, new_material_list: List[Union[Material, UIDProxy]]):
         """
         set the list of material for this inventory node
 

--- a/src/cript/nodes/primary_nodes/inventory.py
+++ b/src/cript/nodes/primary_nodes/inventory.py
@@ -5,6 +5,7 @@ from beartype import beartype
 
 from cript.nodes.primary_nodes.material import Material
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
+from cript.nodes.util.json import NodeUID
 
 
 class Inventory(PrimaryBaseNode):
@@ -59,12 +60,12 @@ class Inventory(PrimaryBaseNode):
         all Inventory attributes
         """
 
-        material: List[Material] = field(default_factory=list)
+        material: List[NodeUID[Material]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
     @beartype
-    def __init__(self, name: str, material: List[Material], notes: str = "", **kwargs) -> None:
+    def __init__(self, name: str, material: List[NodeUID[Material]], notes: str = "", **kwargs) -> None:
         """
         Instantiate an inventory node
 

--- a/src/cript/nodes/primary_nodes/material.py
+++ b/src/cript/nodes/primary_nodes/material.py
@@ -6,6 +6,7 @@ from beartype import beartype
 from cript.nodes.exceptions import CRIPTMaterialIdentifierError
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
 from cript.nodes.primary_nodes.process import Process
+from cript.nodes.util.json import NodeUID
 
 
 class Material(PrimaryBaseNode):
@@ -74,11 +75,11 @@ class Material(PrimaryBaseNode):
         """
 
         # TODO add proper typing in future, using Any for now to avoid circular import error
-        component: List["Material"] = field(default_factory=list)
-        process: Optional[Process] = None
-        property: List[Any] = field(default_factory=list)
-        parent_material: Optional["Material"] = None
-        computational_forcefield: Optional[Any] = None
+        component: List[NodeUID["Material"]] = field(default_factory=list)
+        process: Optional[NodeUID[Process]] = None
+        property: List[NodeUID[Any]] = field(default_factory=list)
+        parent_material: Optional[NodeUID["Material"]] = None
+        computational_forcefield: Optional[NodeUID[Any]] = None
         keyword: List[str] = field(default_factory=list)
         amino_acid: Optional[str] = None
         bigsmiles: Optional[str] = None
@@ -99,11 +100,11 @@ class Material(PrimaryBaseNode):
     def __init__(
         self,
         name: str,
-        component: Optional[List["Material"]] = None,
-        process: Optional[Process] = None,
-        property: Optional[List[Any]] = None,
-        parent_material: Optional["Material"] = None,
-        computational_forcefield: Optional[Any] = None,
+        component: Optional[List[NodeUID["Material"]]] = None,
+        process: Optional[NodeUID[Process]] = None,
+        property: Optional[List[NodeUID[Any]]] = None,
+        parent_material: Optional[NodeUID["Material"]] = None,
+        computational_forcefield: Optional[NodeUID[Any]] = None,
         keyword: Optional[List[str]] = None,
         amino_acid: Optional[str] = None,
         bigsmiles: Optional[str] = None,

--- a/src/cript/nodes/primary_nodes/material.py
+++ b/src/cript/nodes/primary_nodes/material.py
@@ -6,7 +6,7 @@ from beartype import beartype
 from cript.nodes.exceptions import CRIPTMaterialIdentifierError
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
 from cript.nodes.primary_nodes.process import Process
-from cript.nodes.util.json import NodeUID
+from cript.nodes.util.json import UIDProxy
 
 
 class Material(PrimaryBaseNode):
@@ -75,11 +75,11 @@ class Material(PrimaryBaseNode):
         """
 
         # TODO add proper typing in future, using Any for now to avoid circular import error
-        component: List[NodeUID["Material"]] = field(default_factory=list)
-        process: Optional[NodeUID[Process]] = None
-        property: List[NodeUID[Any]] = field(default_factory=list)
-        parent_material: Optional[NodeUID["Material"]] = None
-        computational_forcefield: Optional[NodeUID[Any]] = None
+        component: List[Union["Material", UIDProxy]] = field(default_factory=list)
+        process: Optional[Union[Process, UIDProxy]] = None
+        property: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        parent_material: Optional[Union["Material", UIDProxy]] = None
+        computational_forcefield: Optional[Union[Any, UIDProxy]] = None
         keyword: List[str] = field(default_factory=list)
         amino_acid: Optional[str] = None
         bigsmiles: Optional[str] = None
@@ -100,11 +100,11 @@ class Material(PrimaryBaseNode):
     def __init__(
         self,
         name: str,
-        component: Optional[List[NodeUID["Material"]]] = None,
-        process: Optional[NodeUID[Process]] = None,
-        property: Optional[List[NodeUID[Any]]] = None,
-        parent_material: Optional[NodeUID["Material"]] = None,
-        computational_forcefield: Optional[NodeUID[Any]] = None,
+        component: Optional[List[Union["Material", UIDProxy]]] = None,
+        process: Optional[Union[Process, UIDProxy]] = None,
+        property: Optional[List[Union[Any, UIDProxy]]] = None,
+        parent_material: Optional[Union["Material", UIDProxy]] = None,
+        computational_forcefield: Optional[Union[Any, UIDProxy]] = None,
         keyword: Optional[List[str]] = None,
         amino_acid: Optional[str] = None,
         bigsmiles: Optional[str] = None,
@@ -354,7 +354,7 @@ class Material(PrimaryBaseNode):
 
     @property
     @beartype
-    def component(self) -> List["Material"]:
+    def component(self) -> List[Union["Material", UIDProxy]]:
         """
         list of components ([material nodes](./)) that make up this material
 
@@ -386,7 +386,7 @@ class Material(PrimaryBaseNode):
 
     @component.setter
     @beartype
-    def component(self, new_component_list: List["Material"]) -> None:
+    def component(self, new_component_list: List[Union["Material", UIDProxy]]) -> None:
         """
         set the list of component (material nodes) that make up this material
 
@@ -403,7 +403,7 @@ class Material(PrimaryBaseNode):
 
     @property
     @beartype
-    def parent_material(self) -> Optional["Material"]:
+    def parent_material(self) -> Optional[Union["Material", UIDProxy]]:
         """
         List of parent materials
 
@@ -416,7 +416,7 @@ class Material(PrimaryBaseNode):
 
     @parent_material.setter
     @beartype
-    def parent_material(self, new_parent_material: Optional["Material"]) -> None:
+    def parent_material(self, new_parent_material: Optional[Union["Material", UIDProxy]]) -> None:
         """
         set the [parent materials](./) for this material
 
@@ -459,19 +459,19 @@ class Material(PrimaryBaseNode):
 
     @computational_forcefield.setter
     @beartype
-    def computational_forcefield(self, new_computational_forcefield_list: Any) -> None:
+    def computational_forcefield(self, new_computational_forcefield: Any) -> None:
         """
         sets the list of computational forcefields for this material
 
         Parameters
         ----------
-        new_computation_forcefield_list: List[ComputationalForcefield]
+        new_computation_forcefield: ComputationalForcefield
 
         Returns
         -------
         None
         """
-        new_attrs = replace(self._json_attrs, computational_forcefield=new_computational_forcefield_list)
+        new_attrs = replace(self._json_attrs, computational_forcefield=new_computational_forcefield)
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
@@ -519,11 +519,11 @@ class Material(PrimaryBaseNode):
 
     @property
     @beartype
-    def process(self) -> Optional[Process]:
+    def process(self) -> Optional[Union[Process, UIDProxy]]:
         return self._json_attrs.process  # type: ignore
 
     @process.setter
-    def process(self, new_process: Process) -> None:
+    def process(self, new_process: Union[Process, UIDProxy]) -> None:
         new_attrs = replace(self._json_attrs, process=new_process)
         self._update_json_attrs_if_valid(new_attrs)
 

--- a/src/cript/nodes/primary_nodes/process.py
+++ b/src/cript/nodes/primary_nodes/process.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional
 from beartype import beartype
 
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
+from cript.nodes.util.json import NodeUID
 
 
 class Process(PrimaryBaseNode):
@@ -61,16 +62,16 @@ class Process(PrimaryBaseNode):
 
         type: str = ""
         # TODO add proper typing in future, using Any for now to avoid circular import error
-        ingredient: List[Any] = field(default_factory=list)
+        ingredient: List[NodeUID[Any]] = field(default_factory=list)
         description: str = ""
-        equipment: List[Any] = field(default_factory=list)
-        product: List[Any] = field(default_factory=list)
-        waste: List[Any] = field(default_factory=list)
-        prerequisite_process: List["Process"] = field(default_factory=list)
-        condition: List[Any] = field(default_factory=list)
-        property: List[Any] = field(default_factory=list)
+        equipment: List[NodeUID[Any]] = field(default_factory=list)
+        product: List[NodeUID[Any]] = field(default_factory=list)
+        waste: List[NodeUID[Any]] = field(default_factory=list)
+        prerequisite_process: List[NodeUID["Process"]] = field(default_factory=list)
+        condition: List[NodeUID[Any]] = field(default_factory=list)
+        property: List[NodeUID[Any]] = field(default_factory=list)
         keyword: List[str] = field(default_factory=list)
-        citation: List[Any] = field(default_factory=list)
+        citation: List[NodeUID[Any]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
@@ -79,16 +80,16 @@ class Process(PrimaryBaseNode):
         self,
         name: str,
         type: str,
-        ingredient: Optional[List[Any]] = None,
+        ingredient: Optional[List[NodeUID[Any]]] = None,
         description: str = "",
-        equipment: Optional[List[Any]] = None,
-        product: Optional[List[Any]] = None,
-        waste: Optional[List[Any]] = None,
-        prerequisite_process: Optional[List[Any]] = None,
-        condition: Optional[List[Any]] = None,
-        property: Optional[List[Any]] = None,
+        equipment: Optional[List[NodeUID[Any]]] = None,
+        product: Optional[List[NodeUID[Any]]] = None,
+        waste: Optional[List[NodeUID[Any]]] = None,
+        prerequisite_process: Optional[List[NodeUID["Process"]]] = None,
+        condition: Optional[List[NodeUID[Any]]] = None,
+        property: Optional[List[NodeUID[Any]]] = None,
         keyword: Optional[List[str]] = None,
-        citation: Optional[List[Any]] = None,
+        citation: Optional[List[NodeUID[Any]]] = None,
         notes: str = "",
         **kwargs
     ) -> None:

--- a/src/cript/nodes/primary_nodes/process.py
+++ b/src/cript/nodes/primary_nodes/process.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass, field, replace
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 from beartype import beartype
 
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
-from cript.nodes.util.json import NodeUID
+from cript.nodes.util.json import UIDProxy
 
 
 class Process(PrimaryBaseNode):
@@ -62,16 +62,16 @@ class Process(PrimaryBaseNode):
 
         type: str = ""
         # TODO add proper typing in future, using Any for now to avoid circular import error
-        ingredient: List[NodeUID[Any]] = field(default_factory=list)
+        ingredient: List[Union[Any, UIDProxy]] = field(default_factory=list)
         description: str = ""
-        equipment: List[NodeUID[Any]] = field(default_factory=list)
-        product: List[NodeUID[Any]] = field(default_factory=list)
-        waste: List[NodeUID[Any]] = field(default_factory=list)
-        prerequisite_process: List[NodeUID["Process"]] = field(default_factory=list)
-        condition: List[NodeUID[Any]] = field(default_factory=list)
-        property: List[NodeUID[Any]] = field(default_factory=list)
+        equipment: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        product: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        waste: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        prerequisite_process: List[Union["Process", UIDProxy]] = field(default_factory=list)
+        condition: List[Union[Any, UIDProxy]] = field(default_factory=list)
+        property: List[Union[Any, UIDProxy]] = field(default_factory=list)
         keyword: List[str] = field(default_factory=list)
-        citation: List[NodeUID[Any]] = field(default_factory=list)
+        citation: List[Union[Any, UIDProxy]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
@@ -80,16 +80,16 @@ class Process(PrimaryBaseNode):
         self,
         name: str,
         type: str,
-        ingredient: Optional[List[NodeUID[Any]]] = None,
+        ingredient: Optional[List[Union[Any, UIDProxy]]] = None,
         description: str = "",
-        equipment: Optional[List[NodeUID[Any]]] = None,
-        product: Optional[List[NodeUID[Any]]] = None,
-        waste: Optional[List[NodeUID[Any]]] = None,
-        prerequisite_process: Optional[List[NodeUID["Process"]]] = None,
-        condition: Optional[List[NodeUID[Any]]] = None,
-        property: Optional[List[NodeUID[Any]]] = None,
+        equipment: Optional[List[Union[Any, UIDProxy]]] = None,
+        product: Optional[List[Union[Any, UIDProxy]]] = None,
+        waste: Optional[List[Union[Any, UIDProxy]]] = None,
+        prerequisite_process: Optional[List[Union["Process", UIDProxy]]] = None,
+        condition: Optional[List[Union[Any, UIDProxy]]] = None,
+        property: Optional[List[Union[Any, UIDProxy]]] = None,
         keyword: Optional[List[str]] = None,
-        citation: Optional[List[NodeUID[Any]]] = None,
+        citation: Optional[List[Union[Any, UIDProxy]]] = None,
         notes: str = "",
         **kwargs
     ) -> None:
@@ -417,7 +417,7 @@ class Process(PrimaryBaseNode):
 
     @property
     @beartype
-    def prerequisite_process(self) -> List["Process"]:
+    def prerequisite_process(self) -> List[Union["Process", UIDProxy]]:
         """
         list of prerequisite process nodes
 
@@ -440,7 +440,7 @@ class Process(PrimaryBaseNode):
 
     @prerequisite_process.setter
     @beartype
-    def prerequisite_process(self, new_prerequisite_process_list: List["Process"]) -> None:
+    def prerequisite_process(self, new_prerequisite_process_list: List[Union["Process", UIDProxy]]) -> None:
         """
         set the prerequisite_process for the process node
 

--- a/src/cript/nodes/primary_nodes/project.py
+++ b/src/cript/nodes/primary_nodes/project.py
@@ -7,6 +7,7 @@ from cript.nodes.primary_nodes.collection import Collection
 from cript.nodes.primary_nodes.material import Material
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
 from cript.nodes.supporting_nodes import User
+from cript.nodes.util.json import NodeUID
 
 
 class Project(PrimaryBaseNode):
@@ -59,15 +60,15 @@ class Project(PrimaryBaseNode):
         all Project attributes
         """
 
-        member: List[User] = field(default_factory=list)
-        admin: List[User] = field(default_factory=list)
-        collection: List[Collection] = field(default_factory=list)
-        material: List[Material] = field(default_factory=list)
+        member: List[NodeUID[User]] = field(default_factory=list)
+        admin: List[NodeUID[User]] = field(default_factory=list)
+        collection: List[NodeUID[Collection]] = field(default_factory=list)
+        material: List[NodeUID[Material]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
     @beartype
-    def __init__(self, name: str, collection: Optional[List[Collection]] = None, material: Optional[List[Material]] = None, notes: str = "", **kwargs):
+    def __init__(self, name: str, collection: Optional[List[NodeUID[Collection]]] = None, material: Optional[List[NodeUID[Material]]] = None, notes: str = "", **kwargs):
         """
         Create a Project node with Project name
 

--- a/src/cript/nodes/primary_nodes/project.py
+++ b/src/cript/nodes/primary_nodes/project.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field, replace
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from beartype import beartype
 
@@ -7,7 +7,7 @@ from cript.nodes.primary_nodes.collection import Collection
 from cript.nodes.primary_nodes.material import Material
 from cript.nodes.primary_nodes.primary_base_node import PrimaryBaseNode
 from cript.nodes.supporting_nodes import User
-from cript.nodes.util.json import NodeUID
+from cript.nodes.util.json import UIDProxy
 
 
 class Project(PrimaryBaseNode):
@@ -60,15 +60,15 @@ class Project(PrimaryBaseNode):
         all Project attributes
         """
 
-        member: List[NodeUID[User]] = field(default_factory=list)
-        admin: List[NodeUID[User]] = field(default_factory=list)
-        collection: List[NodeUID[Collection]] = field(default_factory=list)
-        material: List[NodeUID[Material]] = field(default_factory=list)
+        member: List[Union[User, UIDProxy]] = field(default_factory=list)
+        admin: List[Union[User, UIDProxy]] = field(default_factory=list)
+        collection: List[Union[Collection, UIDProxy]] = field(default_factory=list)
+        material: List[Union[Material, UIDProxy]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
     @beartype
-    def __init__(self, name: str, collection: Optional[List[NodeUID[Collection]]] = None, material: Optional[List[NodeUID[Material]]] = None, notes: str = "", **kwargs):
+    def __init__(self, name: str, collection: Optional[List[Union[Collection, UIDProxy]]] = None, material: Optional[List[Union[Material, UIDProxy]]] = None, notes: str = "", **kwargs):
         """
         Create a Project node with Project name
 
@@ -149,17 +149,17 @@ class Project(PrimaryBaseNode):
 
     @property
     @beartype
-    def member(self) -> List[User]:
+    def member(self) -> List[Union[User, UIDProxy]]:
         return self._json_attrs.member.copy()
 
     @property
     @beartype
-    def admin(self) -> List[User]:
+    def admin(self) -> List[Union[User, UIDProxy]]:
         return self._json_attrs.admin
 
     @property
     @beartype
-    def collection(self) -> List[Collection]:
+    def collection(self) -> List[Union[Collection, UIDProxy]]:
         """
         Collection is a Project node's property that can be set during creation in the constructor
         or later by setting the project's property
@@ -180,7 +180,7 @@ class Project(PrimaryBaseNode):
 
     @collection.setter
     @beartype
-    def collection(self, new_collection: List[Collection]) -> None:
+    def collection(self, new_collection: List[Union[Collection, UIDProxy]]) -> None:
         """
         set list of collections for the project node
 
@@ -197,7 +197,7 @@ class Project(PrimaryBaseNode):
 
     @property
     @beartype
-    def material(self) -> List[Material]:
+    def material(self) -> List[Union[Material, UIDProxy]]:
         """
         List of Materials that belong to this Project.
 
@@ -217,7 +217,7 @@ class Project(PrimaryBaseNode):
 
     @material.setter
     @beartype
-    def material(self, new_materials: List[Material]) -> None:
+    def material(self, new_materials: List[Union[Material, UIDProxy]]) -> None:
         """
         set the list of materials for this project
 

--- a/src/cript/nodes/subobjects/algorithm.py
+++ b/src/cript/nodes/subobjects/algorithm.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass, field, replace
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from cript.nodes.subobjects.citation import Citation
 from cript.nodes.subobjects.parameter import Parameter
-from cript.nodes.util.json import NodeUID
+from cript.nodes.util.json import UIDProxy
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -70,12 +70,12 @@ class Algorithm(UUIDBaseNode):
         key: str = ""
         type: str = ""
 
-        parameter: List[NodeUID[Parameter]] = field(default_factory=list)
-        citation: List[NodeUID[Citation]] = field(default_factory=list)
+        parameter: List[Union[Parameter, UIDProxy]] = field(default_factory=list)
+        citation: List[Union[Citation, UIDProxy]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
-    def __init__(self, key: str, type: str, parameter: Optional[List[NodeUID[Parameter]]] = None, citation: Optional[List[NodeUID[Citation]]] = None, **kwargs):  # ignored
+    def __init__(self, key: str, type: str, parameter: Optional[List[Union[Parameter, UIDProxy]]] = None, citation: Optional[List[Union[Citation, UIDProxy]]] = None, **kwargs):  # ignored
         """
         Create algorithm sub-object
 
@@ -173,7 +173,7 @@ class Algorithm(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
-    def parameter(self) -> List[Parameter]:
+    def parameter(self) -> List[Union[Parameter, UIDProxy]]:
         """
         list of [Parameter](../parameter) sub-objects for the algorithm sub-object
 
@@ -195,7 +195,7 @@ class Algorithm(UUIDBaseNode):
         return self._json_attrs.parameter.copy()
 
     @parameter.setter
-    def parameter(self, new_parameter: List[Parameter]) -> None:
+    def parameter(self, new_parameter: List[Union[Parameter, UIDProxy]]) -> None:
         """
         set a list of cript.Parameter sub-objects
 
@@ -212,7 +212,7 @@ class Algorithm(UUIDBaseNode):
         self._update_json_attrs_if_valid(new_attrs)
 
     @property
-    def citation(self) -> Citation:
+    def citation(self) -> List[Union[Citation, UIDProxy]]:
         """
         [citation](../citation) subobject for algorithm subobject
 
@@ -248,7 +248,7 @@ class Algorithm(UUIDBaseNode):
         return self._json_attrs.citation.copy()  # type: ignore
 
     @citation.setter
-    def citation(self, new_citation: List[Citation]) -> None:
+    def citation(self, new_citation: List[Union[Citation, UIDProxy]]) -> None:
         """
         set the algorithm citation subobject
 

--- a/src/cript/nodes/subobjects/algorithm.py
+++ b/src/cript/nodes/subobjects/algorithm.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 
 from cript.nodes.subobjects.citation import Citation
 from cript.nodes.subobjects.parameter import Parameter
+from cript.nodes.util.json import NodeUID
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -69,12 +70,12 @@ class Algorithm(UUIDBaseNode):
         key: str = ""
         type: str = ""
 
-        parameter: List[Parameter] = field(default_factory=list)
-        citation: List[Citation] = field(default_factory=list)
+        parameter: List[NodeUID[Parameter]] = field(default_factory=list)
+        citation: List[NodeUID[Citation]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
-    def __init__(self, key: str, type: str, parameter: Optional[List[Parameter]] = None, citation: Optional[List[Citation]] = None, **kwargs):  # ignored
+    def __init__(self, key: str, type: str, parameter: Optional[List[NodeUID[Parameter]]] = None, citation: Optional[List[NodeUID[Citation]]] = None, **kwargs):  # ignored
         """
         Create algorithm sub-object
 

--- a/src/cript/nodes/subobjects/citation.py
+++ b/src/cript/nodes/subobjects/citation.py
@@ -4,7 +4,7 @@ from typing import Optional, Union
 from beartype import beartype
 
 from cript.nodes.primary_nodes.reference import Reference
-from cript.nodes.util.json import NodeUID
+from cript.nodes.util.json import UIDProxy
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -61,12 +61,12 @@ class Citation(UUIDBaseNode):
     @dataclass(frozen=True)
     class JsonAttributes(UUIDBaseNode.JsonAttributes):
         type: str = ""
-        reference: Optional[NodeUID[Reference]] = None
+        reference: Optional[Union[Reference, UIDProxy]] = None
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
     @beartype
-    def __init__(self, type: str, reference: NodeUID[Reference], **kwargs):
+    def __init__(self, type: str, reference: Union[Reference, UIDProxy], **kwargs):
         """
         create a Citation subobject
 
@@ -165,7 +165,7 @@ class Citation(UUIDBaseNode):
 
     @property
     @beartype
-    def reference(self) -> Union[Reference, None]:
+    def reference(self) -> Union[Reference, None, UIDProxy]:
         """
         citation reference node
 

--- a/src/cript/nodes/subobjects/citation.py
+++ b/src/cript/nodes/subobjects/citation.py
@@ -4,6 +4,7 @@ from typing import Optional, Union
 from beartype import beartype
 
 from cript.nodes.primary_nodes.reference import Reference
+from cript.nodes.util.json import NodeUID
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -60,12 +61,12 @@ class Citation(UUIDBaseNode):
     @dataclass(frozen=True)
     class JsonAttributes(UUIDBaseNode.JsonAttributes):
         type: str = ""
-        reference: Optional[Reference] = None
+        reference: Optional[NodeUID[Reference]] = None
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
     @beartype
-    def __init__(self, type: str, reference: Reference, **kwargs):
+    def __init__(self, type: str, reference: NodeUID[Reference], **kwargs):
         """
         create a Citation subobject
 

--- a/src/cript/nodes/subobjects/computational_forcefield.py
+++ b/src/cript/nodes/subobjects/computational_forcefield.py
@@ -5,6 +5,7 @@ from beartype import beartype
 
 from cript.nodes.primary_nodes.data import Data
 from cript.nodes.subobjects.citation import Citation
+from cript.nodes.util.json import NodeUID
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -88,13 +89,24 @@ class ComputationalForcefield(UUIDBaseNode):
         implicit_solvent: str = ""
         source: str = ""
         description: str = ""
-        data: List[Data] = field(default_factory=list)
-        citation: List[Citation] = field(default_factory=list)
+        data: List[NodeUID[Data]] = field(default_factory=list)
+        citation: List[NodeUID[Citation]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
     @beartype
-    def __init__(self, key: str, building_block: str, coarse_grained_mapping: str = "", implicit_solvent: str = "", source: str = "", description: str = "", data: Optional[List[Data]] = None, citation: Optional[List[Citation]] = None, **kwargs):
+    def __init__(
+        self,
+        key: str,
+        building_block: str,
+        coarse_grained_mapping: str = "",
+        implicit_solvent: str = "",
+        source: str = "",
+        description: str = "",
+        data: Optional[List[NodeUID[Data]]] = None,
+        citation: Optional[List[NodeUID[Citation]]] = None,
+        **kwargs
+    ):
         """
         instantiate a computational_forcefield subobject
 

--- a/src/cript/nodes/subobjects/computational_forcefield.py
+++ b/src/cript/nodes/subobjects/computational_forcefield.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass, field, replace
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from beartype import beartype
 
 from cript.nodes.primary_nodes.data import Data
 from cript.nodes.subobjects.citation import Citation
-from cript.nodes.util.json import NodeUID
+from cript.nodes.util.json import UIDProxy
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -89,8 +89,8 @@ class ComputationalForcefield(UUIDBaseNode):
         implicit_solvent: str = ""
         source: str = ""
         description: str = ""
-        data: List[NodeUID[Data]] = field(default_factory=list)
-        citation: List[NodeUID[Citation]] = field(default_factory=list)
+        data: List[Union[Data, UIDProxy]] = field(default_factory=list)
+        citation: List[Union[Citation, UIDProxy]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
@@ -103,8 +103,8 @@ class ComputationalForcefield(UUIDBaseNode):
         implicit_solvent: str = "",
         source: str = "",
         description: str = "",
-        data: Optional[List[NodeUID[Data]]] = None,
-        citation: Optional[List[NodeUID[Citation]]] = None,
+        data: Optional[List[Union[Data, UIDProxy]]] = None,
+        citation: Optional[List[Union[Citation, UIDProxy]]] = None,
         **kwargs
     ):
         """
@@ -405,7 +405,7 @@ class ComputationalForcefield(UUIDBaseNode):
 
     @property
     @beartype
-    def data(self) -> List[Data]:
+    def data(self) -> List[Union[Data, UIDProxy]]:
         """
         details of mapping schema and forcefield parameters
 
@@ -438,7 +438,7 @@ class ComputationalForcefield(UUIDBaseNode):
 
     @data.setter
     @beartype
-    def data(self, new_data: List[Data]) -> None:
+    def data(self, new_data: List[Union[Data, UIDProxy]]) -> None:
         """
         set the data attribute of this computational_forcefield node
 
@@ -456,7 +456,7 @@ class ComputationalForcefield(UUIDBaseNode):
 
     @property
     @beartype
-    def citation(self) -> List[Citation]:
+    def citation(self) -> List[Union[Citation, UIDProxy]]:
         """
         reference to a book, paper, or scholarly work
 
@@ -495,7 +495,7 @@ class ComputationalForcefield(UUIDBaseNode):
 
     @citation.setter
     @beartype
-    def citation(self, new_citation: List[Citation]) -> None:
+    def citation(self, new_citation: List[Union[Citation, UIDProxy]]) -> None:
         """
         set the citation subobject of the computational_forcefield subobject
 

--- a/src/cript/nodes/subobjects/condition.py
+++ b/src/cript/nodes/subobjects/condition.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Union
 from beartype import beartype
 
 from cript.nodes.primary_nodes.data import Data
-from cript.nodes.util.json import NodeUID
+from cript.nodes.util.json import UIDProxy
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -87,7 +87,7 @@ class Condition(UUIDBaseNode):
         uncertainty_type: str = ""
         set_id: Optional[int] = None
         measurement_id: Optional[int] = None
-        data: List[NodeUID[Data]] = field(default_factory=list)
+        data: List[Union[Data, UIDProxy]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
@@ -103,7 +103,7 @@ class Condition(UUIDBaseNode):
         uncertainty_type: str = "",
         set_id: Optional[int] = None,
         measurement_id: Optional[int] = None,
-        data: Optional[List[NodeUID[Data]]] = None,
+        data: Optional[List[Union[Data, UIDProxy]]] = None,
         **kwargs
     ):
         """
@@ -505,7 +505,7 @@ class Condition(UUIDBaseNode):
 
     @property
     @beartype
-    def data(self) -> List[Data]:
+    def data(self) -> List[Union[Data, UIDProxy]]:
         """
         detailed data associated with the condition
 
@@ -540,7 +540,7 @@ class Condition(UUIDBaseNode):
 
     @data.setter
     @beartype
-    def data(self, new_data: List[Data]) -> None:
+    def data(self, new_data: List[Union[Data, UIDProxy]]) -> None:
         """
         set the data node for this Condition Subobject
 

--- a/src/cript/nodes/subobjects/condition.py
+++ b/src/cript/nodes/subobjects/condition.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Union
 from beartype import beartype
 
 from cript.nodes.primary_nodes.data import Data
+from cript.nodes.util.json import NodeUID
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -86,7 +87,7 @@ class Condition(UUIDBaseNode):
         uncertainty_type: str = ""
         set_id: Optional[int] = None
         measurement_id: Optional[int] = None
-        data: List[Data] = field(default_factory=list)
+        data: List[NodeUID[Data]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
@@ -102,7 +103,7 @@ class Condition(UUIDBaseNode):
         uncertainty_type: str = "",
         set_id: Optional[int] = None,
         measurement_id: Optional[int] = None,
-        data: Optional[List[Data]] = None,
+        data: Optional[List[NodeUID[Data]]] = None,
         **kwargs
     ):
         """

--- a/src/cript/nodes/subobjects/equipment.py
+++ b/src/cript/nodes/subobjects/equipment.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass, field, replace
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from beartype import beartype
 
 from cript.nodes.subobjects.citation import Citation
 from cript.nodes.subobjects.condition import Condition
 from cript.nodes.supporting_nodes.file import File
-from cript.nodes.util.json import NodeUID
+from cript.nodes.util.json import UIDProxy
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -54,14 +54,14 @@ class Equipment(UUIDBaseNode):
     class JsonAttributes(UUIDBaseNode.JsonAttributes):
         key: str = ""
         description: str = ""
-        condition: List[NodeUID[Condition]] = field(default_factory=list)
-        file: List[NodeUID[File]] = field(default_factory=list)
-        citation: List[NodeUID[Citation]] = field(default_factory=list)
+        condition: List[Union[Condition, UIDProxy]] = field(default_factory=list)
+        file: List[Union[File, UIDProxy]] = field(default_factory=list)
+        citation: List[Union[Citation, UIDProxy]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
     @beartype
-    def __init__(self, key: str, description: str = "", condition: Optional[List[NodeUID[Condition]]] = None, file: Optional[List[NodeUID[File]]] = None, citation: Optional[List[NodeUID[Citation]]] = None, **kwargs) -> None:
+    def __init__(self, key: str, description: str = "", condition: Optional[List[Union[Condition, UIDProxy]]] = None, file: Optional[List[Union[File, UIDProxy]]] = None, citation: Optional[List[Union[Citation, UIDProxy]]] = None, **kwargs) -> None:
         """
         create equipment sub-object
 
@@ -175,7 +175,7 @@ class Equipment(UUIDBaseNode):
 
     @property
     @beartype
-    def condition(self) -> List[Condition]:
+    def condition(self) -> List[Union[Condition, UIDProxy]]:
         """
         conditions under which the property was measured
 
@@ -200,7 +200,7 @@ class Equipment(UUIDBaseNode):
 
     @condition.setter
     @beartype
-    def condition(self, new_condition: List[Condition]) -> None:
+    def condition(self, new_condition: List[Union[Condition, UIDProxy]]) -> None:
         """
         set a list of Conditions for the equipment sub-object
 
@@ -218,7 +218,7 @@ class Equipment(UUIDBaseNode):
 
     @property
     @beartype
-    def file(self) -> List[File]:
+    def file(self) -> List[Union[File, UIDProxy]]:
         """
         list of file nodes to link to calibration or equipment specification documents
 
@@ -243,7 +243,7 @@ class Equipment(UUIDBaseNode):
 
     @file.setter
     @beartype
-    def file(self, new_file: List[File]) -> None:
+    def file(self, new_file: List[Union[File, UIDProxy]]) -> None:
         """
         set the file node for the equipment subobject
 
@@ -261,7 +261,7 @@ class Equipment(UUIDBaseNode):
 
     @property
     @beartype
-    def citation(self) -> List[Citation]:
+    def citation(self) -> List[Union[Citation, UIDProxy]]:
         """
         reference to a book, paper, or scholarly work
 
@@ -297,7 +297,7 @@ class Equipment(UUIDBaseNode):
 
     @citation.setter
     @beartype
-    def citation(self, new_citation: List[Citation]) -> None:
+    def citation(self, new_citation: List[Union[Citation, UIDProxy]]) -> None:
         """
         set the citation subobject for this equipment subobject
 

--- a/src/cript/nodes/subobjects/equipment.py
+++ b/src/cript/nodes/subobjects/equipment.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass, field, replace
-from typing import List, Union
+from typing import List, Optional
 
 from beartype import beartype
 
 from cript.nodes.subobjects.citation import Citation
 from cript.nodes.subobjects.condition import Condition
 from cript.nodes.supporting_nodes.file import File
+from cript.nodes.util.json import NodeUID
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -53,14 +54,14 @@ class Equipment(UUIDBaseNode):
     class JsonAttributes(UUIDBaseNode.JsonAttributes):
         key: str = ""
         description: str = ""
-        condition: List[Condition] = field(default_factory=list)
-        file: List[File] = field(default_factory=list)
-        citation: List[Citation] = field(default_factory=list)
+        condition: List[NodeUID[Condition]] = field(default_factory=list)
+        file: List[NodeUID[File]] = field(default_factory=list)
+        citation: List[NodeUID[Citation]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
     @beartype
-    def __init__(self, key: str, description: str = "", condition: Union[List[Condition], None] = None, file: Union[List[File], None] = None, citation: Union[List[Citation], None] = None, **kwargs) -> None:
+    def __init__(self, key: str, description: str = "", condition: Optional[List[NodeUID[Condition]]] = None, file: Optional[List[NodeUID[File]]] = None, citation: Optional[List[NodeUID[Citation]]] = None, **kwargs) -> None:
         """
         create equipment sub-object
 

--- a/src/cript/nodes/subobjects/ingredient.py
+++ b/src/cript/nodes/subobjects/ingredient.py
@@ -5,6 +5,7 @@ from beartype import beartype
 
 from cript.nodes.primary_nodes.material import Material
 from cript.nodes.subobjects.quantity import Quantity
+from cript.nodes.util.json import NodeUID
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -65,14 +66,14 @@ class Ingredient(UUIDBaseNode):
 
     @dataclass(frozen=True)
     class JsonAttributes(UUIDBaseNode.JsonAttributes):
-        material: Optional[Material] = None
-        quantity: List[Quantity] = field(default_factory=list)
+        material: Optional[NodeUID[Material]] = None
+        quantity: List[NodeUID[Quantity]] = field(default_factory=list)
         keyword: List[str] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
     @beartype
-    def __init__(self, material: Material, quantity: List[Quantity], keyword: Optional[List[str]] = None, **kwargs):
+    def __init__(self, material: NodeUID[Material], quantity: List[NodeUID[Quantity]], keyword: Optional[List[str]] = None, **kwargs):
         """
         create an ingredient sub-object
 

--- a/src/cript/nodes/subobjects/ingredient.py
+++ b/src/cript/nodes/subobjects/ingredient.py
@@ -5,7 +5,7 @@ from beartype import beartype
 
 from cript.nodes.primary_nodes.material import Material
 from cript.nodes.subobjects.quantity import Quantity
-from cript.nodes.util.json import NodeUID
+from cript.nodes.util.json import UIDProxy
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -66,14 +66,14 @@ class Ingredient(UUIDBaseNode):
 
     @dataclass(frozen=True)
     class JsonAttributes(UUIDBaseNode.JsonAttributes):
-        material: Optional[NodeUID[Material]] = None
-        quantity: List[NodeUID[Quantity]] = field(default_factory=list)
+        material: Optional[Union[Material, UIDProxy]] = None
+        quantity: List[Union[Quantity, UIDProxy]] = field(default_factory=list)
         keyword: List[str] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
     @beartype
-    def __init__(self, material: NodeUID[Material], quantity: List[NodeUID[Quantity]], keyword: Optional[List[str]] = None, **kwargs):
+    def __init__(self, material: Union[Material, UIDProxy], quantity: List[Union[Quantity, UIDProxy]], keyword: Optional[List[str]] = None, **kwargs):
         """
         create an ingredient sub-object
 
@@ -118,7 +118,7 @@ class Ingredient(UUIDBaseNode):
 
     @property
     @beartype
-    def material(self) -> Union[Material, None]:
+    def material(self) -> Union[Material, None, UIDProxy]:
         """
         current material in this ingredient sub-object
 
@@ -131,7 +131,7 @@ class Ingredient(UUIDBaseNode):
 
     @property
     @beartype
-    def quantity(self) -> List[Quantity]:
+    def quantity(self) -> List[Union[Quantity, UIDProxy]]:
         """
         quantity for the ingredient sub-object
 
@@ -143,7 +143,7 @@ class Ingredient(UUIDBaseNode):
         return self._json_attrs.quantity.copy()
 
     @beartype
-    def set_material(self, new_material: Material, new_quantity: List[Quantity]) -> None:
+    def set_material(self, new_material: Union[Material, UIDProxy], new_quantity: List[Union[Quantity, UIDProxy]]) -> None:
         """
         update ingredient sub-object with new material and new list of quantities
 

--- a/src/cript/nodes/subobjects/property.py
+++ b/src/cript/nodes/subobjects/property.py
@@ -10,7 +10,7 @@ from cript.nodes.primary_nodes.material import Material
 from cript.nodes.primary_nodes.process import Process
 from cript.nodes.subobjects.citation import Citation
 from cript.nodes.subobjects.condition import Condition
-from cript.nodes.util.json import NodeUID
+from cript.nodes.util.json import UIDProxy
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -77,14 +77,14 @@ class Property(UUIDBaseNode):
         unit: Optional[str] = ""
         uncertainty: Optional[Number] = None
         uncertainty_type: str = ""
-        component: List[NodeUID[Material]] = field(default_factory=list)
+        component: List[Union[Material, UIDProxy]] = field(default_factory=list)
         structure: str = ""
         method: str = ""
-        sample_preparation: Optional[NodeUID[Process]] = None
-        condition: List[NodeUID[Condition]] = field(default_factory=list)
-        data: List[Data] = field(default_factory=list)
-        computation: List[NodeUID[Computation]] = field(default_factory=list)
-        citation: List[NodeUID[Citation]] = field(default_factory=list)
+        sample_preparation: Optional[Union[Process, UIDProxy]] = None
+        condition: List[Union[Condition, UIDProxy]] = field(default_factory=list)
+        data: List[Union[Data, UIDProxy]] = field(default_factory=list)
+        computation: List[Union[Computation, UIDProxy]] = field(default_factory=list)
+        citation: List[Union[Citation, UIDProxy]] = field(default_factory=list)
         notes: str = ""
 
     _json_attrs: JsonAttributes = JsonAttributes()
@@ -98,14 +98,14 @@ class Property(UUIDBaseNode):
         unit: Union[str, None],
         uncertainty: Optional[Number] = None,
         uncertainty_type: str = "",
-        component: Optional[List[NodeUID[Material]]] = None,
+        component: Optional[List[Union[Material, UIDProxy]]] = None,
         structure: str = "",
         method: str = "",
-        sample_preparation: Optional[NodeUID[Process]] = None,
-        condition: Optional[List[NodeUID[Condition]]] = None,
-        data: Optional[List[NodeUID[Data]]] = None,
-        computation: Optional[List[NodeUID[Computation]]] = None,
-        citation: Optional[List[NodeUID[Citation]]] = None,
+        sample_preparation: Optional[Union[Process, UIDProxy]] = None,
+        condition: Optional[List[Union[Condition, UIDProxy]]] = None,
+        data: Optional[List[Union[Data, UIDProxy]]] = None,
+        computation: Optional[List[Union[Computation, UIDProxy]]] = None,
+        citation: Optional[List[Union[Citation, UIDProxy]]] = None,
         notes: str = "",
         **kwargs
     ):
@@ -373,7 +373,7 @@ class Property(UUIDBaseNode):
 
     @property
     @beartype
-    def component(self) -> List[Material]:
+    def component(self) -> List[Union[Material, UIDProxy]]:
         """
         list of Materials that the Property relates to
 
@@ -393,7 +393,7 @@ class Property(UUIDBaseNode):
 
     @component.setter
     @beartype
-    def component(self, new_component: List[Material]) -> None:
+    def component(self, new_component: List[Union[Material, UIDProxy]]) -> None:
         """
         set the list of Materials as components for the Property subobject
 
@@ -487,7 +487,7 @@ class Property(UUIDBaseNode):
 
     @property
     @beartype
-    def sample_preparation(self) -> Union[Process, None]:
+    def sample_preparation(self) -> Union[Process, None, UIDProxy]:
         """
         sample_preparation
 
@@ -507,7 +507,7 @@ class Property(UUIDBaseNode):
 
     @sample_preparation.setter
     @beartype
-    def sample_preparation(self, new_sample_preparation: Union[Process, None]) -> None:
+    def sample_preparation(self, new_sample_preparation: Union[Process, None, UIDProxy]) -> None:
         """
         set the sample_preparation for the Property subobject
 
@@ -525,7 +525,7 @@ class Property(UUIDBaseNode):
 
     @property
     @beartype
-    def condition(self) -> List[Condition]:
+    def condition(self) -> List[Union[Condition, UIDProxy]]:
         """
         list of Conditions under which the property was measured
 
@@ -545,7 +545,7 @@ class Property(UUIDBaseNode):
 
     @condition.setter
     @beartype
-    def condition(self, new_condition: List[Condition]) -> None:
+    def condition(self, new_condition: List[Union[Condition, UIDProxy]]) -> None:
         """
         set the list of Conditions for this property subobject
 
@@ -563,7 +563,7 @@ class Property(UUIDBaseNode):
 
     @property
     @beartype
-    def data(self) -> List[Data]:
+    def data(self) -> List[Union[Data, UIDProxy]]:
         """
         List of Data nodes for this Property subobjects
 
@@ -590,7 +590,7 @@ class Property(UUIDBaseNode):
 
     @data.setter
     @beartype
-    def data(self, new_data: List[Data]) -> None:
+    def data(self, new_data: List[Union[Data, UIDProxy]]) -> None:
         """
         set the Data node for the Property subobject
 
@@ -608,7 +608,7 @@ class Property(UUIDBaseNode):
 
     @property
     @beartype
-    def computation(self) -> List[Computation]:
+    def computation(self) -> List[Union[Computation, UIDProxy]]:
         """
         list of Computation nodes that produced this property
 
@@ -628,7 +628,7 @@ class Property(UUIDBaseNode):
 
     @computation.setter
     @beartype
-    def computation(self, new_computation: List[Computation]) -> None:
+    def computation(self, new_computation: List[Union[Computation, UIDProxy]]) -> None:
         """
         set the list of Computation nodes that produced this property
 
@@ -646,7 +646,7 @@ class Property(UUIDBaseNode):
 
     @property
     @beartype
-    def citation(self) -> List[Citation]:
+    def citation(self) -> List[Union[Citation, UIDProxy]]:
         """
         list of Citation subobjects for this Property subobject
 
@@ -682,7 +682,7 @@ class Property(UUIDBaseNode):
 
     @citation.setter
     @beartype
-    def citation(self, new_citation: List[Citation]) -> None:
+    def citation(self, new_citation: List[Union[Citation, UIDProxy]]) -> None:
         """
         set the list of Citation subobjects for the Property subobject
 

--- a/src/cript/nodes/subobjects/property.py
+++ b/src/cript/nodes/subobjects/property.py
@@ -10,6 +10,7 @@ from cript.nodes.primary_nodes.material import Material
 from cript.nodes.primary_nodes.process import Process
 from cript.nodes.subobjects.citation import Citation
 from cript.nodes.subobjects.condition import Condition
+from cript.nodes.util.json import NodeUID
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -76,14 +77,14 @@ class Property(UUIDBaseNode):
         unit: Optional[str] = ""
         uncertainty: Optional[Number] = None
         uncertainty_type: str = ""
-        component: List[Material] = field(default_factory=list)
+        component: List[NodeUID[Material]] = field(default_factory=list)
         structure: str = ""
         method: str = ""
-        sample_preparation: Optional[Process] = None
-        condition: List[Condition] = field(default_factory=list)
+        sample_preparation: Optional[NodeUID[Process]] = None
+        condition: List[NodeUID[Condition]] = field(default_factory=list)
         data: List[Data] = field(default_factory=list)
-        computation: List[Computation] = field(default_factory=list)
-        citation: List[Citation] = field(default_factory=list)
+        computation: List[NodeUID[Computation]] = field(default_factory=list)
+        citation: List[NodeUID[Citation]] = field(default_factory=list)
         notes: str = ""
 
     _json_attrs: JsonAttributes = JsonAttributes()
@@ -97,14 +98,14 @@ class Property(UUIDBaseNode):
         unit: Union[str, None],
         uncertainty: Optional[Number] = None,
         uncertainty_type: str = "",
-        component: Optional[List[Material]] = None,
+        component: Optional[List[NodeUID[Material]]] = None,
         structure: str = "",
         method: str = "",
-        sample_preparation: Optional[Process] = None,
-        condition: Optional[List[Condition]] = None,
-        data: Optional[List[Data]] = None,
-        computation: Optional[List[Computation]] = None,
-        citation: Optional[List[Citation]] = None,
+        sample_preparation: Optional[NodeUID[Process]] = None,
+        condition: Optional[List[NodeUID[Condition]]] = None,
+        data: Optional[List[NodeUID[Data]]] = None,
+        computation: Optional[List[NodeUID[Computation]]] = None,
+        citation: Optional[List[NodeUID[Citation]]] = None,
         notes: str = "",
         **kwargs
     ):

--- a/src/cript/nodes/subobjects/software_configuration.py
+++ b/src/cript/nodes/subobjects/software_configuration.py
@@ -6,7 +6,7 @@ from beartype import beartype
 from cript.nodes.subobjects.algorithm import Algorithm
 from cript.nodes.subobjects.citation import Citation
 from cript.nodes.subobjects.software import Software
-from cript.nodes.util.json import NodeUID
+from cript.nodes.util.json import UIDProxy
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -58,15 +58,15 @@ class SoftwareConfiguration(UUIDBaseNode):
 
     @dataclass(frozen=True)
     class JsonAttributes(UUIDBaseNode.JsonAttributes):
-        software: Optional[NodeUID[Software]] = None
-        algorithm: List[NodeUID[Algorithm]] = field(default_factory=list)
+        software: Optional[Union[Software, UIDProxy]] = None
+        algorithm: List[Union[Algorithm, UIDProxy]] = field(default_factory=list)
         notes: str = ""
-        citation: List[NodeUID[Citation]] = field(default_factory=list)
+        citation: List[Union[Citation, UIDProxy]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
     @beartype
-    def __init__(self, software: NodeUID[Software], algorithm: Optional[List[NodeUID[Algorithm]]] = None, notes: str = "", citation: Union[List[NodeUID[Citation]], None] = None, **kwargs):
+    def __init__(self, software: Union[Software, UIDProxy], algorithm: Optional[List[Union[Algorithm, UIDProxy]]] = None, notes: str = "", citation: Union[List[Union[Citation, UIDProxy]], None] = None, **kwargs):
         """
         Create Software_Configuration sub-object
 
@@ -103,7 +103,7 @@ class SoftwareConfiguration(UUIDBaseNode):
 
     @property
     @beartype
-    def software(self) -> Union[Software, None]:
+    def software(self) -> Union[Software, None, UIDProxy]:
         """
         Software used
 
@@ -123,7 +123,7 @@ class SoftwareConfiguration(UUIDBaseNode):
 
     @software.setter
     @beartype
-    def software(self, new_software: Union[Software, None]) -> None:
+    def software(self, new_software: Union[Software, None, UIDProxy]) -> None:
         """
         set the Software used
 
@@ -141,7 +141,7 @@ class SoftwareConfiguration(UUIDBaseNode):
 
     @property
     @beartype
-    def algorithm(self) -> List[Algorithm]:
+    def algorithm(self) -> List[Union[Algorithm, UIDProxy]]:
         """
         list of Algorithms used
 
@@ -162,7 +162,7 @@ class SoftwareConfiguration(UUIDBaseNode):
 
     @algorithm.setter
     @beartype
-    def algorithm(self, new_algorithm: List[Algorithm]) -> None:
+    def algorithm(self, new_algorithm: List[Union[Algorithm, UIDProxy]]) -> None:
         """
         set the list of Algorithms
 
@@ -225,7 +225,7 @@ class SoftwareConfiguration(UUIDBaseNode):
 
     @property
     @beartype
-    def citation(self) -> List[Citation]:
+    def citation(self) -> List[Union[Citation, UIDProxy]]:
         """
         list of Citation sub-objects for the Software_Configuration
 
@@ -262,7 +262,7 @@ class SoftwareConfiguration(UUIDBaseNode):
 
     @citation.setter
     @beartype
-    def citation(self, new_citation: List[Citation]) -> None:
+    def citation(self, new_citation: List[Union[Citation, UIDProxy]]) -> None:
         """
         set the Citation sub-object
 

--- a/src/cript/nodes/subobjects/software_configuration.py
+++ b/src/cript/nodes/subobjects/software_configuration.py
@@ -6,6 +6,7 @@ from beartype import beartype
 from cript.nodes.subobjects.algorithm import Algorithm
 from cript.nodes.subobjects.citation import Citation
 from cript.nodes.subobjects.software import Software
+from cript.nodes.util.json import NodeUID
 from cript.nodes.uuid_base import UUIDBaseNode
 
 
@@ -57,15 +58,15 @@ class SoftwareConfiguration(UUIDBaseNode):
 
     @dataclass(frozen=True)
     class JsonAttributes(UUIDBaseNode.JsonAttributes):
-        software: Union[Software, None] = None
-        algorithm: List[Algorithm] = field(default_factory=list)
+        software: Optional[NodeUID[Software]] = None
+        algorithm: List[NodeUID[Algorithm]] = field(default_factory=list)
         notes: str = ""
-        citation: List[Citation] = field(default_factory=list)
+        citation: List[NodeUID[Citation]] = field(default_factory=list)
 
     _json_attrs: JsonAttributes = JsonAttributes()
 
     @beartype
-    def __init__(self, software: Software, algorithm: Optional[List[Algorithm]] = None, notes: str = "", citation: Union[List[Citation], None] = None, **kwargs):
+    def __init__(self, software: NodeUID[Software], algorithm: Optional[List[NodeUID[Algorithm]]] = None, notes: str = "", citation: Union[List[NodeUID[Citation]], None] = None, **kwargs):
         """
         Create Software_Configuration sub-object
 

--- a/src/cript/nodes/util/core.py
+++ b/src/cript/nodes/util/core.py
@@ -67,3 +67,16 @@ def get_orphaned_experiment_exception(orphaned_node):
         return CRIPTOrphanedComputationalProcessError(orphaned_node)
     # Base case raise the parent exception. TODO add bug warning.
     return CRIPTOrphanedExperimentError(orphaned_node)
+
+
+def iterate_leaves(obj):
+    """Helper function that iterates over all leaves of nested dictionaries or lists."""
+
+    if isinstance(obj, dict):
+        for value in obj.values():
+            yield from iterate_leaves(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from iterate_leaves(item)
+    else:
+        yield obj

--- a/src/cript/nodes/util/json.py
+++ b/src/cript/nodes/util/json.py
@@ -5,7 +5,7 @@ import dataclasses
 import inspect
 import json
 import uuid
-from typing import Dict, List, Optional, Set, Union, _SpecialForm, _type_check
+from typing import Dict, List, Optional, Set, Union
 
 import cript.nodes
 from cript.nodes.core import BaseNode
@@ -215,13 +215,6 @@ class NodeEncoder(json.JSONEncoder):
         return serialize_dict, uid_of_condensed
 
 
-@_SpecialForm
-def NodeUID(self, parameters):
-    """Node[X] is equivalent to Union[X, UIDProxy]. (Implementation from CPython.typing.Optional)"""
-    arg = _type_check(parameters, f"{self} requires a single type.")
-    return Union[arg, UIDProxy]
-
-
 class _NodeDecoderHook:
     def __init__(self, uid_cache: Optional[Dict] = None):
         """
@@ -247,7 +240,7 @@ class _NodeDecoderHook:
     def uid_cache(self):
         return self._uid_cache
 
-    def __call__(self, node_str: Union[Dict, str]) -> Dict:
+    def __call__(self, node_str: Union[Dict, str]) -> Union[Dict, UIDProxy]:
         """
         Internal function, used as a hook for json deserialization.
 

--- a/tests/fixtures/primary_nodes.py
+++ b/tests/fixtures/primary_nodes.py
@@ -48,6 +48,387 @@ def complex_project_node(complex_project_dict) -> cript.Project:
 
 
 @pytest.fixture(scope="function")
+def fixed_cyclic_project_node() -> cript.Project:
+    project_json_string: str = "{\n"
+    project_json_string += '"node": ["Project"],\n'
+    project_json_string += '"uid": "_:0e487131-1dbf-4c6c-9ee0-650df148b06e",\n'
+    project_json_string += '"uuid": "55a41f23-4791-4dc7-bf2c-48fd2b6fc90b",\n'
+    project_json_string += '"updated_by": {\n'
+    project_json_string += '"node": ["User"],\n'
+    project_json_string += '"uid": "_:5838e9cc-f01d-468e-96de-93bfe6fb758f",\n'
+    project_json_string += '"uuid": "5838e9cc-f01d-468e-96de-93bfe6fb758f",\n'
+    project_json_string += '"created_at": "2024-03-12 15:58:12.486673",\n'
+    project_json_string += '"updated_at": "2024-03-12 15:58:12.486681",\n'
+    project_json_string += '"email": "test@emai.com",\n'
+    project_json_string += '"model_version": "1.0.0",\n'
+    project_json_string += '"orcid": "0000-0002-0000-0000",\n'
+    project_json_string += '"picture": "/my/picture/path",\n'
+    project_json_string += '"username": "testuser"\n'
+    project_json_string += "},\n"
+    project_json_string += '"created_by": {\n'
+    project_json_string += '"node": ["User"],\n'
+    project_json_string += '"uid": "_:2bb1fc16-6e72-480d-a3df-b74eac4d32e8",\n'
+    project_json_string += '"uuid": "ab385d26-6ee5-40d4-9095-2d623616a162",\n'
+    project_json_string += '"created_at": "2024-03-12 15:58:12.486673",\n'
+    project_json_string += '"updated_at": "2024-03-12 15:58:12.486681",\n'
+    project_json_string += '"email": "test@emai.com",\n'
+    project_json_string += '"model_version": "1.0.0",\n'
+    project_json_string += '"orcid": "0000-0002-0000-0000",\n'
+    project_json_string += '"picture": "/my/picture/path",\n'
+    project_json_string += '"username": "testuser"\n'
+    project_json_string += "},\n"
+    project_json_string += '"locked": true,\n'
+    project_json_string += '"model_version": "1.0.0",\n'
+    project_json_string += '"public": true,\n'
+    project_json_string += '"name": "my project name",\n'
+    project_json_string += '"notes": "my project notes",\n'
+    project_json_string += '"member": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"uid": "_:2bb1fc16-6e72-480d-a3df-b74eac4d32e8"\n'
+    project_json_string += "}\n"
+    project_json_string += "],\n"
+    project_json_string += '"admin": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"uid": "_:2bb1fc16-6e72-480d-a3df-b74eac4d32e8"\n'
+    project_json_string += "}\n"
+    project_json_string += "],\n"
+    project_json_string += '"collection": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"node": ["Collection"],\n'
+    project_json_string += '"uid": "_:61a99328-108b-4307-bfcb-fccd12a5dd91",\n'
+    project_json_string += '"uuid": "61a99328-108b-4307-bfcb-fccd12a5dd91",\n'
+    project_json_string += '"name": "my complex collection name",\n'
+    project_json_string += '"experiment": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"node": ["Experiment"],\n'
+    project_json_string += '"uid": "_:d2b3169d-c200-4143-811a-a0d07439dd96",\n'
+    project_json_string += '"uuid": "d2b3169d-c200-4143-811a-a0d07439dd96",\n'
+    project_json_string += '"name": "my experiment name",\n'
+    project_json_string += '"process": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"node": ["Process"],\n'
+    project_json_string += '"uid": "_:5d649b93-8f2c-4509-9aa7-311213df9405",\n'
+    project_json_string += '"uuid": "5d649b93-8f2c-4509-9aa7-311213df9405",\n'
+    project_json_string += '"name": "my process name",\n'
+    project_json_string += '"type": "affinity_pure",\n'
+    project_json_string += '"ingredient": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"node": ["Ingredient"],\n'
+    project_json_string += '"uid": "_:21601ad5-c225-4626-8baa-3a7c1d64cafa",\n'
+    project_json_string += '"uuid": "21601ad5-c225-4626-8baa-3a7c1d64cafa",\n'
+    project_json_string += '"material": {\n'
+    project_json_string += '"node": ["Material"],\n'
+    project_json_string += '"uid": "_:ea9ad3e7-84a7-475f-82a8-16f5b9241e37",\n'
+    project_json_string += '"uuid": "ea9ad3e7-84a7-475f-82a8-16f5b9241e37",\n'
+    project_json_string += '"name": "my test material 9221be1d-247c-4f67-8a0a-fe1ec657705b",\n'
+    project_json_string += '"property": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"node": ["Property"],\n'
+    project_json_string += '"uid": "_:fc504202-6fdd-43c7-830d-40c7d3f0cb8c",\n'
+    project_json_string += '"uuid": "fc504202-6fdd-43c7-830d-40c7d3f0cb8c",\n'
+    project_json_string += '"key": "modulus_shear",\n'
+    project_json_string += '"type": "value",\n'
+    project_json_string += '"value": 5.0,\n'
+    project_json_string += '"unit": "GPa",\n'
+    project_json_string += '"computation": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"node": ["Computation"],\n'
+    project_json_string += '"uid": "_:175708fa-cc29-4442-be7f-adf85e995330",\n'
+    project_json_string += '"uuid": "175708fa-cc29-4442-be7f-adf85e995330",\n'
+    project_json_string += '"name": "my computation name",\n'
+    project_json_string += '"type": "analysis",\n'
+    project_json_string += '"input_data": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"node": ["Data"],\n'
+    project_json_string += '"uid": "_:dcb516a1-951d-461a-beb6-bdf2aecd0778",\n'
+    project_json_string += '"uuid": "dcb516a1-951d-461a-beb6-bdf2aecd0778",\n'
+    project_json_string += '"name": "my data name",\n'
+    project_json_string += '"type": "afm_amp",\n'
+    project_json_string += '"file": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"node": ["File"],\n'
+    project_json_string += '"uid": "_:c94aba31-adf2-4eeb-b51e-8c70568c2eb0",\n'
+    project_json_string += '"uuid": "c94aba31-adf2-4eeb-b51e-8c70568c2eb0",\n'
+    project_json_string += '"name": "my complex file node fixture",\n'
+    project_json_string += '"source": "https://criptapp.org",\n'
+    project_json_string += '"type": "calibration",\n'
+    project_json_string += '"extension": ".csv",\n'
+    project_json_string += '"data_dictionary": "my file\'s data dictionary"\n'
+    project_json_string += "}\n"
+    project_json_string += "]\n"
+    project_json_string += "}\n"
+    project_json_string += "],\n"
+    project_json_string += '"output_data": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"node": ["Data"],\n'
+    project_json_string += '"uid": "_:6a2e81af-861b-4c66-96fd-b969a38b81b1",\n'
+    project_json_string += '"uuid": "6a2e81af-861b-4c66-96fd-b969a38b81b1",\n'
+    project_json_string += '"name": "my data name",\n'
+    project_json_string += '"type": "afm_amp",\n'
+    project_json_string += '"file": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"node": ["File"],\n'
+    project_json_string += '"uid": "_:ce01ba93-cfc5-4265-a6d6-8c38397deb43",\n'
+    project_json_string += '"uuid": "ce01ba93-cfc5-4265-a6d6-8c38397deb43",\n'
+    project_json_string += '"name": "my complex file node fixture",\n'
+    project_json_string += '"source": "https://criptapp.org",\n'
+    project_json_string += '"type": "calibration",\n'
+    project_json_string += '"extension": ".csv",\n'
+    project_json_string += '"data_dictionary": "my file\'s data dictionary"\n'
+    project_json_string += "}\n"
+    project_json_string += "]\n"
+    project_json_string += "}\n"
+    project_json_string += "]\n"
+    project_json_string += "},\n"
+    project_json_string += "{\n"
+    project_json_string += '"node": ["Computation"],\n'
+    project_json_string += '"uid": "_:1aa11462-b394-4c35-906e-d0e9198be6da",\n'
+    project_json_string += '"uuid": "1aa11462-b394-4c35-906e-d0e9198be6da",\n'
+    project_json_string += '"name": "my computation name",\n'
+    project_json_string += '"type": "analysis",\n'
+    project_json_string += '"input_data": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"uid": "_:dcb516a1-951d-461a-beb6-bdf2aecd0778"\n'
+    project_json_string += "}\n"
+    project_json_string += "],\n"
+    project_json_string += '"output_data": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"uid": "_:6a2e81af-861b-4c66-96fd-b969a38b81b1"\n'
+    project_json_string += "}\n"
+    project_json_string += "]\n"
+    project_json_string += "}\n"
+    project_json_string += "]\n"
+    project_json_string += "}\n"
+    project_json_string += "],\n"
+    project_json_string += '"parent_material": {\n'
+    project_json_string += '"node": ["Material"],\n'
+    project_json_string += '"uid": "_:2ee56671-5efb-4f99-a7ea-d659f5b5dd9a",\n'
+    project_json_string += '"uuid": "2ee56671-5efb-4f99-a7ea-d659f5b5dd9a",\n'
+    project_json_string += '"name": "my test material 9221be1d-247c-4f67-8a0a-fe1ec657705b",\n'
+    project_json_string += '"process": {\n'
+    project_json_string += '"uid": "_:5d649b93-8f2c-4509-9aa7-311213df9405"\n'
+    project_json_string += "},\n"
+    project_json_string += '"property": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"node": ["Property"],\n'
+    project_json_string += '"uid": "_:fde629f5-8d3a-4546-8cd3-9de63b990187",\n'
+    project_json_string += '"uuid": "fde629f5-8d3a-4546-8cd3-9de63b990187",\n'
+    project_json_string += '"key": "modulus_shear",\n'
+    project_json_string += '"type": "value",\n'
+    project_json_string += '"value": 5.0,\n'
+    project_json_string += '"unit": "GPa",\n'
+    project_json_string += '"computation": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"node": ["Computation"],\n'
+    project_json_string += '"uid": "_:2818ed85-2758-45f9-9f30-5c3dfedd3d33",\n'
+    project_json_string += '"uuid": "2818ed85-2758-45f9-9f30-5c3dfedd3d33",\n'
+    project_json_string += '"name": "my computation name",\n'
+    project_json_string += '"type": "analysis",\n'
+    project_json_string += '"input_data": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"node": ["Data"],\n'
+    project_json_string += '"uid": "_:0a88e09d-488f-45ed-ad9c-14873792b8fd",\n'
+    project_json_string += '"uuid": "0a88e09d-488f-45ed-ad9c-14873792b8fd",\n'
+    project_json_string += '"name": "my data name",\n'
+    project_json_string += '"type": "afm_amp",\n'
+    project_json_string += '"file": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"node": ["File"],\n'
+    project_json_string += '"uid": "_:1fc95012-2845-46ac-a8e3-7178fe19afcd",\n'
+    project_json_string += '"uuid": "1fc95012-2845-46ac-a8e3-7178fe19afcd",\n'
+    project_json_string += '"name": "my complex file node fixture",\n'
+    project_json_string += '"source": "https://criptapp.org",\n'
+    project_json_string += '"type": "calibration",\n'
+    project_json_string += '"extension": ".csv",\n'
+    project_json_string += '"data_dictionary": "my file\'s data dictionary"\n'
+    project_json_string += "}\n"
+    project_json_string += "]\n"
+    project_json_string += "}\n"
+    project_json_string += "],\n"
+    project_json_string += '"output_data": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"node": ["Data"],\n'
+    project_json_string += '"uid": "_:309b0d7b-027c-4422-ab5f-58069fe4adb1",\n'
+    project_json_string += '"uuid": "309b0d7b-027c-4422-ab5f-58069fe4adb1",\n'
+    project_json_string += '"name": "my data name",\n'
+    project_json_string += '"type": "afm_amp",\n'
+    project_json_string += '"file": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"node": ["File"],\n'
+    project_json_string += '"uid": "_:e78cf3cf-de6c-4364-93c4-4fb3d352bde2",\n'
+    project_json_string += '"uuid": "e78cf3cf-de6c-4364-93c4-4fb3d352bde2",\n'
+    project_json_string += '"name": "my complex file node fixture",\n'
+    project_json_string += '"source": "https://criptapp.org",\n'
+    project_json_string += '"type": "calibration",\n'
+    project_json_string += '"extension": ".csv",\n'
+    project_json_string += '"data_dictionary": "my file\'s data dictionary"\n'
+    project_json_string += "}\n"
+    project_json_string += "]\n"
+    project_json_string += "}\n"
+    project_json_string += "]\n"
+    project_json_string += "},\n"
+    project_json_string += "{\n"
+    project_json_string += '"node": ["Computation"],\n'
+    project_json_string += '"uid": "_:09cf72a4-a397-4953-baa6-7cdf5be067c4",\n'
+    project_json_string += '"uuid": "09cf72a4-a397-4953-baa6-7cdf5be067c4",\n'
+    project_json_string += '"name": "my computation name",\n'
+    project_json_string += '"type": "analysis",\n'
+    project_json_string += '"input_data": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"uid": "_:0a88e09d-488f-45ed-ad9c-14873792b8fd"\n'
+    project_json_string += "}\n"
+    project_json_string += "],\n"
+    project_json_string += '"output_data": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"uid": "_:309b0d7b-027c-4422-ab5f-58069fe4adb1"\n'
+    project_json_string += "}\n"
+    project_json_string += "]\n"
+    project_json_string += "}\n"
+    project_json_string += "]\n"
+    project_json_string += "}\n"
+    project_json_string += "],\n"
+    project_json_string += '"bigsmiles": "{[][$]COC[$][]}"\n'
+    project_json_string += "},\n"
+    project_json_string += '"bigsmiles": "{[][$]COC[$][]}"\n'
+    project_json_string += "}\n"
+    project_json_string += "}\n"
+    project_json_string += "],\n"
+    project_json_string += '"product": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"uid": "_:ea9ad3e7-84a7-475f-82a8-16f5b9241e37"\n'
+    project_json_string += "}\n"
+    project_json_string += "]\n"
+    project_json_string += "}\n"
+    project_json_string += "],\n"
+    project_json_string += '"computation": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"uid": "_:2818ed85-2758-45f9-9f30-5c3dfedd3d33"\n'
+    project_json_string += "},\n"
+    project_json_string += "{\n"
+    project_json_string += '"uid": "_:09cf72a4-a397-4953-baa6-7cdf5be067c4"\n'
+    project_json_string += "},\n"
+    project_json_string += "{\n"
+    project_json_string += '"uid": "_:175708fa-cc29-4442-be7f-adf85e995330"\n'
+    project_json_string += "},\n"
+    project_json_string += "{\n"
+    project_json_string += '"uid": "_:1aa11462-b394-4c35-906e-d0e9198be6da"\n'
+    project_json_string += "}\n"
+    project_json_string += "],\n"
+    project_json_string += '"data": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"uid": "_:0a88e09d-488f-45ed-ad9c-14873792b8fd"\n'
+    project_json_string += "},\n"
+    project_json_string += "{\n"
+    project_json_string += '"uid": "_:309b0d7b-027c-4422-ab5f-58069fe4adb1"\n'
+    project_json_string += "},\n"
+    project_json_string += "{\n"
+    project_json_string += '"uid": "_:dcb516a1-951d-461a-beb6-bdf2aecd0778"\n'
+    project_json_string += "},\n"
+    project_json_string += "{\n"
+    project_json_string += '"uid": "_:6a2e81af-861b-4c66-96fd-b969a38b81b1"\n'
+    project_json_string += "}\n"
+    project_json_string += "]\n"
+    project_json_string += "}\n"
+    project_json_string += "],\n"
+    project_json_string += '"inventory": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"node": ["Inventory"],\n'
+    project_json_string += '"uid": "_:1ff50987-e0a2-4aa3-a1a2-bdcefd54693d",\n'
+    project_json_string += '"uuid": "1ff50987-e0a2-4aa3-a1a2-bdcefd54693d",\n'
+    project_json_string += '"name": "my inventory name",\n'
+    project_json_string += '"material": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"uid": "_:ea9ad3e7-84a7-475f-82a8-16f5b9241e37"\n'
+    project_json_string += "},\n"
+    project_json_string += "{\n"
+    project_json_string += '"node": ["Material"],\n'
+    project_json_string += '"uid": "_:845c90c1-5a93-416f-9c42-1bac1de0bd9a",\n'
+    project_json_string += '"uuid": "845c90c1-5a93-416f-9c42-1bac1de0bd9a",\n'
+    project_json_string += '"name": "material 2 730f2483-f018-4583-82d3-beb27947d470",\n'
+    project_json_string += '"process": {\n'
+    project_json_string += '"uid": "_:5d649b93-8f2c-4509-9aa7-311213df9405"\n'
+    project_json_string += "},\n"
+    project_json_string += '"property": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"uid": "_:fc504202-6fdd-43c7-830d-40c7d3f0cb8c"\n'
+    project_json_string += "}\n"
+    project_json_string += "],\n"
+    project_json_string += '"bigsmiles": "{[][$]COC[$][]}"\n'
+    project_json_string += "}\n"
+    project_json_string += "]\n"
+    project_json_string += "}\n"
+    project_json_string += "],\n"
+    project_json_string += '"doi": "10.1038/1781168a0",\n'
+    project_json_string += '"citation": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"node": ["Citation"],\n'
+    project_json_string += '"uid": "_:1232d7be-d870-4357-bf41-f53a09707cca",\n'
+    project_json_string += '"uuid": "1232d7be-d870-4357-bf41-f53a09707cca",\n'
+    project_json_string += '"type": "reference",\n'
+    project_json_string += '"reference": {\n'
+    project_json_string += '"node": ["Reference"],\n'
+    project_json_string += '"uid": "_:3fb7801f-7253-4d6b-813b-f1d2d25b6316",\n'
+    project_json_string += '"uuid": "3fb7801f-7253-4d6b-813b-f1d2d25b6316",\n'
+    project_json_string += '"type": "journal_article",\n'
+    project_json_string += '"title": "Multi-architecture Monte-Carlo (MC) simulation of soft coarse-grained polymeric materials: SOft coarse grained Monte-Carlo Acceleration (SOMA)",\n'
+    project_json_string += '"author": ["Ludwig Schneider", "Marcus M\u00fcller"],\n'
+    project_json_string += '"journal": "Computer Physics Communications",\n'
+    project_json_string += '"publisher": "Elsevier",\n'
+    project_json_string += '"year": 2019,\n'
+    project_json_string += '"pages": [463, 476],\n'
+    project_json_string += '"doi": "10.1016/j.cpc.2018.08.011",\n'
+    project_json_string += '"issn": "0010-4655",\n'
+    project_json_string += '"website": "https://www.sciencedirect.com/science/article/pii/S0010465518303072"\n'
+    project_json_string += "}\n"
+    project_json_string += "}\n"
+    project_json_string += "]\n"
+    project_json_string += "}\n"
+    project_json_string += "],\n"
+    project_json_string += '"material": [\n'
+    project_json_string += "{\n"
+    project_json_string += '"uid": "_:2ee56671-5efb-4f99-a7ea-d659f5b5dd9a"\n'
+    project_json_string += "}\n"
+    project_json_string += "]\n"
+    project_json_string += "}\n"
+
+    return cript.load_nodes_from_json(project_json_string)
+
+
+@pytest.fixture(scope="function")
+def fixed_cyclic_project_dfs_uuid_order():
+    expected_list = [
+        "55a41f23-4791-4dc7-bf2c-48fd2b6fc90b",
+        "ab385d26-6ee5-40d4-9095-2d623616a162",
+        "61a99328-108b-4307-bfcb-fccd12a5dd91",
+        "1232d7be-d870-4357-bf41-f53a09707cca",
+        "3fb7801f-7253-4d6b-813b-f1d2d25b6316",
+        "d2b3169d-c200-4143-811a-a0d07439dd96",
+        "2818ed85-2758-45f9-9f30-5c3dfedd3d33",
+        "0a88e09d-488f-45ed-ad9c-14873792b8fd",
+        "1fc95012-2845-46ac-a8e3-7178fe19afcd",
+        "309b0d7b-027c-4422-ab5f-58069fe4adb1",
+        "e78cf3cf-de6c-4364-93c4-4fb3d352bde2",
+        "09cf72a4-a397-4953-baa6-7cdf5be067c4",
+        "175708fa-cc29-4442-be7f-adf85e995330",
+        "dcb516a1-951d-461a-beb6-bdf2aecd0778",
+        "c94aba31-adf2-4eeb-b51e-8c70568c2eb0",
+        "6a2e81af-861b-4c66-96fd-b969a38b81b1",
+        "ce01ba93-cfc5-4265-a6d6-8c38397deb43",
+        "1aa11462-b394-4c35-906e-d0e9198be6da",
+        "5d649b93-8f2c-4509-9aa7-311213df9405",
+        "21601ad5-c225-4626-8baa-3a7c1d64cafa",
+        "ea9ad3e7-84a7-475f-82a8-16f5b9241e37",
+        "2ee56671-5efb-4f99-a7ea-d659f5b5dd9a",
+        "fde629f5-8d3a-4546-8cd3-9de63b990187",
+        "fc504202-6fdd-43c7-830d-40c7d3f0cb8c",
+        "1ff50987-e0a2-4aa3-a1a2-bdcefd54693d",
+        "845c90c1-5a93-416f-9c42-1bac1de0bd9a",
+        "5838e9cc-f01d-468e-96de-93bfe6fb758f",
+    ]
+    return expected_list
+
+
+@pytest.fixture(scope="function")
 def simple_collection_node(simple_experiment_node) -> cript.Collection:
     """
     create a simple collection node for other tests to be able to easily and cleanly reuse

--- a/tests/test_node_util.py
+++ b/tests/test_node_util.py
@@ -196,27 +196,13 @@ def test_local_search(simple_algorithm_node, complex_parameter_node):
     assert find_parameter == []
 
 
-def test_cycles(complex_data_node, simple_computation_node):
-    # We create a wrong cycle with parameters here.
-    # TODO replace this with nodes that actually can form a cycle
-    d = copy.deepcopy(complex_data_node)
-    c = copy.deepcopy(simple_computation_node)
-    d.computation += [c]
-    # Using input and output data guarantees a cycle here.
-    c.output_data += [d]
-    c.input_data += [d]
+def test_cycles(fixed_cyclic_project_node):
+    new_project = fixed_cyclic_project_node
+    new_json = new_project.get_expanded_json()
 
-    # # Test the repetition of a citation.
-    # # Notice that we do not use a deepcopy here, as we want the citation to be the exact same node.
-    # citation = d.citation[0]
-    # # c._json_attrs.citation.append(citation)
-    # c.citation += [citation]
-    # # print(c.get_json(indent=2).json)
-    # # c.validate()
-
-    # Generate json with an implicit cycle
-    c.json
-    d.json
+    reloaded_project, cache = cript.load_nodes_from_json(new_json, _use_uuid_cache=dict())
+    assert reloaded_project is not new_project
+    assert reloaded_project.uuid == new_project.uuid
 
 
 def test_uid_serial(simple_inventory_node):
@@ -373,3 +359,8 @@ def test_uuid_cache_override(complex_project_node):
         new_node = cache[key]
         assert old_node.uuid == new_node.uuid
         assert old_node is not new_node
+
+
+def test_dfs_order(fixed_cyclic_project_node, fixed_cyclic_project_dfs_uuid_order):
+    for i, node in enumerate(fixed_cyclic_project_node):
+        assert node.uuid == fixed_cyclic_project_dfs_uuid_order[i]


### PR DESCRIPTION
# Description

Some JSON with cycles broken by UID couldn't be deserialized because the order of UID was not good for the JSON module.

## Changes

Store a temporary UIDProxy element if a UID can't be resolved.
After reading in with `load_nodes_from_json` the proxies are replaced by the nodes if possible.

The type declaration was fixed to nodes before, now UIDProxy objects are permissible.

## Known Issues

For the implementation of the Node type hint that is equivalent to `Union[Node, UIDProxy]` internal implementations of the `typing` module are used.

## Notes

## Checklist

- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
- [x] My code changes have been verified by automated tests and pass all relevant test scenarios.
