### PR TITLE
Update search, so it works with the new `after` syntax.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
 
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.12]
+        python-version: ["3.10", 3.12]
 
     env:
       CRIPT_HOST: https://lb-stage.mycriptapp.org/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](./CRIPT_full_logo_colored_transparent.png)](https://github.com/C-Accel-CRIPT/Python-SDK/blob/develop/LICENSE.md)
 
 [![License](https://img.shields.io/github/license/C-Accel-CRIPT/cript?style=flat-square)](https://github.com/C-Accel-CRIPT/Python-SDK/blob/develop/LICENSE.md)
-[![Python](https://img.shields.io/badge/Language-Python%203.8+-blue?style=flat-square&logo=python)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/Language-Python%203.10+-blue?style=flat-square&logo=python)](https://www.python.org/)
 [![Code style is black](https://img.shields.io/badge/Code%20Style-black-000000.svg?style=flat-square&logo=python)](https://github.com/psf/black)
 [![Link to CRIPT website](https://img.shields.io/badge/platform-criptapp.org-blueviolet?style=flat-square)](https://criptapp.org/)
 [![Using Pytest](https://img.shields.io/badge/Dependencies-pytest-green?style=flat-square&logo=Pytest)](https://docs.pytest.org/en/7.2.x/)
@@ -36,7 +36,7 @@ The CRIPT Python SDK allows programmatic access to the [CRIPT platform](https://
 
 ## Installation
 
-CRIPT Python SDK requires Python 3.8+
+CRIPT Python SDK requires Python 3.10+
 
 The latest released of CRIPT Python SDK is available on [Python Package Index (PyPI)](https://pypi.org/project/cript/)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,13 +14,13 @@ classifiers =
     Topic :: Scientific/Engineering
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.10
 
 [options]
 package_dir =
     =src
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.10
 include_package_data = True
 install_requires =
         requests==2.31.0

--- a/src/cript/api/api.py
+++ b/src/cript/api/api.py
@@ -787,35 +787,32 @@ class API:
         node_type = node_type.node_type_snake_case
 
         api_endpoint: str = ""
-        page_number: Union[int, None] = None
-
+        limit_node_fetches: Optional[int] = None
         if search_mode == SearchModes.NODE_TYPE:
             api_endpoint = f"/search/{node_type}"
-            page_number = 0
+            value_to_search = ""
 
         elif search_mode == SearchModes.CONTAINS_NAME:
             api_endpoint = f"/search/{node_type}"
-            page_number = 0
 
         elif search_mode == SearchModes.EXACT_NAME:
             api_endpoint = f"/search/exact/{node_type}"
-            page_number = None
+            limit_node_fetches = 1
 
         elif search_mode == SearchModes.UUID:
             api_endpoint = f"/{node_type}/{value_to_search}"
             # putting the value_to_search in the URL instead of a query
             value_to_search = ""
-            page_number = None
+            limit_node_fetches = 1
 
         elif search_mode == SearchModes.BIGSMILES:
             api_endpoint = "/search/bigsmiles/"
-            page_number = 0
 
         # error handling if none of the API endpoints got hit
         else:
             raise RuntimeError("Internal Error: Failed to recognize any search modes. Please report this bug on https://github.com/C-Accel-CRIPT/Python-SDK/issues.")
 
-        return Paginator(api=self, url_path=api_endpoint, page_number=page_number, query=value_to_search)
+        return Paginator(api=self, url_path=api_endpoint, query=value_to_search, limit_node_fetches=limit_node_fetches)
 
     def delete(self, node) -> None:
         """

--- a/src/cript/api/paginator.py
+++ b/src/cript/api/paginator.py
@@ -9,12 +9,12 @@ from cript.api.exceptions import APIError
 from cript.nodes.util import load_nodes_from_json
 
 
-def _get_uuid_score_from_json(node_dict: str) -> Tuple[str, Optional[float]]:
+def _get_uuid_score_from_json(node_dict: Dict) -> Tuple[str, Optional[float]]:
     """
     Get the UUID string and search score from a JSON node representation if available.
     """
-    node_uuid = node_dict["uuid"]
-    node_score = node_dict.get("score", None)
+    node_uuid: str = node_dict["uuid"]
+    node_score: Optional[float] = node_dict.get("score", None)
 
     return node_uuid, node_score
 
@@ -41,7 +41,7 @@ class Paginator:
     _query: str
     _current_position: int
     _fetched_nodes: list
-    _uuid_search_score_map: Dict[str, float]
+    _uuid_search_score_map: Dict
     _number_fetched_pages: int = 0
     _limit_node_fetches: Optional[int] = None
     _start_after_uuid: Optional[str] = None

--- a/src/cript/nodes/core.py
+++ b/src/cript/nodes/core.py
@@ -174,6 +174,10 @@ class BaseNode(ABC):
                 pass
             else:
                 arguments[field] = json_dict[field]
+        try:  # TODO remove this hack to work with compatible model versions
+            del arguments["model_version"]
+        except KeyError:
+            pass
 
         # add omitted fields from default (necessary if they are required)
         for field_name in [field.name for field in dataclasses.fields(default_dataclass)]:

--- a/src/cript/nodes/primary_nodes/computation_process.py
+++ b/src/cript/nodes/primary_nodes/computation_process.py
@@ -521,7 +521,7 @@ class ComputationProcess(PrimaryBaseNode):
         Examples
         --------
         >>> import cript
-        >>> my_property = cript.Property(key="modulus_shear", type="min", value=1.23, unit="gram")
+        >>> my_property = cript.Property(key="enthalpy", type="min", value=1.23, unit="J")
         >>> my_computation_process.property = [my_property]     # doctest: +SKIP
 
         Returns

--- a/src/cript/nodes/primary_nodes/material.py
+++ b/src/cript/nodes/primary_nodes/material.py
@@ -540,7 +540,7 @@ class Material(PrimaryBaseNode):
         ...     name="my component material 1",
         ...     smiles = "component 1 smiles",
         ... )
-        >>> my_property = cript.Property(key="modulus_shear", type="min", value=1.23, unit="gram")
+        >>> my_property = cript.Property(key="enthalpy", type="min", value=1.23, unit="J")
         >>> my_material.property = [my_property]
 
         Returns

--- a/src/cript/nodes/primary_nodes/process.py
+++ b/src/cript/nodes/primary_nodes/process.py
@@ -580,7 +580,7 @@ class Process(PrimaryBaseNode):
         --------
         >>> import cript
         >>> my_process = cript.Process(name="my process name", type="affinity_pure")
-        >>> my_property = cript.Property(key="modulus_shear", type="min", value=1.23, unit="gram")
+        >>> my_property = cript.Property(key="enthalpy", type="min", value=1.23, unit="J")
         >>> my_process.property = [my_property]
 
         Returns

--- a/src/cript/nodes/subobjects/property.py
+++ b/src/cript/nodes/subobjects/property.py
@@ -38,7 +38,7 @@ class Property(UUIDBaseNode):
 
     | attribute          | type              | example                                 | description                                                                  | required | vocab |
     |--------------------|-------------------|-----------------------------------------|------------------------------------------------------------------------------|----------|-------|
-    | key                | str               | modulus_shear                           | type of property                                                             | True     | True  |
+    | key                | str               | enthalpy                                | type of property                                                             | True     | True  |
     | type               | str               | min                                     | type of value stored                                                         | True     | True  |
     | value              | Any               | 1.23                                    | value or quantity                                                            | True     |       |
     | unit               | str               | gram                                    | unit for value                                                               | True     |       |
@@ -58,10 +58,10 @@ class Property(UUIDBaseNode):
     ## JSON Representation
     ```json
     {
-       "key":"modulus_shear",
+       "key":"enthalpy",
        "node":["Property"],
        "type":"value",
-       "unit":"GPa",
+       "unit":"J",
        "value":5.0
        "uid":"_:bc3abb68-25b5-4144-aa1b-85d82b7c77e1",
        "uuid":"bc3abb68-25b5-4144-aa1b-85d82b7c77e1",
@@ -149,7 +149,7 @@ class Property(UUIDBaseNode):
         Examples
         --------
         >>> import cript
-        >>> my_property = cript.Property(key="air_flow", type="min", value=1.00, unit="gram")
+        >>> my_property = cript.Property(key="enthalpy", type="min", value=1.00, unit="J")
 
         Returns
         -------
@@ -197,7 +197,7 @@ class Property(UUIDBaseNode):
         Examples
         --------
         >>> import cript
-        >>> my_property = cript.Property(key="air_flow", type="min", value=1.00, unit="gram")
+        >>> my_property = cript.Property(key="enthalpy", type="min", value=1.00, unit="J")
         >>> my_property.key = "angle_rdist"
 
         Returns
@@ -236,7 +236,7 @@ class Property(UUIDBaseNode):
         Examples
         ---------
         >>> import cript
-        >>> my_property = cript.Property(key="air_flow", type="min", value=1.00, unit="gram")
+        >>> my_property = cript.Property(key="enthalpy", type="min", value=1.00, unit="J")
         >>> my_property.type = "max"
 
         Returns
@@ -285,7 +285,7 @@ class Property(UUIDBaseNode):
         Examples
         ---------
         >>> import cript
-        >>> my_property = cript.Property(key="air_flow", type="min", value=1.00, unit="gram")
+        >>> my_property = cript.Property(key="enthalpy", type="min", value=1.00, unit="J")
         >>> my_property.set_value(new_value=1, new_unit="gram")
 
         Parameters
@@ -345,7 +345,7 @@ class Property(UUIDBaseNode):
         Examples
         --------
         >>> import cript
-        >>> my_property = cript.Property(key="air_flow", type="min", value=1.00, unit="gram")
+        >>> my_property = cript.Property(key="enthalpy", type="min", value=1.00, unit="J")
         >>> my_property.set_uncertainty(new_uncertainty=2, new_uncertainty_type="fwhm")
 
         Returns
@@ -380,7 +380,7 @@ class Property(UUIDBaseNode):
         Examples
         ---------
         >>> import cript
-        >>> my_property = cript.Property(key="air_flow", type="min", value=1.00, unit="gram")
+        >>> my_property = cript.Property(key="enthalpy", type="min", value=1.00, unit="J")
         >>> my_material = cript.Material(name="my material", bigsmiles = "123456")
         >>> my_property.component = [my_material]
 
@@ -418,7 +418,7 @@ class Property(UUIDBaseNode):
         Examples
         --------
         >>> import cript
-        >>> my_property = cript.Property(key="air_flow", type="min", value=1.00, unit="gram")
+        >>> my_property = cript.Property(key="enthalpy", type="min", value=1.00, unit="J")
         >>> my_property.structure = "{[][$][C:1][C:1][$],[$][C:2][C:2]([C:2])[$][]}"
 
         Returns
@@ -457,7 +457,7 @@ class Property(UUIDBaseNode):
         Examples
         --------
         >>> import cript
-        >>> my_property = cript.Property(key="air_flow", type="min", value=1.00, unit="gram")
+        >>> my_property = cript.Property(key="enthalpy", type="min", value=1.00, unit="J")
         >>> my_property.method = "ASTM_D3574_Test_A"
 
         Returns
@@ -494,7 +494,7 @@ class Property(UUIDBaseNode):
         Examples
         --------
         >>> import cript
-        >>> my_property = cript.Property(key="air_flow", type="min", value=1.00, unit="gram")
+        >>> my_property = cript.Property(key="enthalpy", type="min", value=1.00, unit="J")
         >>> my_process = cript.Process(name="my process name", type="affinity_pure")
         >>> my_property.sample_preparation = my_process
 
@@ -532,7 +532,7 @@ class Property(UUIDBaseNode):
         Examples
         --------
         >>> import cript
-        >>> my_property = cript.Property(key="air_flow", type="min", value=1.00, unit="gram")
+        >>> my_property = cript.Property(key="enthalpy", type="min", value=1.00, unit="J")
         >>> my_condition = cript.Condition(key="atm", type="max", value=1)
         >>> my_property.condition = [my_condition]
 
@@ -570,7 +570,7 @@ class Property(UUIDBaseNode):
         Examples
         --------
         >>> import cript
-        >>> my_property = cript.Property(key="air_flow", type="min", value=1.00, unit="gram")
+        >>> my_property = cript.Property(key="enthalpy", type="min", value=1.00, unit="J")
         >>> my_file = cript.File(
         ...     name="my file node name",
         ...     source="https://criptapp.org",
@@ -615,7 +615,7 @@ class Property(UUIDBaseNode):
         Examples
         --------
         >>> import cript
-        >>> my_property = cript.Property(key="air_flow", type="min", value=1.00, unit="gram")
+        >>> my_property = cript.Property(key="enthalpy", type="min", value=1.00, unit="J")
         >>> my_computation = cript.Computation(name="my computation name", type="analysis")
         >>> my_property.computation = [my_computation]
 
@@ -653,7 +653,7 @@ class Property(UUIDBaseNode):
         Examples
         --------
         >>> import cript
-        >>> my_property = cript.Property(key="air_flow", type="min", value=1.00, unit="gram")
+        >>> my_property = cript.Property(key="enthalpy", type="min", value=1.00, unit="J")
         >>> title = (
         ...     "Multi-architecture Monte-Carlo (MC) simulation of soft coarse-grained polymeric materials: "
         ...     "Soft coarse grained Monte-Carlo Acceleration (SOMA)"
@@ -707,7 +707,7 @@ class Property(UUIDBaseNode):
         Examples
         --------
         >>> import cript
-        >>> my_property = cript.Property(key="air_flow", type="min", value=1.00, unit="gram")
+        >>> my_property = cript.Property(key="enthalpy", type="min", value=1.00, unit="J")
         >>> my_property.notes = "these are my notes"
 
         Returns

--- a/tests/fixtures/api_fixtures.py
+++ b/tests/fixtures/api_fixtures.py
@@ -26,7 +26,8 @@ def dynamic_material_data(cript_api: cript.API) -> Dict[str, str]:
 
     exact_name_paginator = cript_api.search(node_type=cript.Material, search_mode=cript.SearchModes.EXACT_NAME, value_to_search=material_name)
 
+    exact_name_paginator.auto_load_nodes = False
     material = next(exact_name_paginator)
-    material_uuid: str = str(material.uuid)
+    material_uuid: str = material["uuid"]
 
     return {"name": material_name, "uuid": material_uuid}

--- a/tests/fixtures/primary_nodes.py
+++ b/tests/fixtures/primary_nodes.py
@@ -25,7 +25,6 @@ def simple_project_node(simple_collection_node) -> cript.Project:
 def complex_project_dict(complex_collection_node, simple_material_node, complex_user_node) -> dict:
     project_dict = {"node": ["Project"]}
     project_dict["locked"] = True
-    project_dict["model_version"] = "1.0.1"
     project_dict["updated_by"] = json.loads(copy.deepcopy(complex_user_node).get_expanded_json())
     project_dict["created_by"] = json.loads(complex_user_node.get_expanded_json())
     project_dict["public"] = True
@@ -60,7 +59,6 @@ def fixed_cyclic_project_node() -> cript.Project:
     project_json_string += '"created_at": "2024-03-12 15:58:12.486673",\n'
     project_json_string += '"updated_at": "2024-03-12 15:58:12.486681",\n'
     project_json_string += '"email": "test@emai.com",\n'
-    project_json_string += '"model_version": "1.0.1",\n'
     project_json_string += '"orcid": "0000-0002-0000-0000",\n'
     project_json_string += '"picture": "/my/picture/path",\n'
     project_json_string += '"username": "testuser"\n'
@@ -72,13 +70,11 @@ def fixed_cyclic_project_node() -> cript.Project:
     project_json_string += '"created_at": "2024-03-12 15:58:12.486673",\n'
     project_json_string += '"updated_at": "2024-03-12 15:58:12.486681",\n'
     project_json_string += '"email": "test@emai.com",\n'
-    project_json_string += '"model_version": "1.0.1",\n'
     project_json_string += '"orcid": "0000-0002-0000-0000",\n'
     project_json_string += '"picture": "/my/picture/path",\n'
     project_json_string += '"username": "testuser"\n'
     project_json_string += "},\n"
     project_json_string += '"locked": true,\n'
-    project_json_string += '"model_version": "1.0.1",\n'
     project_json_string += '"public": true,\n'
     project_json_string += '"name": "my project name",\n'
     project_json_string += '"notes": "my project notes",\n'

--- a/tests/fixtures/primary_nodes.py
+++ b/tests/fixtures/primary_nodes.py
@@ -25,7 +25,7 @@ def simple_project_node(simple_collection_node) -> cript.Project:
 def complex_project_dict(complex_collection_node, simple_material_node, complex_user_node) -> dict:
     project_dict = {"node": ["Project"]}
     project_dict["locked"] = True
-    project_dict["model_version"] = "1.0.0"
+    project_dict["model_version"] = "1.0.1"
     project_dict["updated_by"] = json.loads(copy.deepcopy(complex_user_node).get_expanded_json())
     project_dict["created_by"] = json.loads(complex_user_node.get_expanded_json())
     project_dict["public"] = True
@@ -60,7 +60,7 @@ def fixed_cyclic_project_node() -> cript.Project:
     project_json_string += '"created_at": "2024-03-12 15:58:12.486673",\n'
     project_json_string += '"updated_at": "2024-03-12 15:58:12.486681",\n'
     project_json_string += '"email": "test@emai.com",\n'
-    project_json_string += '"model_version": "1.0.0",\n'
+    project_json_string += '"model_version": "1.0.1",\n'
     project_json_string += '"orcid": "0000-0002-0000-0000",\n'
     project_json_string += '"picture": "/my/picture/path",\n'
     project_json_string += '"username": "testuser"\n'
@@ -72,13 +72,13 @@ def fixed_cyclic_project_node() -> cript.Project:
     project_json_string += '"created_at": "2024-03-12 15:58:12.486673",\n'
     project_json_string += '"updated_at": "2024-03-12 15:58:12.486681",\n'
     project_json_string += '"email": "test@emai.com",\n'
-    project_json_string += '"model_version": "1.0.0",\n'
+    project_json_string += '"model_version": "1.0.1",\n'
     project_json_string += '"orcid": "0000-0002-0000-0000",\n'
     project_json_string += '"picture": "/my/picture/path",\n'
     project_json_string += '"username": "testuser"\n'
     project_json_string += "},\n"
     project_json_string += '"locked": true,\n'
-    project_json_string += '"model_version": "1.0.0",\n'
+    project_json_string += '"model_version": "1.0.1",\n'
     project_json_string += '"public": true,\n'
     project_json_string += '"name": "my project name",\n'
     project_json_string += '"notes": "my project notes",\n'
@@ -126,7 +126,7 @@ def fixed_cyclic_project_node() -> cript.Project:
     project_json_string += '"node": ["Property"],\n'
     project_json_string += '"uid": "_:fc504202-6fdd-43c7-830d-40c7d3f0cb8c",\n'
     project_json_string += '"uuid": "fc504202-6fdd-43c7-830d-40c7d3f0cb8c",\n'
-    project_json_string += '"key": "modulus_shear",\n'
+    project_json_string += '"key": "enthalpy",\n'
     project_json_string += '"type": "value",\n'
     project_json_string += '"value": 5.0,\n'
     project_json_string += '"unit": "GPa",\n'
@@ -213,7 +213,7 @@ def fixed_cyclic_project_node() -> cript.Project:
     project_json_string += '"node": ["Property"],\n'
     project_json_string += '"uid": "_:fde629f5-8d3a-4546-8cd3-9de63b990187",\n'
     project_json_string += '"uuid": "fde629f5-8d3a-4546-8cd3-9de63b990187",\n'
-    project_json_string += '"key": "modulus_shear",\n'
+    project_json_string += '"key": "enthalpy",\n'
     project_json_string += '"type": "value",\n'
     project_json_string += '"value": 5.0,\n'
     project_json_string += '"unit": "GPa",\n'

--- a/tests/fixtures/subobjects.py
+++ b/tests/fixtures/subobjects.py
@@ -122,7 +122,7 @@ def complex_property_node(complex_material_node, complex_condition_node, complex
     a maximal property sub-object with all possible fields filled
     """
     my_complex_property = cript.Property(
-        key="modulus_shear",
+        key="enthalpy",
         type="value",
         value=5.0,
         unit="GPa",
@@ -144,7 +144,7 @@ def complex_property_node(complex_material_node, complex_condition_node, complex
 def complex_property_dict(complex_material_node, complex_condition_dict, complex_citation_dict, complex_data_node, simple_process_node, simple_computation_node) -> dict:
     ret_dict = {
         "node": ["Property"],
-        "key": "modulus_shear",
+        "key": "enthalpy",
         "type": "value",
         "value": 5.0,
         "unit": "GPa",
@@ -165,7 +165,7 @@ def complex_property_dict(complex_material_node, complex_condition_dict, complex
 @pytest.fixture(scope="function")
 def simple_property_node() -> cript.Property:
     my_property = cript.Property(
-        key="modulus_shear",
+        key="enthalpy",
         type="value",
         value=5.0,
         unit="GPa",
@@ -177,7 +177,7 @@ def simple_property_node() -> cript.Property:
 def simple_property_dict() -> dict:
     ret_dict = {
         "node": ["Property"],
-        "key": "modulus_shear",
+        "key": "enthalpy",
         "type": "value",
         "value": 5.0,
         "unit": "GPa",

--- a/tests/fixtures/supporting_nodes.py
+++ b/tests/fixtures/supporting_nodes.py
@@ -63,7 +63,6 @@ def complex_local_file_node(tmp_path_factory) -> cript.File:
 def complex_user_dict() -> dict:
     user_dict = {"node": ["User"]}
     user_dict["created_at"] = str(datetime.datetime.now())
-    user_dict["model_version"] = "1.0.1"
     user_dict["picture"] = "/my/picture/path"
     user_dict["updated_at"] = str(datetime.datetime.now())
     user_dict["username"] = "testuser"

--- a/tests/fixtures/supporting_nodes.py
+++ b/tests/fixtures/supporting_nodes.py
@@ -63,7 +63,7 @@ def complex_local_file_node(tmp_path_factory) -> cript.File:
 def complex_user_dict() -> dict:
     user_dict = {"node": ["User"]}
     user_dict["created_at"] = str(datetime.datetime.now())
-    user_dict["model_version"] = "1.0.0"
+    user_dict["model_version"] = "1.0.1"
     user_dict["picture"] = "/my/picture/path"
     user_dict["updated_at"] = str(datetime.datetime.now())
     user_dict["username"] = "testuser"

--- a/tests/nodes/primary_nodes/test_material.py
+++ b/tests/nodes/primary_nodes/test_material.py
@@ -34,7 +34,7 @@ def test_create_complex_material(cript_api, simple_material_node, simple_computa
     component = [simple_material_node]
     forcefield = simple_computational_forcefield_node
 
-    my_property = [cript.Property(key="modulus_shear", type="min", value=1.23, unit="gram")]
+    my_property = [cript.Property(key="rho_z", type="min", value=1.23, unit="gram")]
 
     my_material = cript.Material(
         name=material_name,

--- a/tests/nodes/subobjects/test_property.py
+++ b/tests/nodes/subobjects/test_property.py
@@ -20,8 +20,8 @@ def test_json(complex_property_node, complex_property_dict):
 
 
 def test_setter_getter(complex_property_node, simple_material_node, simple_process_node, complex_condition_node, simple_data_node, simple_computation_node, complex_citation_node):
-    complex_property_node.key = "modulus_loss"
-    assert complex_property_node.key == "modulus_loss"
+    complex_property_node.key = "rho_z"
+    assert complex_property_node.key == "rho_z"
 
     complex_property_node.type = "min"
     assert complex_property_node.type == "min"

--- a/tests/nodes/test_utils.py
+++ b/tests/nodes/test_utils.py
@@ -35,7 +35,7 @@ def test_load_node_from_json_dict_argument() -> None:
         "uuid": material_uuid,
         "name": material_name,
         "notes": material_notes,
-        "property": [{"node": ["Property"], "uid": "_:aedce614-7acb-49d2-a2f6-47463f15b707", "uuid": "aedce614-7acb-49d2-a2f6-47463f15b707", "key": "modulus_shear", "type": "value", "value": 5.0, "unit": "GPa"}],
+        "property": [{"node": ["Property"], "uid": "_:aedce614-7acb-49d2-a2f6-47463f15b707", "uuid": "aedce614-7acb-49d2-a2f6-47463f15b707", "key": "enthalpy", "type": "value", "value": 5.0, "unit": "GPa"}],
         "computational_forcefield": {"node": ["ComputationalForcefield"], "uid": "_:059952a3-20f2-4739-96bd-a5ea43068065", "uuid": "059952a3-20f2-4739-96bd-a5ea43068065", "key": "amber", "building_block": "atom"},
         "keyword": ["acetylene"],
         "bigsmiles": material_bigsmiles,

--- a/tests/test_node_util.py
+++ b/tests/test_node_util.py
@@ -33,8 +33,8 @@ def test_uid_deserialization(simple_algorithm_node, complex_parameter_node, simp
     material = cript.Material(name="my material", bigsmiles="{[][$]CC[$][]}")
 
     computation = cript.Computation(name="my computation name", type="analysis")
-    property1 = cript.Property("modulus_shear", "value", 5.0, "GPa", computation=[computation])
-    property2 = cript.Property("modulus_loss", "value", 5.0, "GPa", computation=[computation])
+    property1 = cript.Property("enthalpy", "value", 5.0, "GPa", computation=[computation])
+    property2 = cript.Property("rho_z", "value", 5.0, "GPa", computation=[computation])
     material.property = [property1, property2]
 
     material2 = cript.load_nodes_from_json(material.json)
@@ -50,7 +50,7 @@ def test_uid_deserialization(simple_algorithm_node, complex_parameter_node, simp
                 "node": ["Property"],
                 "uid": "_:82e7270e-9f35-4b35-80a2-faa6e7f670be",
                 "uuid": "82e7270e-9f35-4b35-80a2-faa6e7f670be",
-                "key": "modulus_shear",
+                "key": "enthalpy",
                 "type": "value",
                 "value": 5.0,
                 "unit": "GPa",
@@ -60,7 +60,7 @@ def test_uid_deserialization(simple_algorithm_node, complex_parameter_node, simp
                 "node": ["Property"],
                 "uid": "_:fc4dfa5e-742c-4d0b-bb66-2185461f4582",
                 "uuid": "fc4dfa5e-742c-4d0b-bb66-2185461f4582",
-                "key": "modulus_loss",
+                "key": "rho_z",
                 "type": "value",
                 "value": 5.0,
                 "unit": "GPa",
@@ -92,7 +92,7 @@ def test_uid_deserialization(simple_algorithm_node, complex_parameter_node, simp
     #             ],
     #             "uid": "_:82e7270e-9f35-4b35-80a2-faa6e7f670be",
     #             "uuid": "82e7270e-9f35-4b35-80a2-faa6e7f670be",
-    #             "key": "modulus_shear",
+    #             "key": "enthalpy",
     #             "type": "value",
     #             "value": 5.0,
     #             "unit": "GPa",
@@ -111,7 +111,7 @@ def test_uid_deserialization(simple_algorithm_node, complex_parameter_node, simp
     #             ],
     #             "uid": "_:fc4dfa5e-742c-4d0b-bb66-2185461f4582",
     #             "uuid": "fc4dfa5e-742c-4d0b-bb66-2185461f4582",
-    #             "key": "modulus_loss",
+    #             "key": "rho_z",
     #             "type": "value",
     #             "value": 5.0,
     #             "unit": "GPa",


### PR DESCRIPTION
# Description
Updated search URL generation.
It now works with 

## Changes

Some updates to the paginator interface that enables partial searches, that allows interrupted searches for the SDK as well.

## Known Issues

Many entries on `stage` are invalid.
So we had to work around this in the tests.
Ideally we don't have to do that.

@brili 
I noticed, that BigSMILES search does not deliver 10 nodes by default. It is 1 node for me.

@brili 
Also it appears that the `after` method returns some nodes multiple times.
I get the same UUID in the search results, I don't think that is as it should be.

## Notes

## Checklist

- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
- [x] My code changes have been verified by automated tests and pass all relevant test scenarios.
